### PR TITLE
RUST-305 Fix deserialization of non-generic binary

### DIFF
--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -312,10 +312,11 @@ impl<'de> Deserializer<'de> for Decoder {
             Bson::I32(v) => visitor.visit_i32(v),
             Bson::I64(v) => visitor.visit_i64(v),
             Bson::Binary(BinarySubtype::Generic, v) => visitor.visit_bytes(&v),
-            binary @ Bson::Binary(..) => visitor.visit_map(MapDecoder { iter: binary.to_extended_document()
-                                                                                    .into_iter(),
-                                                                        value: None,
-                                                                        len: 2 }),
+            binary @ Bson::Binary(..) => visitor.visit_map(MapDecoder {
+                iter: binary.to_extended_document().into_iter(),
+                value: None,
+                len: 2,
+            }),
             _ => {
                 let doc = value.to_extended_document();
                 let len = doc.len();

--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -311,7 +311,11 @@ impl<'de> Deserializer<'de> for Decoder {
             Bson::Null => visitor.visit_unit(),
             Bson::I32(v) => visitor.visit_i32(v),
             Bson::I64(v) => visitor.visit_i64(v),
-            Bson::Binary(_, v) => visitor.visit_bytes(&v),
+            Bson::Binary(BinarySubtype::Generic, v) => visitor.visit_bytes(&v),
+            binary @ Bson::Binary(..) => visitor.visit_map(MapDecoder { iter: binary.to_extended_document()
+                                                                                    .into_iter(),
+                                                                        value: None,
+                                                                        len: 2 }),
             _ => {
                 let doc = value.to_extended_document();
                 let len = doc.len();

--- a/src/encoder/serde.rs
+++ b/src/encoder/serde.rs
@@ -182,7 +182,6 @@ impl Serializer for Encoder {
     }
 
     fn serialize_bytes(self, value: &[u8]) -> EncoderResult<Bson> {
-        use crate::spec::BinarySubtype;
         // let mut state = self.serialize_seq(Some(value.len()))?;
         // for byte in value {
         //     state.serialize_element(byte)?;

--- a/src/encoder/serde.rs
+++ b/src/encoder/serde.rs
@@ -17,6 +17,7 @@ use crate::decimal128::Decimal128;
 use crate::{
     bson::{Array, Bson, Document, TimeStamp, UtcDateTime},
     oid::ObjectId,
+    spec::BinarySubtype,
 };
 
 use super::{to_bson, EncoderError, EncoderResult};
@@ -62,7 +63,7 @@ impl Serialize for Bson {
             Bson::Null => serializer.serialize_unit(),
             Bson::I32(v) => serializer.serialize_i32(v),
             Bson::I64(v) => serializer.serialize_i64(v),
-            Bson::Binary(_, ref v) => serializer.serialize_bytes(v),
+            Bson::Binary(BinarySubtype::Generic, ref v) => serializer.serialize_bytes(v),
             _ => {
                 let doc = self.to_extended_document();
                 doc.serialize(serializer)

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::blacklisted_name)]
 
-use bson::{bson, doc, Bson, Decoder, Encoder};
+use bson::{bson, doc, spec::BinarySubtype, Bson, Decoder, Encoder};
 use serde::{Deserialize, Serialize};
 use serde_derive::{Deserialize, Serialize};
 
@@ -138,6 +138,48 @@ fn test_compat_u2f() {
 
     let de_foo = bson::from_bson::<Foo>(b).unwrap();
     assert_eq!(de_foo, foo);
+}
+
+#[test]
+fn test_binary_generic_roundtrip() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    pub struct Foo {
+        data: Bson,
+    }
+
+    let x = Foo {
+        data: Bson::Binary(BinarySubtype::Generic, b"12345abcde".to_vec()),
+    };
+
+    let b = bson::to_bson(&x).unwrap();
+    assert_eq!(
+        b.as_document().unwrap(),
+        &doc! {"data": Bson::Binary(BinarySubtype::Generic, b"12345abcde".to_vec())}
+    );
+
+    let f = bson::from_bson::<Foo>(b).unwrap();
+    assert_eq!(x, f);
+}
+
+#[test]
+fn test_binary_non_generic_roundtrip() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    pub struct Foo {
+        data: Bson,
+    }
+
+    let x = Foo {
+        data: Bson::Binary(BinarySubtype::BinaryOld, b"12345abcde".to_vec()),
+    };
+
+    let b = bson::to_bson(&x).unwrap();
+    assert_eq!(
+        b.as_document().unwrap(),
+        &doc! {"data": Bson::Binary(BinarySubtype::BinaryOld, b"12345abcde".to_vec())}
+    );
+
+    let f = bson::from_bson::<Foo>(b).unwrap();
+    assert_eq!(x, f);
 }
 
 #[test]


### PR DESCRIPTION
[RUST-305](https://jira.mongodb.org/browse/RUST-305)

As discussed in person on Monday, this fixes a bug where the library deserializes all binary subtypes into subtype 0 (generic) regardless of the original subtype that was being deserialized. This occurred due to the fact that the deserialize implementation for the bson Decoder called `visit_bytes` on the visitor; while it allowed `Bson::Binary` to be deserialized into `Vec<u8>`, it also caused the subtype to be ignored in the case that `Bson` was getting deserialized back into `Bson` (which occurs most often in cases where a struct that derives `Deserialize` contains a field of type `Document` or `Bson`). This fixes that bug by calling `visit_bytes` in the case that the subtype of the `Binary` being deserialized is generic, and instead piggyback off of the extended JSON implementation to deserialize other binary subtypes. The downside of this solution is that it removes the functionality to deserialize non-generic subtypes into `Vec<u8>`, but I think this is worth it because a) deserializing non-generic binary without losing the subtype is more important than the non-essential quality of life improvement to deserialize into `Vec<u8>` and b) users can still implement a custom deserializer on a field of type `Vec<u8>` if they still want this functionality.