### PR TITLE
Fix failing evergreen lint

### DIFF
--- a/.evergreen/check-clippy.sh
+++ b/.evergreen/check-clippy.sh
@@ -3,4 +3,4 @@
 set -o errexit
 
 . ~/.cargo/env
-cargo clippy --all-targets --all-features -p mongodb -- -D warnings
+cargo clippy --all-targets --all-features -p bson -- -D warnings

--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -1,4 +1,3 @@
-
 use std::io::Cursor;
 
 use bson::{decode_document, encode_document, oid, Array, Bson, Document};
@@ -11,7 +10,9 @@ fn main() {
     let mut arr = Array::new();
     arr.push(Bson::String("blah".to_string()));
     arr.push(Bson::UtcDatetime(chrono::Utc::now()));
-    arr.push(Bson::ObjectId(oid::ObjectId::with_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])));
+    arr.push(Bson::ObjectId(oid::ObjectId::with_bytes([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ])));
 
     doc.insert("array".to_string(), Bson::Array(arr));
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -159,7 +159,7 @@ impl Display for Bson {
             Bson::I64(i) => write!(fmt, "{}", i),
             Bson::TimeStamp(i) => {
                 let time = (i >> 32) as i32;
-                let inc = (i & 0xFFFFFFFF) as i32;
+                let inc = (i & 0xFFFF_FFFF) as i32;
 
                 write!(fmt, "Timestamp({}, {})", time, inc)
             }
@@ -252,7 +252,7 @@ where
     T: Clone + Into<Bson>,
 {
     fn from(s: &[T]) -> Bson {
-        Bson::Array(s.into_iter().cloned().map(|val| val.into()).collect())
+        Bson::Array(s.iter().cloned().map(|val| val.into()).collect())
     }
 }
 
@@ -372,7 +372,7 @@ impl From<Bson> for Value {
             Bson::ObjectId(v) => json!({"$oid": v.to_string()}),
             Bson::UtcDatetime(v) => json!({
                 "$date": {
-                    "$numberLong": (v.timestamp() * 1000) + ((v.nanosecond() / 1000000) as i64)
+                    "$numberLong": (v.timestamp() * 1000) + ((v.nanosecond() / 1_000_000) as i64)
                 }
             }),
             // FIXME: Don't know what is the best way to encode Symbol type
@@ -475,7 +475,7 @@ impl Bson {
             Bson::UtcDatetime(ref v) => {
                 doc! {
                     "$date": {
-                        "$numberLong" => (v.timestamp() * 1000) + v.nanosecond() as i64 / 1000000,
+                        "$numberLong" => (v.timestamp() * 1000) + v.nanosecond() as i64 / 1_000_000,
                     }
                 }
             }

--- a/src/compat/u2f.rs
+++ b/src/compat/u2f.rs
@@ -34,8 +34,9 @@ impl ToF64 for u64 {
 
 /// Serialize unsigned types to `Bson::FloatingPoint`
 pub fn serialize<T, S>(v: &T, s: S) -> Result<S::Ok, S::Error>
-    where T: ToF64,
-          S: Serializer
+where
+    T: ToF64,
+    S: Serializer,
 {
     s.serialize_f64(v.to_f64())
 }
@@ -72,8 +73,9 @@ impl FromF64 for u64 {
 
 /// Deserialize unsigned types to `Bson::FloatingPoint`
 pub fn deserialize<'de, T, D>(d: D) -> Result<T, D::Error>
-    where D: Deserializer<'de>,
-          T: FromF64
+where
+    D: Deserializer<'de>,
+    T: FromF64,
 {
     f64::deserialize(d).map(T::from_f64)
 }

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -1,7 +1,6 @@
 //! [BSON Decimal128](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst) data type representation
 
-use std::fmt;
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use decimal::d128;
 
@@ -26,7 +25,9 @@ impl Decimal128 {
     /// let dec128 = Decimal128::from_str("1.05E+3");
     /// ```
     pub fn from_str(s: &str) -> Decimal128 {
-        Decimal128 { inner: s.parse::<d128>().expect("Invalid Decimal128 string"), }
+        Decimal128 {
+            inner: s.parse::<d128>().expect("Invalid Decimal128 string"),
+        }
     }
 
     /// Construct a `Decimal128` from a `i32` number.
@@ -38,7 +39,9 @@ impl Decimal128 {
     /// let dec128 = Decimal128::from_i32(num);
     /// ```
     pub fn from_i32(d: i32) -> Decimal128 {
-        Decimal128 { inner: From::from(d) }
+        Decimal128 {
+            inner: From::from(d),
+        }
     }
 
     /// Construct a `Decimal128` from a `u32` number.
@@ -50,7 +53,9 @@ impl Decimal128 {
     /// let dec128 = Decimal128::from_u32(num);
     /// ```
     pub fn from_u32(d: u32) -> Decimal128 {
-        Decimal128 { inner: From::from(d) }
+        Decimal128 {
+            inner: From::from(d),
+        }
     }
 
     /// Construct a `Decimal128` from a `i32` number.
@@ -89,7 +94,9 @@ impl Decimal128 {
     /// let dec128 = Decimal128::zero();
     /// ```
     pub fn zero() -> Decimal128 {
-        Decimal128 { inner: d128::zero() }
+        Decimal128 {
+            inner: d128::zero(),
+        }
     }
 
     #[doc(hidden)]
@@ -98,7 +105,9 @@ impl Decimal128 {
             raw.reverse();
         }
 
-        Decimal128 { inner: d128::from_raw_bytes(raw), }
+        Decimal128 {
+            inner: d128::from_raw_bytes(raw),
+        }
     }
 
     #[doc(hidden)]

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -24,6 +24,7 @@ impl Decimal128 {
     ///
     /// let dec128 = Decimal128::from_str("1.05E+3");
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Decimal128 {
         Decimal128 {
             inner: s.parse::<d128>().expect("Invalid Decimal128 string"),
@@ -68,7 +69,22 @@ impl Decimal128 {
     /// let int = dec128.into_i32();
     /// assert_eq!(int, num);
     /// ```
+    #[deprecated(since = "0.15.0", note = "Replaced by `to_i32`")]
     pub fn into_i32(&self) -> i32 {
+        Into::into(self.inner)
+    }
+
+    /// Construct a `Decimal128` from a `i32` number.
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: i32 = 23;
+    /// let dec128 = Decimal128::from_i32(num);
+    /// let int = dec128.to_i32();
+    /// assert_eq!(int, num);
+    /// ```
+    pub fn to_i32(&self) -> i32 {
         Into::into(self.inner)
     }
 
@@ -82,7 +98,22 @@ impl Decimal128 {
     /// let int = dec128.into_u32();
     /// assert_eq!(int, num);
     /// ```
+    #[deprecated(since = "0.15.0", note = "Replaced by `to_u32`")]
     pub fn into_u32(&self) -> u32 {
+        Into::into(self.inner)
+    }
+
+    /// Construct a `Decimal128` from a `i32` number.
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: u32 = 23;
+    /// let dec128 = Decimal128::from_u32(num);
+    /// let int = dec128.to_u32();
+    /// assert_eq!(int, num);
+    /// ```
+    pub fn to_u32(&self) -> u32 {
         Into::into(self.inner)
     }
 

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -69,6 +69,7 @@ impl Decimal128 {
     /// let int = dec128.into_i32();
     /// assert_eq!(int, num);
     /// ```
+    #[allow(clippy::wrong_self_convention)]
     #[deprecated(since = "0.15.0", note = "Replaced by `to_i32`")]
     pub fn into_i32(&self) -> i32 {
         Into::into(self.inner)
@@ -98,6 +99,7 @@ impl Decimal128 {
     /// let int = dec128.into_u32();
     /// assert_eq!(int, num);
     /// ```
+    #[allow(clippy::wrong_self_convention)]
     #[deprecated(since = "0.15.0", note = "Replaced by `to_u32`")]
     pub fn into_u32(&self) -> u32 {
         Into::into(self.inner)
@@ -253,7 +255,7 @@ mod test {
 
         assert!(!dec128.is_nan());
         assert!(!dec128.is_zero());
-        assert_eq!(dec128.into_i32(), num);
+        assert_eq!(dec128.to_i32(), num);
     }
 
     #[test]
@@ -263,7 +265,7 @@ mod test {
 
         assert!(!dec128.is_nan());
         assert!(!dec128.is_zero());
-        assert_eq!(dec128.into_u32(), num);
+        assert_eq!(dec128.to_u32(), num);
     }
 
     #[test]

--- a/src/decoder/error.rs
+++ b/src/decoder/error.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-use std::{error, fmt, io, string};
+use std::{error, fmt, fmt::Display, io, string};
 
 use serde::de::{self, Expected, Unexpected};
 
@@ -53,16 +52,22 @@ impl fmt::Display for DecoderError {
         match *self {
             DecoderError::IoError(ref inner) => inner.fmt(fmt),
             DecoderError::FromUtf8Error(ref inner) => inner.fmt(fmt),
-            DecoderError::UnrecognizedElementType(tag) => write!(fmt, "unrecognized element type `{}`", tag),
+            DecoderError::UnrecognizedElementType(tag) => {
+                write!(fmt, "unrecognized element type `{}`", tag)
+            }
             DecoderError::InvalidArrayKey(ref want, ref got) => {
                 write!(fmt, "invalid array key: expected `{}`, got `{}`", want, got)
             }
-            DecoderError::ExpectedField(field_type) => write!(fmt, "expected a field of type `{}`", field_type),
+            DecoderError::ExpectedField(field_type) => {
+                write!(fmt, "expected a field of type `{}`", field_type)
+            }
             DecoderError::UnknownField(ref field) => write!(fmt, "unknown field `{}`", field),
             DecoderError::SyntaxError(ref inner) => inner.fmt(fmt),
             DecoderError::EndOfStream => fmt.write_str("end of stream"),
             DecoderError::InvalidType(ref desc) => desc.fmt(fmt),
-            DecoderError::InvalidLength(ref len, ref desc) => write!(fmt, "expecting length {}, {}", len, desc),
+            DecoderError::InvalidLength(ref len, ref desc) => {
+                write!(fmt, "expecting length {}, {}", len, desc)
+            }
             DecoderError::DuplicatedField(ref field) => write!(fmt, "duplicated field `{}`", field),
             DecoderError::UnknownVariant(ref var) => write!(fmt, "unknown variant `{}`", var),
             DecoderError::InvalidValue(ref desc) => desc.fmt(fmt),

--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -1,42 +1,52 @@
-use std::fmt;
-use std::vec;
+use std::{fmt, vec};
 
 use serde::de::{
-    self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Error, MapAccess, SeqAccess, Unexpected,
-    VariantAccess, Visitor,
+    self,
+    Deserialize,
+    DeserializeSeed,
+    Deserializer,
+    EnumAccess,
+    Error,
+    MapAccess,
+    SeqAccess,
+    Unexpected,
+    VariantAccess,
+    Visitor,
 };
 
 use super::error::{DecoderError, DecoderResult};
-use crate::bson::{Bson, TimeStamp, UtcDateTime};
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
-use crate::oid::ObjectId;
-use crate::ordered::{OrderedDocument, OrderedDocumentIntoIterator, OrderedDocumentVisitor};
-use crate::spec::BinarySubtype;
+use crate::{
+    bson::{Bson, TimeStamp, UtcDateTime},
+    oid::ObjectId,
+    ordered::{OrderedDocument, OrderedDocumentIntoIterator, OrderedDocumentVisitor},
+    spec::BinarySubtype,
+};
 
 pub struct BsonVisitor;
 
 impl<'de> Deserialize<'de> for ObjectId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         deserializer.deserialize_map(BsonVisitor).and_then(|bson| {
-                                                     if let Bson::ObjectId(oid) = bson {
-                                                         Ok(oid)
-                                                     } else {
-                                                         let err =
-                                                             format!("expected objectId extended document, found {}",
-                                                                     bson);
-                                                         Err(de::Error::invalid_type(Unexpected::Map, &&err[..]))
-                                                     }
-                                                 })
+            if let Bson::ObjectId(oid) = bson {
+                Ok(oid)
+            } else {
+                let err = format!("expected objectId extended document, found {}", bson);
+                Err(de::Error::invalid_type(Unexpected::Map, &&err[..]))
+            }
+        })
     }
 }
 
 impl<'de> Deserialize<'de> for OrderedDocument {
     /// Deserialize this value given this `Deserializer`.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         deserializer.deserialize_map(BsonVisitor).and_then(|bson| {
             if let Bson::Document(doc) = bson {
@@ -52,7 +62,8 @@ impl<'de> Deserialize<'de> for OrderedDocument {
 impl<'de> Deserialize<'de> for Bson {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Bson, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         deserializer.deserialize_any(BsonVisitor)
     }
@@ -67,65 +78,86 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
     #[inline]
     fn visit_bool<E>(self, value: bool) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
         Ok(Bson::Boolean(value))
     }
 
     #[inline]
     fn visit_i8<E>(self, value: i8) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
         Ok(Bson::I32(value as i32))
     }
 
     #[inline]
     fn visit_u8<E>(self, value: u8) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
-        Err(Error::invalid_type(Unexpected::Unsigned(value as u64), &"a signed integer"))
+        Err(Error::invalid_type(
+            Unexpected::Unsigned(value as u64),
+            &"a signed integer",
+        ))
     }
 
     #[inline]
     fn visit_i16<E>(self, value: i16) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
         Ok(Bson::I32(value as i32))
     }
 
     #[inline]
     fn visit_u16<E>(self, value: u16) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
-        Err(Error::invalid_type(Unexpected::Unsigned(value as u64), &"a signed integer"))
+        Err(Error::invalid_type(
+            Unexpected::Unsigned(value as u64),
+            &"a signed integer",
+        ))
     }
 
     #[inline]
     fn visit_i32<E>(self, value: i32) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
         Ok(Bson::I32(value))
     }
 
     #[inline]
     fn visit_u32<E>(self, value: u32) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
-        Err(Error::invalid_type(Unexpected::Unsigned(value as u64), &"a signed integer"))
+        Err(Error::invalid_type(
+            Unexpected::Unsigned(value as u64),
+            &"a signed integer",
+        ))
     }
 
     #[inline]
     fn visit_i64<E>(self, value: i64) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
         Ok(Bson::I64(value))
     }
 
     #[inline]
     fn visit_u64<E>(self, value: u64) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
-        Err(Error::invalid_type(Unexpected::Unsigned(value), &"a signed integer"))
+        Err(Error::invalid_type(
+            Unexpected::Unsigned(value),
+            &"a signed integer",
+        ))
     }
 
     #[inline]
@@ -135,7 +167,8 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
     #[inline]
     fn visit_str<E>(self, value: &str) -> Result<Bson, E>
-        where E: de::Error
+    where
+        E: de::Error,
     {
         self.visit_string(String::from(value))
     }
@@ -152,7 +185,8 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
     #[inline]
     fn visit_some<D>(self, deserializer: D) -> Result<Bson, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         deserializer.deserialize_any(self)
     }
@@ -164,7 +198,8 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
     #[inline]
     fn visit_seq<V>(self, mut visitor: V) -> Result<Bson, V::Error>
-        where V: SeqAccess<'de>
+    where
+        V: SeqAccess<'de>,
     {
         let mut values = Vec::new();
 
@@ -177,7 +212,8 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
     #[inline]
     fn visit_map<V>(self, visitor: V) -> Result<Bson, V::Error>
-        where V: MapAccess<'de>
+    where
+        V: MapAccess<'de>,
     {
         let values = OrderedDocumentVisitor::new().visit_map(visitor)?;
         Ok(Bson::from_extended_document(values.into()))
@@ -185,7 +221,8 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
     #[inline]
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Bson, E>
-        where E: Error
+    where
+        E: Error,
     {
         Ok(Bson::Binary(BinarySubtype::Generic, v.to_vec()))
     }
@@ -244,7 +281,8 @@ impl<'de> Deserializer<'de> for Decoder {
 
     #[inline]
     fn deserialize_any<V>(mut self, visitor: V) -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         let value = match self.value.take() {
             Some(value) => value,
@@ -256,14 +294,18 @@ impl<'de> Deserializer<'de> for Decoder {
             Bson::String(v) => visitor.visit_string(v),
             Bson::Array(v) => {
                 let len = v.len();
-                visitor.visit_seq(SeqDecoder { iter: v.into_iter(),
-                                               len: len })
+                visitor.visit_seq(SeqDecoder {
+                    iter: v.into_iter(),
+                    len: len,
+                })
             }
             Bson::Document(v) => {
                 let len = v.len();
-                visitor.visit_map(MapDecoder { iter: v.into_iter(),
-                                               value: None,
-                                               len: len })
+                visitor.visit_map(MapDecoder {
+                    iter: v.into_iter(),
+                    value: None,
+                    len: len,
+                })
             }
             Bson::Boolean(v) => visitor.visit_bool(v),
             Bson::Null => visitor.visit_unit(),
@@ -273,16 +315,19 @@ impl<'de> Deserializer<'de> for Decoder {
             _ => {
                 let doc = value.to_extended_document();
                 let len = doc.len();
-                visitor.visit_map(MapDecoder { iter: doc.into_iter(),
-                                               value: None,
-                                               len: len })
+                visitor.visit_map(MapDecoder {
+                    iter: doc.into_iter(),
+                    value: None,
+                    len: len,
+                })
             }
         }
     }
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         match self.value {
             Some(Bson::Null) => visitor.visit_none(),
@@ -292,18 +337,22 @@ impl<'de> Deserializer<'de> for Decoder {
     }
 
     #[inline]
-    fn deserialize_enum<V>(mut self,
-                           _name: &str,
-                           _variants: &'static [&'static str],
-                           visitor: V)
-                           -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    fn deserialize_enum<V>(
+        mut self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> DecoderResult<V::Value>
+    where
+        V: Visitor<'de>,
     {
         let value = match self.value.take() {
             Some(Bson::Document(value)) => value,
             Some(Bson::String(variant)) => {
-                return visitor.visit_enum(EnumDecoder { val: Bson::String(variant),
-                                                        decoder: VariantDecoder { val: None } });
+                return visitor.visit_enum(EnumDecoder {
+                    val: Bson::String(variant),
+                    decoder: VariantDecoder { val: None },
+                });
             }
             Some(_) => {
                 return Err(DecoderError::InvalidType("expected an enum".to_owned()));
@@ -317,20 +366,33 @@ impl<'de> Deserializer<'de> for Decoder {
 
         let (variant, value) = match iter.next() {
             Some(v) => v,
-            None => return Err(DecoderError::SyntaxError("expected a variant name".to_owned())),
+            None => {
+                return Err(DecoderError::SyntaxError(
+                    "expected a variant name".to_owned(),
+                ))
+            }
         };
 
         // enums are encoded in json as maps with a single key:value pair
         match iter.next() {
-            Some(_) => Err(DecoderError::InvalidType("expected a single key:value pair".to_owned())),
-            None => visitor.visit_enum(EnumDecoder { val: Bson::String(variant),
-                                                     decoder: VariantDecoder { val: Some(value) } }),
+            Some(_) => Err(DecoderError::InvalidType(
+                "expected a single key:value pair".to_owned(),
+            )),
+            None => visitor.visit_enum(EnumDecoder {
+                val: Bson::String(variant),
+                decoder: VariantDecoder { val: Some(value) },
+            }),
         }
     }
 
     #[inline]
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> DecoderResult<V::Value>
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
     }
@@ -373,7 +435,8 @@ impl<'de> EnumAccess<'de> for EnumDecoder {
     type Error = DecoderError;
     type Variant = VariantDecoder;
     fn variant_seed<V>(self, seed: V) -> DecoderResult<(V::Value, Self::Variant)>
-        where V: DeserializeSeed<'de>
+    where
+        V: DeserializeSeed<'de>,
     {
         let dec = Decoder::new(self.val);
         let value = seed.deserialize(dec)?;
@@ -396,31 +459,42 @@ impl<'de> VariantAccess<'de> for VariantDecoder {
     }
 
     fn newtype_variant_seed<T>(mut self, seed: T) -> DecoderResult<T::Value>
-        where T: DeserializeSeed<'de>
+    where
+        T: DeserializeSeed<'de>,
     {
         let dec = Decoder::new(self.val.take().ok_or(DecoderError::EndOfStream)?);
         seed.deserialize(dec)
     }
 
     fn tuple_variant<V>(mut self, _len: usize, visitor: V) -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         if let Bson::Array(fields) = self.val.take().ok_or(DecoderError::EndOfStream)? {
-            let de = SeqDecoder { len: fields.len(),
-                                  iter: fields.into_iter() };
+            let de = SeqDecoder {
+                len: fields.len(),
+                iter: fields.into_iter(),
+            };
             de.deserialize_any(visitor)
         } else {
             return Err(DecoderError::InvalidType("expected a tuple".to_owned()));
         }
     }
 
-    fn struct_variant<V>(mut self, _fields: &'static [&'static str], visitor: V) -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    fn struct_variant<V>(
+        mut self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> DecoderResult<V::Value>
+    where
+        V: Visitor<'de>,
     {
         if let Bson::Document(fields) = self.val.take().ok_or(DecoderError::EndOfStream)? {
-            let de = MapDecoder { len: fields.len(),
-                                  iter: fields.into_iter(),
-                                  value: None };
+            let de = MapDecoder {
+                len: fields.len(),
+                iter: fields.into_iter(),
+                value: None,
+            };
             de.deserialize_any(visitor)
         } else {
             return Err(DecoderError::InvalidType("expected a struct".to_owned()));
@@ -438,7 +512,8 @@ impl<'de> Deserializer<'de> for SeqDecoder {
 
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         if self.len == 0 {
             visitor.visit_unit()
@@ -483,7 +558,8 @@ impl<'de> SeqAccess<'de> for SeqDecoder {
     type Error = DecoderError;
 
     fn next_element_seed<T>(&mut self, seed: T) -> DecoderResult<Option<T::Value>>
-        where T: DeserializeSeed<'de>
+    where
+        T: DeserializeSeed<'de>,
     {
         match self.iter.next() {
             None => Ok(None),
@@ -513,7 +589,8 @@ impl<'de> MapAccess<'de> for MapDecoder {
     type Error = DecoderError;
 
     fn next_key_seed<K>(&mut self, seed: K) -> DecoderResult<Option<K::Value>>
-        where K: DeserializeSeed<'de>
+    where
+        K: DeserializeSeed<'de>,
     {
         match self.iter.next() {
             Some((key, value)) => {
@@ -532,7 +609,8 @@ impl<'de> MapAccess<'de> for MapDecoder {
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> DecoderResult<V::Value>
-        where V: DeserializeSeed<'de>
+    where
+        V: DeserializeSeed<'de>,
     {
         let value = self.value.take().ok_or(DecoderError::EndOfStream)?;
         let de = Decoder::new(value);
@@ -549,7 +627,8 @@ impl<'de> Deserializer<'de> for MapDecoder {
 
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> DecoderResult<V::Value>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_map(self)
     }
@@ -588,14 +667,17 @@ impl<'de> Deserializer<'de> for MapDecoder {
 
 impl<'de> Deserialize<'de> for TimeStamp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::TimeStamp(ts) => {
                 let ts = ts.to_le();
 
-                Ok(TimeStamp { t: ((ts as u64) >> 32) as u32,
-                               i: (ts & 0xFFFF_FFFF) as u32 })
+                Ok(TimeStamp {
+                    t: ((ts as u64) >> 32) as u32,
+                    i: (ts & 0xFFFF_FFFF) as u32,
+                })
             }
             _ => Err(D::Error::custom("expecting TimeStamp")),
         }
@@ -605,7 +687,8 @@ impl<'de> Deserialize<'de> for TimeStamp {
 #[cfg(feature = "decimal128")]
 impl<'de> Deserialize<'de> for Decimal128 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::Decimal128(d128) => Ok(d128),
@@ -616,7 +699,8 @@ impl<'de> Deserialize<'de> for Decimal128 {
 
 impl<'de> Deserialize<'de> for UtcDateTime {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::UtcDatetime(dt) => Ok(UtcDateTime(dt)),

--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -216,7 +216,7 @@ impl<'de> Visitor<'de> for BsonVisitor {
         V: MapAccess<'de>,
     {
         let values = OrderedDocumentVisitor::new().visit_map(visitor)?;
-        Ok(Bson::from_extended_document(values.into()))
+        Ok(Bson::from_extended_document(values))
     }
 
     #[inline]
@@ -296,7 +296,7 @@ impl<'de> Deserializer<'de> for Decoder {
                 let len = v.len();
                 visitor.visit_seq(SeqDecoder {
                     iter: v.into_iter(),
-                    len: len,
+                    len,
                 })
             }
             Bson::Document(v) => {
@@ -304,7 +304,7 @@ impl<'de> Deserializer<'de> for Decoder {
                 visitor.visit_map(MapDecoder {
                     iter: v.into_iter(),
                     value: None,
-                    len: len,
+                    len,
                 })
             }
             Bson::Boolean(v) => visitor.visit_bool(v),
@@ -318,7 +318,7 @@ impl<'de> Deserializer<'de> for Decoder {
                 visitor.visit_map(MapDecoder {
                     iter: doc.into_iter(),
                     value: None,
-                    len: len,
+                    len,
                 })
             }
         }
@@ -477,7 +477,7 @@ impl<'de> VariantAccess<'de> for VariantDecoder {
             };
             de.deserialize_any(visitor)
         } else {
-            return Err(DecoderError::InvalidType("expected a tuple".to_owned()));
+            Err(DecoderError::InvalidType("expected a tuple".to_owned()))
         }
     }
 
@@ -497,7 +497,7 @@ impl<'de> VariantAccess<'de> for VariantDecoder {
             };
             de.deserialize_any(visitor)
         } else {
-            return Err(DecoderError::InvalidType("expected a struct".to_owned()));
+            Err(DecoderError::InvalidType("expected a struct".to_owned()))
         }
     }
 }

--- a/src/encoder/error.rs
+++ b/src/encoder/error.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-use std::{error, fmt, io};
+use std::{error, fmt, fmt::Display, io};
 
 use serde::ser;
 
@@ -25,14 +24,19 @@ impl fmt::Display for EncoderError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             EncoderError::IoError(ref inner) => inner.fmt(fmt),
-            EncoderError::InvalidMapKeyType(ref bson) => write!(fmt, "Invalid map key type: {:?}", bson),
+            EncoderError::InvalidMapKeyType(ref bson) => {
+                write!(fmt, "Invalid map key type: {:?}", bson)
+            }
             EncoderError::Unknown(ref inner) => inner.fmt(fmt),
-            EncoderError::UnsupportedUnsignedType => fmt.write_str("BSON does not support unsigned type"),
+            EncoderError::UnsupportedUnsignedType => {
+                fmt.write_str("BSON does not support unsigned type")
+            }
             EncoderError::UnsignedTypesValueExceedsRange(value) => write!(
-                                                                          fmt,
-                                                                          "BSON does not support unsigned types.
-                 An attempt to encode the value: {} in a signed type failed due to the value's size.",
-                                                                          value
+                fmt,
+                "BSON does not support unsigned types.
+                 An attempt to encode the value: {} in a signed type failed due to the value's \
+                 size.",
+                value
             ),
         }
     }
@@ -45,8 +49,10 @@ impl error::Error for EncoderError {
             EncoderError::InvalidMapKeyType(_) => "Invalid map key type",
             EncoderError::Unknown(ref inner) => inner,
             EncoderError::UnsupportedUnsignedType => "BSON does not support unsigned type",
-            EncoderError::UnsignedTypesValueExceedsRange(_) => "BSON does not support unsigned types.
-                 An attempt to encode the value: {} in a signed type failed due to the values size.",
+            EncoderError::UnsignedTypesValueExceedsRange(_) => {
+                "BSON does not support unsigned types.
+                 An attempt to encode the value: {} in a signed type failed due to the values size."
+            }
         }
     }
 

--- a/src/encoder/serde.rs
+++ b/src/encoder/serde.rs
@@ -76,6 +76,7 @@ pub struct Encoder;
 
 impl Encoder {
     /// Construct a new `Serializer`.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Encoder {
         Encoder
     }

--- a/src/encoder/serde.rs
+++ b/src/encoder/serde.rs
@@ -1,21 +1,31 @@
 use std::convert::TryFrom;
 
 use serde::ser::{
-    Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
-    SerializeTupleStruct, SerializeTupleVariant, Serializer,
+    Serialize,
+    SerializeMap,
+    SerializeSeq,
+    SerializeStruct,
+    SerializeStructVariant,
+    SerializeTuple,
+    SerializeTupleStruct,
+    SerializeTupleVariant,
+    Serializer,
 };
 
-use crate::bson::{Array, Bson, Document, TimeStamp, UtcDateTime};
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
-use crate::oid::ObjectId;
+use crate::{
+    bson::{Array, Bson, Document, TimeStamp, UtcDateTime},
+    oid::ObjectId,
+};
 
 use super::{to_bson, EncoderError, EncoderResult};
 
 impl Serialize for ObjectId {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         let mut ser = serializer.serialize_map(Some(1))?;
         ser.serialize_entry("$oid", &self.to_string())?;
@@ -26,7 +36,8 @@ impl Serialize for ObjectId {
 impl Serialize for Document {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         let mut state = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
@@ -39,7 +50,8 @@ impl Serialize for Document {
 impl Serialize for Bson {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         match *self {
             Bson::FloatingPoint(v) => serializer.serialize_f64(v),
@@ -184,7 +196,8 @@ impl Serializer for Encoder {
 
     #[inline]
     fn serialize_some<V: ?Sized>(self, value: &V) -> EncoderResult<Bson>
-        where V: Serialize
+    where
+        V: Serialize,
     {
         value.serialize(self)
     }
@@ -200,29 +213,37 @@ impl Serializer for Encoder {
     }
 
     #[inline]
-    fn serialize_unit_variant(self,
-                              _name: &'static str,
-                              _variant_index: u32,
-                              variant: &'static str)
-                              -> EncoderResult<Bson> {
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> EncoderResult<Bson> {
         Ok(Bson::String(variant.to_string()))
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> EncoderResult<Bson>
-        where T: Serialize
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> EncoderResult<Bson>
+    where
+        T: Serialize,
     {
         value.serialize(self)
     }
 
     #[inline]
-    fn serialize_newtype_variant<T: ?Sized>(self,
-                                            _name: &'static str,
-                                            _variant_index: u32,
-                                            variant: &'static str,
-                                            value: &T)
-                                            -> EncoderResult<Bson>
-        where T: Serialize
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> EncoderResult<Bson>
+    where
+        T: Serialize,
     {
         let mut newtype_variant = Document::new();
         newtype_variant.insert(variant, to_bson(value)?);
@@ -231,50 +252,74 @@ impl Serializer for Encoder {
 
     #[inline]
     fn serialize_seq(self, len: Option<usize>) -> EncoderResult<Self::SerializeSeq> {
-        Ok(ArraySerializer { inner: Array::with_capacity(len.unwrap_or(0)) })
+        Ok(ArraySerializer {
+            inner: Array::with_capacity(len.unwrap_or(0)),
+        })
     }
 
     #[inline]
     fn serialize_tuple(self, len: usize) -> EncoderResult<Self::SerializeTuple> {
-        Ok(TupleSerializer { inner: Array::with_capacity(len) })
+        Ok(TupleSerializer {
+            inner: Array::with_capacity(len),
+        })
     }
 
     #[inline]
-    fn serialize_tuple_struct(self, _name: &'static str, len: usize) -> EncoderResult<Self::SerializeTupleStruct> {
-        Ok(TupleStructSerializer { inner: Array::with_capacity(len) })
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> EncoderResult<Self::SerializeTupleStruct> {
+        Ok(TupleStructSerializer {
+            inner: Array::with_capacity(len),
+        })
     }
 
     #[inline]
-    fn serialize_tuple_variant(self,
-                               _name: &'static str,
-                               _variant_index: u32,
-                               variant: &'static str,
-                               len: usize)
-                               -> EncoderResult<Self::SerializeTupleVariant> {
-        Ok(TupleVariantSerializer { inner: Array::with_capacity(len),
-                                    name: variant })
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> EncoderResult<Self::SerializeTupleVariant> {
+        Ok(TupleVariantSerializer {
+            inner: Array::with_capacity(len),
+            name: variant,
+        })
     }
 
     #[inline]
     fn serialize_map(self, _len: Option<usize>) -> EncoderResult<Self::SerializeMap> {
-        Ok(MapSerializer { inner: Document::new(),
-                           next_key: None })
+        Ok(MapSerializer {
+            inner: Document::new(),
+            next_key: None,
+        })
     }
 
     #[inline]
-    fn serialize_struct(self, _name: &'static str, _len: usize) -> EncoderResult<Self::SerializeStruct> {
-        Ok(StructSerializer { inner: Document::new() })
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> EncoderResult<Self::SerializeStruct> {
+        Ok(StructSerializer {
+            inner: Document::new(),
+        })
     }
 
     #[inline]
-    fn serialize_struct_variant(self,
-                                _name: &'static str,
-                                _variant_index: u32,
-                                variant: &'static str,
-                                _len: usize)
-                                -> EncoderResult<Self::SerializeStructVariant> {
-        Ok(StructVariantSerializer { name: variant,
-                                     inner: Document::new() })
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> EncoderResult<Self::SerializeStructVariant> {
+        Ok(StructVariantSerializer {
+            name: variant,
+            inner: Document::new(),
+        })
     }
 }
 
@@ -395,7 +440,11 @@ impl SerializeStruct for StructSerializer {
     type Ok = Bson;
     type Error = EncoderError;
 
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> EncoderResult<()> {
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> EncoderResult<()> {
         self.inner.insert(key, to_bson(value)?);
         Ok(())
     }
@@ -415,7 +464,11 @@ impl SerializeStructVariant for StructVariantSerializer {
     type Ok = Bson;
     type Error = EncoderError;
 
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> EncoderResult<()> {
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> EncoderResult<()> {
         self.inner.insert(key, to_bson(value)?);
         Ok(())
     }
@@ -433,7 +486,8 @@ impl SerializeStructVariant for StructVariantSerializer {
 impl Serialize for TimeStamp {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         let ts = ((self.t.to_le() as u64) << 32) | (self.i.to_le() as u64);
         let doc = Bson::TimeStamp(ts as i64);
@@ -445,7 +499,8 @@ impl Serialize for TimeStamp {
 impl Serialize for Decimal128 {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         let doc = Bson::Decimal128(self.clone());
         doc.serialize(serializer)
@@ -455,7 +510,8 @@ impl Serialize for Decimal128 {
 impl Serialize for UtcDateTime {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         // Cloning a `DateTime` is extremely cheap
         let doc = Bson::UtcDatetime(self.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,13 +41,21 @@
 //! }
 //! ```
 
-
-pub use self::bson::{Array, Bson, Document, TimeStamp, UtcDateTime};
 #[cfg(feature = "decimal128")]
 pub use self::decimal128::Decimal128;
-pub use self::decoder::{decode_document, decode_document_utf8_lossy, from_bson, Decoder, DecoderError, DecoderResult};
-pub use self::encoder::{encode_document, to_bson, Encoder, EncoderError, EncoderResult};
-pub use self::ordered::{ValueAccessError, ValueAccessResult};
+pub use self::{
+    bson::{Array, Bson, Document, TimeStamp, UtcDateTime},
+    decoder::{
+        decode_document,
+        decode_document_utf8_lossy,
+        from_bson,
+        Decoder,
+        DecoderError,
+        DecoderResult,
+    },
+    encoder::{encode_document, to_bson, Encoder, EncoderError, EncoderResult},
+    ordered::{ValueAccessError, ValueAccessResult},
+};
 
 #[macro_use]
 pub mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,13 @@
 //! use bson::{decode_document, encode_document, Bson, Document};
 //! use std::io::Cursor;
 //!
-//! fn main() {
-//!     let mut doc = Document::new();
-//!     doc.insert("foo".to_owned(), Bson::String("bar".to_owned()));
+//! let mut doc = Document::new();
+//! doc.insert("foo".to_owned(), Bson::String("bar".to_owned()));
 //!
-//!     let mut buf = Vec::new();
-//!     encode_document(&mut buf, &doc).unwrap();
+//! let mut buf = Vec::new();
+//! encode_document(&mut buf, &doc).unwrap();
 //!
-//!     let doc = decode_document(&mut Cursor::new(&buf[..])).unwrap();
-//! }
+//! let doc = decode_document(&mut Cursor::new(&buf[..])).unwrap();
 //! ```
 
 #[cfg(feature = "decimal128")]

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,7 +1,12 @@
 //! ObjectId
 
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{error, fmt, io, result};
+use std::{
+    error,
+    fmt,
+    io,
+    result,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use byteorder::{BigEndian, ByteOrder};
 
@@ -53,7 +58,9 @@ impl fmt::Display for Error {
             Error::ArgumentError(ref inner) => inner.fmt(fmt),
             Error::FromHexError(ref inner) => inner.fmt(fmt),
             Error::IoError(ref inner) => inner.fmt(fmt),
-            Error::HostnameError => fmt.write_str("Failed to retrieve hostname for OID generation."),
+            Error::HostnameError => {
+                fmt.write_str("Failed to retrieve hostname for OID generation.")
+            }
         }
     }
 }
@@ -116,7 +123,9 @@ impl ObjectId {
     pub fn with_string(s: &str) -> Result<ObjectId> {
         let bytes: Vec<u8> = hex::decode(s.as_bytes())?;
         if bytes.len() != 12 {
-            Err(Error::ArgumentError("Provided string must be a 12-byte hexadecimal string.".to_owned()))
+            Err(Error::ArgumentError(
+                "Provided string must be a 12-byte hexadecimal string.".to_owned(),
+            ))
         } else {
             let mut byte_array: [u8; 12] = [0; 12];
             byte_array[..].copy_from_slice(&bytes[..]);

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -101,15 +101,12 @@ impl ObjectId {
         let counter = ObjectId::gen_count()?;
 
         let mut buf: [u8; 12] = [0; 12];
-        for i in 0..TIMESTAMP_SIZE {
-            buf[TIMESTAMP_OFFSET + i] = timestamp[i];
-        }
-        for i in 0..PROCESS_ID_SIZE {
-            buf[PROCESS_ID_OFFSET + i] = process_id[i];
-        }
-        for i in 0..COUNTER_SIZE {
-            buf[COUNTER_OFFSET + i] = counter[i];
-        }
+        buf[TIMESTAMP_OFFSET..(TIMESTAMP_SIZE + TIMESTAMP_OFFSET)]
+            .clone_from_slice(&timestamp[..TIMESTAMP_SIZE]);
+        buf[PROCESS_ID_OFFSET..(PROCESS_ID_SIZE + PROCESS_ID_OFFSET)]
+            .clone_from_slice(&process_id[..PROCESS_ID_SIZE]);
+        buf[COUNTER_OFFSET..(COUNTER_SIZE + COUNTER_OFFSET)]
+            .clone_from_slice(&counter[..COUNTER_SIZE]);
 
         Ok(ObjectId::with_bytes(buf))
     }
@@ -155,9 +152,9 @@ impl ObjectId {
     /// Retrieves the increment counter from an ObjectId.
     pub fn counter(&self) -> u32 {
         let mut buf: [u8; 4] = [0; 4];
-        for i in 0..COUNTER_SIZE {
-            buf[i + 1] = self.id[COUNTER_OFFSET + i];
-        }
+        buf[1..=COUNTER_SIZE]
+            .clone_from_slice(&self.id[COUNTER_OFFSET..(COUNTER_SIZE + COUNTER_OFFSET)]);
+
         BigEndian::read_u32(&buf)
     }
 
@@ -235,9 +232,7 @@ fn count_generated_is_big_endian() {
     let count_bytes = count_res.unwrap();
 
     let mut buf: [u8; 4] = [0; 4];
-    for i in 0..COUNTER_SIZE {
-        buf[i + 1] = count_bytes[i];
-    }
+    buf[1..=COUNTER_SIZE].clone_from_slice(&count_bytes[..COUNTER_SIZE]);
 
     let count = BigEndian::read_u32(&buf);
     assert_eq!(start as u32, count);

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -1,9 +1,11 @@
 //! A BSON document represented as an associative HashMap with insertion ordering.
 
-use std::error;
-use std::fmt::{self, Debug, Display, Formatter};
-use std::iter::{Extend, FromIterator, Map};
-use std::marker::PhantomData;
+use std::{
+    error,
+    fmt::{self, Debug, Display, Formatter},
+    iter::{Extend, FromIterator, Map},
+    marker::PhantomData,
+};
 
 use chrono::{DateTime, Utc};
 
@@ -11,11 +13,13 @@ use linked_hash_map::{self, LinkedHashMap};
 
 use serde::de::{self, MapAccess, Visitor};
 
-use crate::bson::{Array, Bson, Document};
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
-use crate::oid::ObjectId;
-use crate::spec::BinarySubtype;
+use crate::{
+    bson::{Array, Bson, Document},
+    oid::ObjectId,
+    spec::BinarySubtype,
+};
 
 /// Error to indicate that either a value was empty or it contained an unexpected
 /// type, for use with the direct getters.
@@ -34,7 +38,9 @@ impl Debug for ValueAccessError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             ValueAccessError::NotPresent => write!(f, "ValueAccessError: field is not present"),
-            ValueAccessError::UnexpectedType => write!(f, "ValueAccessError: field does not have the expected type"),
+            ValueAccessError::UnexpectedType => {
+                write!(f, "ValueAccessError: field does not have the expected type")
+            }
         }
     }
 }
@@ -142,7 +148,9 @@ impl<'a> IntoIterator for &'a OrderedDocument {
     type IntoIter = OrderedDocumentIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        OrderedDocumentIterator { inner: self.inner.iter() }
+        OrderedDocumentIterator {
+            inner: self.inner.iter(),
+        }
     }
 }
 
@@ -175,7 +183,9 @@ impl<'a> Iterator for OrderedDocumentIterator<'a> {
 impl OrderedDocument {
     /// Creates a new empty OrderedDocument.
     pub fn new() -> OrderedDocument {
-        OrderedDocument { inner: LinkedHashMap::new() }
+        OrderedDocument {
+            inner: LinkedHashMap::new(),
+        }
     }
 
     /// Gets an iterator over the entries of the map.
@@ -364,7 +374,8 @@ impl OrderedDocument {
         }
     }
 
-    /// Get a mutable reference to a time stamp value for this key if it exists and has the correct type.
+    /// Get a mutable reference to a time stamp value for this key if it exists and has the correct
+    /// type.
     pub fn get_time_stamp_mut(&mut self, key: &str) -> ValueAccessResult<&mut i64> {
         match self.get_mut(key) {
             Some(&mut Bson::TimeStamp(ref mut v)) => Ok(v),
@@ -373,7 +384,8 @@ impl OrderedDocument {
         }
     }
 
-    /// Get a reference to a generic binary value for this key if it exists and has the correct type.
+    /// Get a reference to a generic binary value for this key if it exists and has the correct
+    /// type.
     pub fn get_binary_generic(&self, key: &str) -> ValueAccessResult<&Vec<u8>> {
         match self.get(key) {
             Some(&Bson::Binary(BinarySubtype::Generic, ref v)) => Ok(v),
@@ -382,7 +394,8 @@ impl OrderedDocument {
         }
     }
 
-    /// Get a mutable reference generic binary value for this key if it exists and has the correct type.
+    /// Get a mutable reference generic binary value for this key if it exists and has the correct
+    /// type.
     pub fn get_binary_generic_mut(&mut self, key: &str) -> ValueAccessResult<&mut Vec<u8>> {
         match self.get_mut(key) {
             Some(&mut Bson::Binary(BinarySubtype::Generic, ref mut v)) => Ok(v),
@@ -400,7 +413,8 @@ impl OrderedDocument {
         }
     }
 
-    /// Get a mutable reference to an object id value for this key if it exists and has the correct type.
+    /// Get a mutable reference to an object id value for this key if it exists and has the correct
+    /// type.
     pub fn get_object_id_mut(&mut self, key: &str) -> ValueAccessResult<&mut ObjectId> {
         match self.get_mut(key) {
             Some(&mut Bson::ObjectId(ref mut v)) => Ok(v),
@@ -418,7 +432,8 @@ impl OrderedDocument {
         }
     }
 
-    /// Get a mutable reference to a UTC datetime value for this key if it exists and has the correct type.
+    /// Get a mutable reference to a UTC datetime value for this key if it exists and has the
+    /// correct type.
     pub fn get_utc_datetime_mut(&mut self, key: &str) -> ValueAccessResult<&mut DateTime<Utc>> {
         match self.get_mut(key) {
             Some(&mut Bson::UtcDatetime(ref mut v)) => Ok(v),
@@ -439,7 +454,9 @@ impl OrderedDocument {
         }
         let first: fn((&'a String, &'a Bson)) -> &'a String = first;
 
-        Keys { inner: self.iter().map(first) }
+        Keys {
+            inner: self.iter().map(first),
+        }
     }
 
     /// Gets a collection of all values in the document.
@@ -449,7 +466,9 @@ impl OrderedDocument {
         }
         let second: fn((&'a String, &'a Bson)) -> &'a Bson = second;
 
-        Values { inner: self.iter().map(second) }
+        Values {
+            inner: self.iter().map(second),
+        }
     }
 
     /// Returns the number of elements in the document.
@@ -481,7 +500,9 @@ impl OrderedDocument {
     }
 
     pub fn entry(&mut self, k: String) -> Entry {
-        Entry { inner: self.inner.entry(k) }
+        Entry {
+            inner: self.inner.entry(k),
+        }
     }
 }
 
@@ -515,7 +536,9 @@ pub struct OrderedDocumentVisitor {
 
 impl OrderedDocumentVisitor {
     pub fn new() -> OrderedDocumentVisitor {
-        OrderedDocumentVisitor { marker: PhantomData }
+        OrderedDocumentVisitor {
+            marker: PhantomData,
+        }
     }
 }
 
@@ -528,14 +551,16 @@ impl<'de> Visitor<'de> for OrderedDocumentVisitor {
 
     #[inline]
     fn visit_unit<E>(self) -> Result<OrderedDocument, E>
-        where E: de::Error
+    where
+        E: de::Error,
     {
         Ok(OrderedDocument::new())
     }
 
     #[inline]
     fn visit_map<V>(self, mut visitor: V) -> Result<OrderedDocument, V::Error>
-        where V: MapAccess<'de>
+    where
+        V: MapAccess<'de>,
     {
         let mut inner = match visitor.size_hint() {
             Some(size) => LinkedHashMap::with_capacity(size),

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -108,20 +108,22 @@ pub struct OrderedDocumentIterator<'a> {
     inner: linked_hash_map::Iter<'a, String, Bson>,
 }
 
+type DocumentMap<'a, T> = Map<OrderedDocumentIterator<'a>, fn((&'a String, &'a Bson)) -> T>;
+
 /// An iterator over an OrderedDocument's keys.
 pub struct Keys<'a> {
-    inner: Map<OrderedDocumentIterator<'a>, fn((&'a String, &'a Bson)) -> &'a String>,
+    inner: DocumentMap<'a, &'a String>,
 }
 
 /// An iterator over an OrderedDocument's values.
 pub struct Values<'a> {
-    inner: Map<OrderedDocumentIterator<'a>, fn((&'a String, &'a Bson)) -> &'a Bson>,
+    inner: DocumentMap<'a, &'a Bson>,
 }
 
 impl<'a> Iterator for Keys<'a> {
     type Item = &'a String;
 
-    fn next(&mut self) -> Option<(&'a String)> {
+    fn next(&mut self) -> Option<&'a String> {
         self.inner.next()
     }
 }
@@ -129,7 +131,7 @@ impl<'a> Iterator for Keys<'a> {
 impl<'a> Iterator for Values<'a> {
     type Item = &'a Bson;
 
-    fn next(&mut self) -> Option<(&'a Bson)> {
+    fn next(&mut self) -> Option<&'a Bson> {
         self.inner.next()
     }
 }
@@ -189,7 +191,7 @@ impl OrderedDocument {
     }
 
     /// Gets an iterator over the entries of the map.
-    pub fn iter<'a>(&'a self) -> OrderedDocumentIterator<'a> {
+    pub fn iter(&self) -> OrderedDocumentIterator {
         self.into_iter()
     }
 
@@ -535,6 +537,7 @@ pub struct OrderedDocumentVisitor {
 }
 
 impl OrderedDocumentVisitor {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> OrderedDocumentVisitor {
         OrderedDocumentVisitor {
             marker: PhantomData,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -78,11 +78,12 @@ pub enum ElementType {
     UtcDatetime = ELEMENT_TYPE_UTC_DATETIME,
     /// Null value
     NullValue = ELEMENT_TYPE_NULL_VALUE,
-    /// Regular expression - The first cstring is the regex pattern, the second is the regex options string.
-    /// Options are identified by characters, which must be stored in alphabetical order.
-    /// Valid options are 'i' for case insensitive matching, 'm' for multiline matching, 'x' for verbose mode,
-    /// 'l' to make \w, \W, etc. locale dependent, 's' for dotall mode ('.' matches everything), and 'u' to
-    /// make \w, \W, etc. match unicode.
+    /// Regular expression - The first cstring is the regex pattern, the second is the regex
+    /// options string. Options are identified by characters, which must be stored in
+    /// alphabetical order. Valid options are 'i' for case insensitive matching, 'm' for
+    /// multiline matching, 'x' for verbose mode, 'l' to make \w, \W, etc. locale dependent,
+    /// 's' for dotall mode ('.' matches everything), and 'u' to make \w, \W, etc. match
+    /// unicode.
     RegularExpression = ELEMENT_TYPE_REGULAR_EXPRESSION,
     /// Deprecated.
     DbPointer = ELEMENT_TYPE_DBPOINTER,
@@ -111,30 +112,30 @@ impl ElementType {
     pub fn from(tag: u8) -> Option<ElementType> {
         use self::ElementType::*;
         Some(match tag {
-                 ELEMENT_TYPE_FLOATING_POINT => FloatingPoint,
-                 ELEMENT_TYPE_UTF8_STRING => Utf8String,
-                 ELEMENT_TYPE_EMBEDDED_DOCUMENT => EmbeddedDocument,
-                 ELEMENT_TYPE_ARRAY => Array,
-                 ELEMENT_TYPE_BINARY => Binary,
-                 ELEMENT_TYPE_UNDEFINED => Undefined,
-                 ELEMENT_TYPE_OBJECT_ID => ObjectId,
-                 ELEMENT_TYPE_BOOLEAN => Boolean,
-                 ELEMENT_TYPE_UTC_DATETIME => UtcDatetime,
-                 ELEMENT_TYPE_NULL_VALUE => NullValue,
-                 ELEMENT_TYPE_REGULAR_EXPRESSION => RegularExpression,
-                 ELEMENT_TYPE_DBPOINTER => DbPointer,
-                 ELEMENT_TYPE_JAVASCRIPT_CODE => JavaScriptCode,
-                 ELEMENT_TYPE_SYMBOL => Symbol,
-                 ELEMENT_TYPE_JAVASCRIPT_CODE_WITH_SCOPE => JavaScriptCodeWithScope,
-                 ELEMENT_TYPE_32BIT_INTEGER => Integer32Bit,
-                 ELEMENT_TYPE_TIMESTAMP => TimeStamp,
-                 ELEMENT_TYPE_64BIT_INTEGER => Integer64Bit,
-                 #[cfg(feature = "decimal128")]
-                 ELEMENT_TYPE_128BIT_DECIMAL => Decimal128Bit,
-                 ELEMENT_TYPE_MAXKEY => MaxKey,
-                 ELEMENT_TYPE_MINKEY => MinKey,
-                 _ => return None,
-             })
+            ELEMENT_TYPE_FLOATING_POINT => FloatingPoint,
+            ELEMENT_TYPE_UTF8_STRING => Utf8String,
+            ELEMENT_TYPE_EMBEDDED_DOCUMENT => EmbeddedDocument,
+            ELEMENT_TYPE_ARRAY => Array,
+            ELEMENT_TYPE_BINARY => Binary,
+            ELEMENT_TYPE_UNDEFINED => Undefined,
+            ELEMENT_TYPE_OBJECT_ID => ObjectId,
+            ELEMENT_TYPE_BOOLEAN => Boolean,
+            ELEMENT_TYPE_UTC_DATETIME => UtcDatetime,
+            ELEMENT_TYPE_NULL_VALUE => NullValue,
+            ELEMENT_TYPE_REGULAR_EXPRESSION => RegularExpression,
+            ELEMENT_TYPE_DBPOINTER => DbPointer,
+            ELEMENT_TYPE_JAVASCRIPT_CODE => JavaScriptCode,
+            ELEMENT_TYPE_SYMBOL => Symbol,
+            ELEMENT_TYPE_JAVASCRIPT_CODE_WITH_SCOPE => JavaScriptCodeWithScope,
+            ELEMENT_TYPE_32BIT_INTEGER => Integer32Bit,
+            ELEMENT_TYPE_TIMESTAMP => TimeStamp,
+            ELEMENT_TYPE_64BIT_INTEGER => Integer64Bit,
+            #[cfg(feature = "decimal128")]
+            ELEMENT_TYPE_128BIT_DECIMAL => Decimal128Bit,
+            ELEMENT_TYPE_MAXKEY => MaxKey,
+            ELEMENT_TYPE_MINKEY => MinKey,
+            _ => return None,
+        })
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::cognitive_complexity)]
+
 mod modules;

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -1,10 +1,13 @@
-use serde_json::{Value, json};
-use bson::{Bson, Document, doc, oid::ObjectId, spec::BinarySubtype};
+use bson::{doc, oid::ObjectId, spec::BinarySubtype, Bson, Document};
+use serde_json::{json, Value};
 
 #[test]
 fn to_json() {
     let mut doc = Document::new();
-    doc.insert("_id", Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl")));
+    doc.insert(
+        "_id",
+        Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl")),
+    );
     doc.insert("first", Bson::I32(1));
     doc.insert("second", Bson::String("foo".to_owned()));
     doc.insert("alphanumeric", Bson::String("bar".to_owned()));
@@ -50,28 +53,54 @@ fn from_impls() {
     assert_eq!(Bson::from(1.5f32), Bson::FloatingPoint(1.5));
     assert_eq!(Bson::from(2.25f64), Bson::FloatingPoint(2.25));
     assert_eq!(Bson::from("data"), Bson::String(String::from("data")));
-    assert_eq!(Bson::from(String::from("data")), Bson::String(String::from("data")));
-    assert_eq!(Bson::from(doc!{}), Bson::Document(Document::new()));
+    assert_eq!(
+        Bson::from(String::from("data")),
+        Bson::String(String::from("data"))
+    );
+    assert_eq!(Bson::from(doc! {}), Bson::Document(Document::new()));
     assert_eq!(Bson::from(false), Bson::Boolean(false));
-    assert_eq!(Bson::from((String::from("\\s+$"), String::from("i"))), Bson::RegExp(String::from("\\s+$"), String::from("i")));
-    assert_eq!(Bson::from((String::from("alert(\"hi\");"), doc!{})), Bson::JavaScriptCodeWithScope(String::from("alert(\"hi\");"), doc!{}));
+    assert_eq!(
+        Bson::from((String::from("\\s+$"), String::from("i"))),
+        Bson::RegExp(String::from("\\s+$"), String::from("i"))
+    );
+    assert_eq!(
+        Bson::from((String::from("alert(\"hi\");"), doc! {})),
+        Bson::JavaScriptCodeWithScope(String::from("alert(\"hi\");"), doc! {})
+    );
     //
-    assert_eq!(Bson::from((BinarySubtype::Generic, vec![1, 2, 3])), Bson::Binary(BinarySubtype::Generic, vec![1, 2, 3]));
+    assert_eq!(
+        Bson::from((BinarySubtype::Generic, vec![1, 2, 3])),
+        Bson::Binary(BinarySubtype::Generic, vec![1, 2, 3])
+    );
     assert_eq!(Bson::from(-48i32), Bson::I32(-48));
     assert_eq!(Bson::from(-96i64), Bson::I64(-96));
     assert_eq!(Bson::from(152u32), Bson::I32(152));
     assert_eq!(Bson::from(4096u64), Bson::I64(4096));
 
     let oid = ObjectId::new().unwrap();
-    assert_eq!(Bson::from(b"abcdefghijkl"), Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl")));
+    assert_eq!(
+        Bson::from(b"abcdefghijkl"),
+        Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl"))
+    );
     assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
-    assert_eq!(Bson::from(vec![1, 2, 3]), Bson::Array(vec![Bson::I32(1), Bson::I32(2), Bson::I32(3)]));
-    assert_eq!(Bson::from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})), Bson::Document(doc!{"_id": &oid, "name": ["bson-rs"]}));
+    assert_eq!(
+        Bson::from(vec![1, 2, 3]),
+        Bson::Array(vec![Bson::I32(1), Bson::I32(2), Bson::I32(3)])
+    );
+    assert_eq!(
+        Bson::from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})),
+        Bson::Document(doc! {"_id": &oid, "name": ["bson-rs"]})
+    );
 
     // References
     assert_eq!(Bson::from(&24i32), Bson::I32(24));
-    assert_eq!(Bson::from(&String::from("data")), Bson::String(String::from("data")));
+    assert_eq!(
+        Bson::from(&String::from("data")),
+        Bson::String(String::from("data"))
+    );
     assert_eq!(Bson::from(&oid), Bson::ObjectId(oid));
-    assert_eq!(Bson::from(&doc!{"a": "b"}), Bson::Document(doc!{"a": "b"}));
-
+    assert_eq!(
+        Bson::from(&doc! {"a": "b"}),
+        Bson::Document(doc! {"a": "b"})
+    );
 }

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -11,7 +11,7 @@ fn to_json() {
     doc.insert("first", Bson::I32(1));
     doc.insert("second", Bson::String("foo".to_owned()));
     doc.insert("alphanumeric", Bson::String("bar".to_owned()));
-    let data: Value = Bson::Document(doc).clone().into();
+    let data: Value = Bson::Document(doc).into();
 
     assert!(data.is_object());
     let obj = data.as_object().unwrap();

--- a/tests/modules/encoder_decoder.rs
+++ b/tests/modules/encoder_decoder.rs
@@ -275,7 +275,7 @@ fn test_encode_decode_object_id() {
 
 #[test]
 fn test_encode_utc_date_time() {
-    let src = Utc.timestamp(1286705410, 0);
+    let src = Utc.timestamp(1_286_705_410, 0);
     let dst = vec![
         18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0,
     ];
@@ -311,7 +311,7 @@ fn test_encode_decode_symbol() {
 
 #[test]
 fn test_decode_utc_date_time_overflows() {
-    let t = 1530492218 * 1_000 + 999;
+    let t = 1_530_492_218 * 1_000 + 999;
 
     let mut raw0 = vec![0x09, b'A', 0x00];
     raw0.write_i64::<LittleEndian>(t).unwrap();
@@ -324,7 +324,7 @@ fn test_decode_utc_date_time_overflows() {
 
     let decoded = decode_document(&mut Cursor::new(raw)).unwrap();
 
-    let expected = doc! { "A" => Utc.timestamp(1530492218, 999 * 1_000_000)};
+    let expected = doc! { "A" => Utc.timestamp(1_530_492_218, 999 * 1_000_000)};
     assert_eq!(decoded, expected);
 }
 

--- a/tests/modules/encoder_decoder.rs
+++ b/tests/modules/encoder_decoder.rs
@@ -1,18 +1,24 @@
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
-use bson::doc;
-use bson::oid::ObjectId;
-use bson::spec::BinarySubtype;
-use bson::{decode_document, decode_document_utf8_lossy, encode_document, Bson};
+use bson::{
+    decode_document,
+    decode_document_utf8_lossy,
+    doc,
+    encode_document,
+    oid::ObjectId,
+    spec::BinarySubtype,
+    Bson,
+};
 use byteorder::{LittleEndian, WriteBytesExt};
-use chrono::offset::TimeZone;
-use chrono::Utc;
+use chrono::{offset::TimeZone, Utc};
 use std::io::{Cursor, Write};
 
 #[test]
 fn test_encode_decode_floating_point() {
     let src = 1020.123;
-    let dst = vec![18, 0, 0, 0, 1, 107, 101, 121, 0, 68, 139, 108, 231, 251, 224, 143, 64, 0];
+    let dst = vec![
+        18, 0, 0, 0, 1, 107, 101, 121, 0, 68, 139, 108, 231, 251, 224, 143, 64, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -28,8 +34,10 @@ fn test_encode_decode_floating_point() {
 #[test]
 fn test_encode_decode_utf8_string() {
     let src = "test你好吗".to_owned();
-    let dst = vec![28, 0, 0, 0, 2, 107, 101, 121, 0, 14, 0, 0, 0, 116, 101, 115, 116, 228, 189, 160, 229, 165, 189,
-                   229, 144, 151, 0, 0];
+    let dst = vec![
+        28, 0, 0, 0, 2, 107, 101, 121, 0, 14, 0, 0, 0, 116, 101, 115, 116, 228, 189, 160, 229, 165,
+        189, 229, 144, 151, 0, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -60,8 +68,10 @@ fn test_encode_decode_utf8_string_invalid() {
 #[test]
 fn test_encode_decode_array() {
     let src = vec![Bson::FloatingPoint(1.01), Bson::String("xyz".to_owned())];
-    let dst = vec![37, 0, 0, 0, 4, 107, 101, 121, 0, 27, 0, 0, 0, 1, 48, 0, 41, 92, 143, 194, 245, 40, 240, 63, 2, 49,
-                   0, 4, 0, 0, 0, 120, 121, 122, 0, 0, 0];
+    let dst = vec![
+        37, 0, 0, 0, 4, 107, 101, 121, 0, 27, 0, 0, 0, 1, 48, 0, 41, 92, 143, 194, 245, 40, 240,
+        63, 2, 49, 0, 4, 0, 0, 0, 120, 121, 122, 0, 0, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -77,7 +87,10 @@ fn test_encode_decode_array() {
 #[test]
 fn test_encode_decode_document() {
     let src = doc! { "subkey": 1 };
-    let dst = vec![27, 0, 0, 0, 3, 107, 101, 121, 0, 17, 0, 0, 0, 16, 115, 117, 98, 107, 101, 121, 0, 1, 0, 0, 0, 0, 0];
+    let dst = vec![
+        27, 0, 0, 0, 3, 107, 101, 121, 0, 17, 0, 0, 0, 16, 115, 117, 98, 107, 101, 121, 0, 1, 0, 0,
+        0, 0, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -157,7 +170,9 @@ fn test_encode_decode_javascript_code() {
 #[test]
 fn test_encode_decode_javascript_code_with_scope() {
     let src = Bson::JavaScriptCodeWithScope("1".to_owned(), doc! {});
-    let dst = vec![25, 0, 0, 0, 15, 107, 101, 121, 0, 15, 0, 0, 0, 2, 0, 0, 0, 49, 0, 5, 0, 0, 0, 0, 0];
+    let dst = vec![
+        25, 0, 0, 0, 15, 107, 101, 121, 0, 15, 0, 0, 0, 2, 0, 0, 0, 49, 0, 5, 0, 0, 0, 0, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -189,7 +204,9 @@ fn test_encode_decode_i32() {
 #[test]
 fn test_encode_decode_i64() {
     let src = 100i64;
-    let dst = vec![18, 0, 0, 0, 18, 107, 101, 121, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0];
+    let dst = vec![
+        18, 0, 0, 0, 18, 107, 101, 121, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -205,7 +222,9 @@ fn test_encode_decode_i64() {
 #[test]
 fn test_encode_decode_timestamp() {
     let src = Bson::TimeStamp(100);
-    let dst = vec![18, 0, 0, 0, 17, 107, 101, 121, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0];
+    let dst = vec![
+        18, 0, 0, 0, 17, 107, 101, 121, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -221,7 +240,9 @@ fn test_encode_decode_timestamp() {
 #[test]
 fn test_encode_binary_generic() {
     let src = (BinarySubtype::Generic, vec![0, 1, 2, 3, 4]);
-    let dst = vec![20, 0, 0, 0, 5, 107, 101, 121, 0, 5, 0, 0, 0, 0, 0, 1, 2, 3, 4, 0];
+    let dst = vec![
+        20, 0, 0, 0, 5, 107, 101, 121, 0, 5, 0, 0, 0, 0, 0, 1, 2, 3, 4, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -237,7 +258,9 @@ fn test_encode_binary_generic() {
 #[test]
 fn test_encode_decode_object_id() {
     let src = ObjectId::with_string("507f1f77bcf86cd799439011").unwrap();
-    let dst = vec![22, 0, 0, 0, 7, 107, 101, 121, 0, 80, 127, 31, 119, 188, 248, 108, 215, 153, 67, 144, 17, 0];
+    let dst = vec![
+        22, 0, 0, 0, 7, 107, 101, 121, 0, 80, 127, 31, 119, 188, 248, 108, 215, 153, 67, 144, 17, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -253,7 +276,9 @@ fn test_encode_decode_object_id() {
 #[test]
 fn test_encode_utc_date_time() {
     let src = Utc.timestamp(1286705410, 0);
-    let dst = vec![18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0];
+    let dst = vec![
+        18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0,
+    ];
 
     let doc = doc! { "key": src };
 
@@ -269,7 +294,9 @@ fn test_encode_utc_date_time() {
 #[test]
 fn test_encode_decode_symbol() {
     let symbol = Bson::Symbol("abc".to_owned());
-    let dst = vec![18, 0, 0, 0, 14, 107, 101, 121, 0, 4, 0, 0, 0, 97, 98, 99, 0, 0];
+    let dst = vec![
+        18, 0, 0, 0, 14, 107, 101, 121, 0, 4, 0, 0, 0, 97, 98, 99, 0, 0,
+    ];
 
     let doc = doc! { "key": symbol };
 
@@ -290,7 +317,8 @@ fn test_decode_utc_date_time_overflows() {
     raw0.write_i64::<LittleEndian>(t).unwrap();
 
     let mut raw = vec![];
-    raw.write_i32::<LittleEndian>((raw0.len() + 4 + 1) as i32).unwrap();
+    raw.write_i32::<LittleEndian>((raw0.len() + 4 + 1) as i32)
+        .unwrap();
     raw.write_all(&raw0).unwrap();
     raw.write_u8(0).unwrap();
 
@@ -318,7 +346,9 @@ fn test_decode_multiply_overflows_issue64() {
 #[test]
 fn test_encode_decode_decimal128() {
     let val = Bson::Decimal128(Decimal128::from_i32(0));
-    let dst = vec![26, 0, 0, 0, 19, 107, 101, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 34, 0];
+    let dst = vec![
+        26, 0, 0, 0, 19, 107, 101, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 34, 0,
+    ];
 
     let doc = doc! { "key" => val };
 
@@ -333,6 +363,8 @@ fn test_encode_decode_decimal128() {
 
 #[test]
 fn test_illegal_size() {
-    let buffer = [0x06, 0xcc, 0xf9, 0x0a, 0x05, 0x00, 0x00, 0x03, 0x00, 0xff, 0xff];
+    let buffer = [
+        0x06, 0xcc, 0xf9, 0x0a, 0x05, 0x00, 0x00, 0x03, 0x00, 0xff, 0xff,
+    ];
     assert!(decode_document(&mut Cursor::new(&buffer[..])).is_err());
 }

--- a/tests/modules/macros.rs
+++ b/tests/modules/macros.rs
@@ -1,7 +1,4 @@
-use bson::oid::ObjectId;
-use bson::spec::BinarySubtype;
-use bson::Bson;
-use bson::doc;
+use bson::{doc, oid::ObjectId, spec::BinarySubtype, Bson};
 use chrono::offset::Utc;
 use hex;
 
@@ -40,14 +37,16 @@ fn standard_format() {
         "date": Bson::UtcDatetime(date),
     };
 
-    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1, true, [1, 2]], doc: {{ \
-                 fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, \
-                 regexp: /s[ao]d/i, with_wrapped_parens: -20, code: function(x) {{ return x._id; }}, i32: 12, \
-                 i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, \
-                 0x{}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}",
-                hex::encode("thingies"),
-                hex::encode(id_string),
-                date);
+    let expected = format!(
+        "{{ float: 2.4, string: \"hello\", array: [\"testing\", 1, true, [1, 2]], doc: {{ fish: \
+         \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, \
+         with_wrapped_parens: -20, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, \
+         timestamp: Timestamp(0, 229999444), binary: BinData(5, 0x{}), _id: ObjectId(\"{}\"), \
+         date: Date(\"{}\") }}",
+        hex::encode("thingies"),
+        hex::encode(id_string),
+        date
+    );
 
     assert_eq!(expected, format!("{}", doc));
 }
@@ -88,21 +87,23 @@ fn rocket_format() {
         "date" => Bson::UtcDatetime(date),
     };
 
-    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1, true, [\"nested\", 2]], doc: {{ \
-                 fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, \
-                 regexp: /s[ao]d/i, with_wrapped_parens: -20, code: function(x) {{ return x._id; }}, i32: 12, \
-                 i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, \
-                 0x{}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}",
-                hex::encode("thingies"),
-                hex::encode(id_string),
-                date);
+    let expected = format!(
+        "{{ float: 2.4, string: \"hello\", array: [\"testing\", 1, true, [\"nested\", 2]], doc: \
+         {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, \
+         with_wrapped_parens: -20, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, \
+         timestamp: Timestamp(0, 229999444), binary: BinData(5, 0x{}), _id: ObjectId(\"{}\"), \
+         date: Date(\"{}\") }}",
+        hex::encode("thingies"),
+        hex::encode(id_string),
+        date
+    );
 
     assert_eq!(expected, format!("{}", doc));
 }
 
 #[test]
 fn non_trailing_comma() {
-    let doc = doc!{
+    let doc = doc! {
         "a": "foo",
         "b": { "ok": "then" }
     };
@@ -113,7 +114,7 @@ fn non_trailing_comma() {
 
 #[test]
 fn non_trailing_comma_with_rockets() {
-    let doc = doc!{
+    let doc = doc! {
         "a" => "foo",
         "b" => { "ok": "then" }
     };
@@ -162,11 +163,15 @@ fn recursive_macro() {
                             // Match array items
                             match arr[0] {
                                 Bson::String(ref s) => assert_eq!("seal", s),
-                                _ => panic!("String 'seal' was not inserted into inner array correctly."),
+                                _ => panic!(
+                                    "String 'seal' was not inserted into inner array correctly."
+                                ),
                             }
                             match arr[1] {
                                 Bson::Boolean(ref b) => assert!(!b),
-                                _ => panic!("Boolean 'false' was not inserted into inner array correctly."),
+                                _ => panic!(
+                                    "Boolean 'false' was not inserted into inner array correctly."
+                                ),
                             }
                         }
                         _ => panic!("Inner array was not inserted correctly."),

--- a/tests/modules/macros.rs
+++ b/tests/modules/macros.rs
@@ -7,10 +7,7 @@ fn standard_format() {
     let id_string = "thisismyname";
     let string_bytes: Vec<_> = id_string.bytes().collect();
     let mut bytes = [0; 12];
-
-    for i in 0..12 {
-        bytes[i] = string_bytes[i];
-    }
+    bytes[..12].clone_from_slice(&string_bytes[..12]);
 
     let id = ObjectId::with_bytes(bytes);
     let date = Utc::now();
@@ -31,7 +28,7 @@ fn standard_format() {
         "code": Bson::JavaScriptCode("function(x) { return x._id; }".to_owned()),
         "i32": 12,
         "i64": -55,
-        "timestamp": Bson::TimeStamp(229999444),
+        "timestamp": Bson::TimeStamp(229_999_444),
         "binary": Bson::Binary(BinarySubtype::Md5, "thingies".to_owned().into_bytes()),
         "_id": id,
         "date": Bson::UtcDatetime(date),
@@ -57,10 +54,7 @@ fn rocket_format() {
     let id_string = "thisismyname";
     let string_bytes: Vec<_> = id_string.bytes().collect();
     let mut bytes = [0; 12];
-
-    for i in 0..12 {
-        bytes[i] = string_bytes[i];
-    }
+    bytes[..12].clone_from_slice(&string_bytes[..12]);
 
     let id = ObjectId::with_bytes(bytes);
     let date = Utc::now();
@@ -81,7 +75,7 @@ fn rocket_format() {
         "code" => Bson::JavaScriptCode("function(x) { return x._id; }".to_owned()),
         "i32" => 12,
         "i64" => -55,
-        "timestamp" => Bson::TimeStamp(229999444),
+        "timestamp" => Bson::TimeStamp(229_999_444),
         "binary" => Bson::Binary(BinarySubtype::Md5, "thingies".to_owned().into_bytes()),
         "_id" => id,
         "date" => Bson::UtcDatetime(date),
@@ -108,7 +102,7 @@ fn non_trailing_comma() {
         "b": { "ok": "then" }
     };
 
-    let expected = format!("{{ a: \"foo\", b: {{ ok: \"then\" }} }}");
+    let expected = "{{ a: \"foo\", b: {{ ok: \"then\" }} }}".to_string();
     assert_eq!(expected, format!("{}", doc));
 }
 
@@ -119,11 +113,12 @@ fn non_trailing_comma_with_rockets() {
         "b" => { "ok": "then" }
     };
 
-    let expected = format!("{{ a: \"foo\", b: {{ ok: \"then\" }} }}");
+    let expected = "{{ a: \"foo\", b: {{ ok: \"then\" }} }}".to_string();
     assert_eq!(expected, format!("{}", doc));
 }
 
 #[test]
+#[allow(clippy::float_cmp)]
 fn recursive_macro() {
     let doc = doc! {
         "a": "foo",

--- a/tests/modules/macros.rs
+++ b/tests/modules/macros.rs
@@ -102,7 +102,7 @@ fn non_trailing_comma() {
         "b": { "ok": "then" }
     };
 
-    let expected = "{{ a: \"foo\", b: {{ ok: \"then\" }} }}".to_string();
+    let expected = "{ a: \"foo\", b: { ok: \"then\" } }".to_string();
     assert_eq!(expected, format!("{}", doc));
 }
 
@@ -113,7 +113,7 @@ fn non_trailing_comma_with_rockets() {
         "b" => { "ok": "then" }
     };
 
-    let expected = "{{ a: \"foo\", b: {{ ok: \"then\" }} }}".to_string();
+    let expected = "{ a: \"foo\", b: { ok: \"then\" } }".to_string();
     assert_eq!(expected, format!("{}", doc));
 }
 

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -1,6 +1,6 @@
+mod bson;
 mod encoder_decoder;
 mod macros;
 mod oid;
 mod ordered;
-mod bson;
 mod ser;

--- a/tests/modules/oid.rs
+++ b/tests/modules/oid.rs
@@ -10,13 +10,13 @@ fn deserialize() {
     ];
 
     let oid = ObjectId::with_bytes(bytes);
-    assert_eq!(3735928559 as u32, oid.timestamp());
-    assert_eq!(1122867 as u32, oid.counter());
+    assert_eq!(3_735_928_559 as u32, oid.timestamp());
+    assert_eq!(1_122_867 as u32, oid.counter());
 }
 
 #[test]
 fn timestamp() {
-    let time: u32 = 2000000;
+    let time: u32 = 2_000_000;
     let oid = ObjectId::with_timestamp(time);
     let timestamp = oid.timestamp();
     assert_eq!(time, timestamp);
@@ -24,7 +24,7 @@ fn timestamp() {
 
 #[test]
 fn timestamp_is_big_endian() {
-    let time: u32 = 3857379;
+    let time: u32 = 3_857_379;
     let oid = ObjectId::with_timestamp(time);
     assert_eq!(0x00u8, oid.bytes()[0]);
     assert_eq!(0x3Au8, oid.bytes()[1]);

--- a/tests/modules/oid.rs
+++ b/tests/modules/oid.rs
@@ -3,9 +3,11 @@ use hex;
 
 #[test]
 fn deserialize() {
-    let bytes: [u8; 12] = [0xDEu8, 0xADu8, 0xBEu8, 0xEFu8, // timestamp is 3735928559
-                           0xEFu8, 0xCDu8, 0xABu8, 0xFAu8, 0x29u8, 0x11u8, 0x22u8,
-                           0x33u8 /* increment is 1122867 */];
+    let bytes: [u8; 12] = [
+        0xDEu8, 0xADu8, 0xBEu8, 0xEFu8, // timestamp is 3735928559
+        0xEFu8, 0xCDu8, 0xABu8, 0xFAu8, 0x29u8, 0x11u8, 0x22u8,
+        0x33u8, // increment is 1122867
+    ];
 
     let oid = ObjectId::with_bytes(bytes);
     assert_eq!(3735928559 as u32, oid.timestamp());
@@ -45,8 +47,10 @@ fn byte_string_oid() {
     let oid_res = ObjectId::with_string(s);
     assert!(oid_res.is_ok());
     let oid = oid_res.unwrap();
-    let bytes: [u8; 12] =
-        [0x54u8, 0x1Bu8, 0x1Au8, 0x00u8, 0xE8u8, 0xA2u8, 0x3Au8, 0xFAu8, 0x83u8, 0x2Bu8, 0x21u8, 0x8Eu8];
+    let bytes: [u8; 12] = [
+        0x54u8, 0x1Bu8, 0x1Au8, 0x00u8, 0xE8u8, 0xA2u8, 0x3Au8, 0xFAu8, 0x83u8, 0x2Bu8, 0x21u8,
+        0x8Eu8,
+    ];
 
     assert_eq!(bytes, oid.bytes());
     assert_eq!(s, oid.to_string());

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -51,7 +51,7 @@ fn test_decimal128(_doc: &mut Document) {}
 #[test]
 fn test_getters() {
     let datetime = Utc::now();
-    let cloned_dt = datetime.clone();
+    let cloned_dt = datetime;
     let binary = vec![0, 1, 2, 3, 4];
     let mut doc = doc! {
         "floating_point": 10.0,
@@ -107,18 +107,12 @@ fn test_getters() {
     assert_eq!(Some(&Bson::TimeStamp(100)), doc.get("timestamp"));
     assert_eq!(Ok(100i64), doc.get_time_stamp("timestamp"));
 
-    assert_eq!(
-        Some(&Bson::UtcDatetime(datetime.clone())),
-        doc.get("datetime")
-    );
+    assert_eq!(Some(&Bson::UtcDatetime(datetime)), doc.get("datetime"));
     assert_eq!(Ok(&datetime), doc.get_utc_datetime("datetime"));
 
     test_decimal128(&mut doc);
 
-    assert_eq!(
-        Some(&Bson::UtcDatetime(datetime.clone())),
-        doc.get("datetime")
-    );
+    assert_eq!(Some(&Bson::UtcDatetime(datetime)), doc.get("datetime"));
     assert_eq!(Ok(&datetime), doc.get_utc_datetime("datetime"));
 
     let object_id = ObjectId::new().unwrap();

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -1,10 +1,6 @@
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
-use bson::doc;
-use bson::oid::ObjectId;
-use bson::spec::BinarySubtype;
-use bson::ValueAccessError;
-use bson::{Bson, Document};
+use bson::{doc, oid::ObjectId, spec::BinarySubtype, Bson, Document, ValueAccessError};
 use chrono::Utc;
 
 #[test]
@@ -14,7 +10,11 @@ fn ordered_insert() {
     doc.insert("second".to_owned(), Bson::String("foo".to_owned()));
     doc.insert("alphanumeric".to_owned(), Bson::String("bar".to_owned()));
 
-    let expected_keys = vec!["first".to_owned(), "second".to_owned(), "alphanumeric".to_owned()];
+    let expected_keys = vec![
+        "first".to_owned(),
+        "second".to_owned(),
+        "alphanumeric".to_owned(),
+    ];
 
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);
@@ -27,7 +27,11 @@ fn ordered_insert_shorthand() {
     doc.insert("second", "foo");
     doc.insert("alphanumeric", "bar".to_owned());
 
-    let expected_keys = vec!["first".to_owned(), "second".to_owned(), "alphanumeric".to_owned()];
+    let expected_keys = vec![
+        "first".to_owned(),
+        "second".to_owned(),
+        "alphanumeric".to_owned(),
+    ];
 
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);
@@ -63,12 +67,18 @@ fn test_getters() {
 
     assert_eq!(None, doc.get("nonsense"));
     assert_eq!(Err(ValueAccessError::NotPresent), doc.get_str("nonsense"));
-    assert_eq!(Err(ValueAccessError::UnexpectedType), doc.get_str("floating_point"));
+    assert_eq!(
+        Err(ValueAccessError::UnexpectedType),
+        doc.get_str("floating_point")
+    );
 
     assert_eq!(Some(&Bson::FloatingPoint(10.0)), doc.get("floating_point"));
     assert_eq!(Ok(10.0), doc.get_f64("floating_point"));
 
-    assert_eq!(Some(&Bson::String("a value".to_string())), doc.get("string"));
+    assert_eq!(
+        Some(&Bson::String("a value".to_string())),
+        doc.get("string")
+    );
     assert_eq!(Ok("a value"), doc.get_str("string"));
 
     let array = vec![Bson::I32(10), Bson::I32(20), Bson::I32(30)];
@@ -97,12 +107,18 @@ fn test_getters() {
     assert_eq!(Some(&Bson::TimeStamp(100)), doc.get("timestamp"));
     assert_eq!(Ok(100i64), doc.get_time_stamp("timestamp"));
 
-    assert_eq!(Some(&Bson::UtcDatetime(datetime.clone())), doc.get("datetime"));
+    assert_eq!(
+        Some(&Bson::UtcDatetime(datetime.clone())),
+        doc.get("datetime")
+    );
     assert_eq!(Ok(&datetime), doc.get_utc_datetime("datetime"));
 
     test_decimal128(&mut doc);
 
-    assert_eq!(Some(&Bson::UtcDatetime(datetime.clone())), doc.get("datetime"));
+    assert_eq!(
+        Some(&Bson::UtcDatetime(datetime.clone())),
+        doc.get("datetime")
+    );
     assert_eq!(Ok(&datetime), doc.get_utc_datetime("datetime"));
 
     let object_id = ObjectId::new().unwrap();
@@ -110,8 +126,10 @@ fn test_getters() {
     assert_eq!(Some(&Bson::ObjectId(object_id.clone())), doc.get("_id"));
     assert_eq!(Ok(&object_id), doc.get_object_id("_id"));
 
-    assert_eq!(Some(&Bson::Binary(BinarySubtype::Generic, binary.clone())),
-               doc.get("binary"));
+    assert_eq!(
+        Some(&Bson::Binary(BinarySubtype::Generic, binary.clone())),
+        doc.get("binary")
+    );
     assert_eq!(Ok(&binary), doc.get_binary_generic("binary"));
 }
 
@@ -155,11 +173,13 @@ fn entry() {
         assert_eq!(v, &mut Bson::Null);
     }
 
-    assert_eq!(doc,
-               doc! {
-                   "first": 1i32,
-                   "second": "foo",
-                   "alphanumeric": "bar",
-                   "fourth": Bson::Null,
-               },);
+    assert_eq!(
+        doc,
+        doc! {
+            "first": 1i32,
+            "second": "foo",
+            "alphanumeric": "bar",
+            "fourth": Bson::Null,
+        },
+    );
 }

--- a/tests/modules/ser.rs
+++ b/tests/modules/ser.rs
@@ -1,10 +1,8 @@
 use assert_matches::assert_matches;
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
-use bson::oid::ObjectId;
-use bson::{from_bson, to_bson, Bson, EncoderError, EncoderResult};
-use std::collections::BTreeMap;
-use std::{u16, u32, u64, u8};
+use bson::{from_bson, oid::ObjectId, to_bson, Bson, EncoderError, EncoderResult};
+use std::{collections::BTreeMap, u16, u32, u64, u8};
 
 #[test]
 fn floating_point() {
@@ -141,7 +139,10 @@ fn uint64_u2i() {
     assert_eq!(deser_min, u64::MIN);
 
     let obj_max: EncoderResult<Bson> = to_bson(&u64::MAX);
-    assert_matches!(obj_max, Err(EncoderError::UnsignedTypesValueExceedsRange(u64::MAX)));
+    assert_matches!(
+        obj_max,
+        Err(EncoderError::UnsignedTypesValueExceedsRange(u64::MAX))
+    );
 }
 
 #[test]

--- a/tests/modules/ser.rs
+++ b/tests/modules/ser.rs
@@ -5,6 +5,7 @@ use bson::{from_bson, oid::ObjectId, to_bson, Bson, EncoderError, EncoderResult}
 use std::{collections::BTreeMap, u16, u32, u64, u8};
 
 #[test]
+#[allow(clippy::float_cmp)]
 fn floating_point() {
     let obj = Bson::FloatingPoint(240.5);
     let f: f64 = from_bson(obj.clone()).unwrap();
@@ -27,7 +28,7 @@ fn string() {
 #[test]
 fn arr() {
     let obj = Bson::Array(vec![Bson::I32(0), Bson::I32(1), Bson::I32(2), Bson::I32(3)]);
-    let arr: Vec<i32> = from_bson(obj.clone().clone()).unwrap();
+    let arr: Vec<i32> = from_bson(obj.clone()).unwrap();
     assert_eq!(arr, vec![0i32, 1i32, 2i32, 3i32]);
 
     let deser: Bson = to_bson(&arr).unwrap();

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::blacklisted_name)]
+
 use bson::{bson, doc, Bson, Decoder, Encoder};
 use serde::{Deserialize, Serialize};
 use serde_derive::{Deserialize, Serialize};
@@ -105,7 +107,7 @@ fn test_ser_datetime() {
     let now = Utc::now();
     // FIXME: Due to BSON's datetime precision
     let now = now
-        .with_nanosecond(now.nanosecond() / 1000000 * 1000000)
+        .with_nanosecond(now.nanosecond() / 1_000_000 * 1_000_000)
         .unwrap();
 
     let foo = Foo {
@@ -209,7 +211,7 @@ fn test_serde_tuple_struct() {
 
     let name_1 = Name(String::from("Graydon"), String::from("Hoare"));
     let b = bson::to_bson(&name_1).unwrap();
-    assert_eq!(b, bson!([name_1.0.clone(), name_1.1.clone(),]));
+    assert_eq!(b, bson!([name_1.0.clone(), name_1.1]));
 
     let (first, last) = (String::from("Donald"), String::from("Knuth"));
     let de = bson!([first.clone(), last.clone()]);
@@ -245,6 +247,7 @@ fn test_serde_tuple_variant() {
         ThreeDim(f64, f64, f64),
     }
 
+    #[allow(clippy::approx_constant)]
     let (x1, y1) = (3.14, -2.71);
     let p1 = Point::TwoDim(x1, y1);
     let b = bson::to_bson(&p1).unwrap();

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,4 +1,4 @@
-use bson::{Bson, Decoder, Encoder, bson, doc};
+use bson::{bson, doc, Bson, Decoder, Encoder};
 use serde::{Deserialize, Serialize};
 use serde_derive::{Deserialize, Serialize};
 
@@ -61,10 +61,15 @@ fn test_ser_timestamp() {
         ts: TimeStamp,
     }
 
-    let foo = Foo { ts: TimeStamp { t: 12, i: 10 } };
+    let foo = Foo {
+        ts: TimeStamp { t: 12, i: 10 },
+    };
 
     let x = bson::to_bson(&foo).unwrap();
-    assert_eq!(x.as_document().unwrap(), &doc! { "ts": Bson::TimeStamp(0x0000_000C_0000_000A) });
+    assert_eq!(
+        x.as_document().unwrap(),
+        &doc! { "ts": Bson::TimeStamp(0x0000_000C_0000_000A) }
+    );
 
     let xfoo: Foo = bson::from_bson(x).unwrap();
     assert_eq!(xfoo, foo);
@@ -81,7 +86,8 @@ fn test_de_timestamp() {
 
     let foo: Foo = bson::from_bson(Bson::Document(doc! {
         "ts": Bson::TimeStamp(0x0000_000C_0000_000A),
-    })).unwrap();
+    }))
+    .unwrap();
 
     assert_eq!(foo.ts, TimeStamp { t: 12, i: 10 });
 }
@@ -98,12 +104,19 @@ fn test_ser_datetime() {
 
     let now = Utc::now();
     // FIXME: Due to BSON's datetime precision
-    let now = now.with_nanosecond(now.nanosecond() / 1000000 * 1000000).unwrap();
+    let now = now
+        .with_nanosecond(now.nanosecond() / 1000000 * 1000000)
+        .unwrap();
 
-    let foo = Foo { date: From::from(now) };
+    let foo = Foo {
+        date: From::from(now),
+    };
 
     let x = bson::to_bson(&foo).unwrap();
-    assert_eq!(x.as_document().unwrap(), &doc! { "date": (Bson::UtcDatetime(now)) });
+    assert_eq!(
+        x.as_document().unwrap(),
+        &doc! { "date": (Bson::UtcDatetime(now)) }
+    );
 
     let xfoo: Foo = bson::from_bson(x).unwrap();
     assert_eq!(xfoo, foo);
@@ -133,10 +146,17 @@ fn test_byte_vec() {
         pub challenge: &'a [u8],
     }
 
-    let x = AuthChallenge { challenge: b"18762b98b7c34c25bf9dc3154e4a5ca3", };
+    let x = AuthChallenge {
+        challenge: b"18762b98b7c34c25bf9dc3154e4a5ca3",
+    };
 
     let b = bson::to_bson(&x).unwrap();
-    assert_eq!(b, Bson::Document(doc! { "challenge": (Bson::Binary(bson::spec::BinarySubtype::Generic, x.challenge.to_vec()))}));
+    assert_eq!(
+        b,
+        Bson::Document(
+            doc! { "challenge": (Bson::Binary(bson::spec::BinarySubtype::Generic, x.challenge.to_vec()))}
+        )
+    );
 
     // let mut buf = Vec::new();
     // bson::encode_document(&mut buf, b.as_document().unwrap()).unwrap();
@@ -153,11 +173,15 @@ fn test_serde_bytes() {
         data: Vec<u8>,
     }
 
-    let x = Foo { data: b"12345abcde".to_vec(), };
+    let x = Foo {
+        data: b"12345abcde".to_vec(),
+    };
 
     let b = bson::to_bson(&x).unwrap();
-    assert_eq!(b.as_document().unwrap(),
-               &doc! {"data": Bson::Binary(bson::spec::BinarySubtype::Generic, b"12345abcde".to_vec())});
+    assert_eq!(
+        b.as_document().unwrap(),
+        &doc! {"data": Bson::Binary(bson::spec::BinarySubtype::Generic, b"12345abcde".to_vec())}
+    );
 
     let f = bson::from_bson::<Foo>(b).unwrap();
     assert_eq!(x, f);
@@ -185,10 +209,7 @@ fn test_serde_tuple_struct() {
 
     let name_1 = Name(String::from("Graydon"), String::from("Hoare"));
     let b = bson::to_bson(&name_1).unwrap();
-    assert_eq!(b, bson!([
-        name_1.0.clone(),
-        name_1.1.clone(),
-    ]));
+    assert_eq!(b, bson!([name_1.0.clone(), name_1.1.clone(),]));
 
     let (first, last) = (String::from("Donald"), String::from("Knuth"));
     let de = bson!([first.clone(), last.clone()]);


### PR DESCRIPTION
I've updated the BSON library to use the same rustfmt config as the driver and reformatted it, as well as fixed all of the clippy lints that don't require breaking changes and whitelisted the rest.