### PR TITLE
Fix building on ARM arch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ time = "0.1"
 linked-hash-map = "0.5"
 hex = "0.3"
 md5 = "0.6"
-decimal = { version = "2.0.4", default_features = false, optional = true }
+decimal = { git = "https://github.com/alkis/decimal.git", rev = "5577a60b9b8860a322288856ff2419c191ed080f", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ time = "0.1"
 linked-hash-map = "0.5"
 hex = "0.3"
 md5 = "0.6"
-decimal = { git = "https://github.com/alkis/decimal.git", rev = "5577a60b9b8860a322288856ff2419c191ed080f", optional = true }
+decimal = { git = "https://github.com/alkis/decimal.git", rev = "5577a60b9b8860a322288856ff2419c191ed080f", default_features = false, optional = true }
 
 [dev-dependencies]
 assert_matches = "1.2"


### PR DESCRIPTION
Hello.

`bson-rs` has a depending crate `decimal` which may using with optional feature "decimal128". Building `decimal` (last version 2.0.4) is terminating with error on ARM arch when I run
```bash
cargo build --features="decimal128"
```
The reason is the difference representation `c_char` type by two different platforms: `c_char` is `i8` on `x86`\\`amd64` and is `u8` on `arm`.

I guess you want ask me why I write here and don't create an issue inside 'decimal' repository. The fact is `decimal` crate already has a merged PR alkis/decimal#42 for fix that, however fixed version hasn't released. The trouble is, @alkis, author of the crate, has no active since April and I have no idea how much time we will not be able to get a fixed version on crates.io.

So, I suggest change source of the depending crate from crates.io to git commit with fixed compile error. It is the fastest and more safety path to resolve the problem.

On the other hand it is possible to migrate on another crate, for example, [rust_decimal](https://crates.io/crates/rust-decimal) or other. It will be more complex and require some code changes for apply new library API.
