### PR TITLE
Added support for relaxed format of DateTime 

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -559,6 +559,12 @@ impl Bson {
                 return Bson::UtcDatetime(
                     Utc.timestamp(long / 1000, ((long % 1000) * 1_000_000) as u32),
                 );
+            } else if let Ok(string) = values
+                .get_str("$date")
+            {
+                if let Ok(date) = chrono::DateTime::parse_from_rfc3339(string) {
+                    return Bson::UtcDatetime(date.into())
+                }
             } else if let Ok(sym) = values.get_str("$symbol") {
                 return Bson::Symbol(sym.to_owned());
             }


### PR DESCRIPTION
Added support for relaxed format of DateTime Extended JSON.
Fixes #160.

**Caveat**
Uses https://docs.rs/chrono/0.4.6/chrono/struct.DateTime.html#method.parse_from_rfc3339 to parse the date string which is stricter than ISO 8601 mention in https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Date specification

**Update:** The Mongodb Extended json specification also uses the stricter format as they were referring the RFC3339 only.