### PR TITLE
Cleanup deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,12 @@ decimal128 = ["decimal"]
 name = "bson"
 
 [dependencies]
-byteorder = "1"
 chrono = "0.4"
-libc = "0.2"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 linked-hash-map = "0.5.3"
 hex = "0.4.2"
-md5 = "0.7.0"
 decimal = { version = "2.0.4", default_features = false, optional = true }
 base64 = "0.12.1"
 lazy_static = "1.4.0"

--- a/src/document.rs
+++ b/src/document.rs
@@ -9,8 +9,6 @@ use std::{
     mem,
 };
 
-use byteorder::{ReadBytesExt, WriteBytesExt};
-
 use chrono::{DateTime, Utc};
 
 use linked_hash_map::{self, LinkedHashMap};
@@ -522,7 +520,7 @@ impl Document {
             (buf.len() + mem::size_of::<i32>() + mem::size_of::<u8>()) as i32,
         )?;
         writer.write_all(&buf)?;
-        writer.write_u8(0)?;
+        writer.write_all(&[0])?;
         Ok(())
     }
 
@@ -544,7 +542,9 @@ impl Document {
             "document length longer than contents",
             |cursor| {
                 loop {
-                    let tag = cursor.read_u8()?;
+                    let mut tag_byte = [0];
+                    cursor.read_exact(&mut tag_byte)?;
+                    let tag = tag_byte[0];
 
                     if tag == 0 {
                         break;

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -17,7 +17,6 @@ use crate::{
     Regex,
     Timestamp,
 };
-use byteorder::{LittleEndian, WriteBytesExt};
 use chrono::{offset::TimeZone, Utc};
 use serde_json::json;
 
@@ -333,16 +332,16 @@ fn test_serialize_deserialize_symbol() {
 #[test]
 fn test_deserialize_utc_date_time_overflows() {
     let _guard = LOCK.run_concurrently();
-    let t = 1_530_492_218 * 1_000 + 999;
+    let t: i64 = 1_530_492_218 * 1_000 + 999;
 
     let mut raw0 = vec![0x09, b'A', 0x00];
-    raw0.write_i64::<LittleEndian>(t).unwrap();
+    raw0.write_all(&t.to_le_bytes()).unwrap();
 
     let mut raw = vec![];
-    raw.write_i32::<LittleEndian>((raw0.len() + 4 + 1) as i32)
+    raw.write_all(&((raw0.len() + 4 + 1) as i32).to_le_bytes())
         .unwrap();
     raw.write_all(&raw0).unwrap();
-    raw.write_u8(0).unwrap();
+    raw.write_all(&[0]).unwrap();
 
     let deserialized = Document::from_reader(&mut Cursor::new(raw)).unwrap();
 


### PR DESCRIPTION
- Remove unused dependencies (libc, md5)
- Replace the time crate with std equivalent
- Replace the byteorder crate with the std's `{to,from}_{le,be}_bytes` functions on integers
- Some formatting