### PR TITLE
RUST-217 Rephrase unsupported/corrupt BSON messages

### DIFF
--- a/src/decoder/error.rs
+++ b/src/decoder/error.rs
@@ -7,7 +7,7 @@ use serde::de::{self, Expected, Unexpected};
 pub enum DecoderError {
     IoError(io::Error),
     FromUtf8Error(string::FromUtf8Error),
-    UnrecognizedElementType(u8),
+    UnrecognizedElementType { key: String, element_type: u8 },
     InvalidArrayKey(usize, String),
     // A field was expected, but none was found.
     ExpectedField(&'static str),
@@ -52,9 +52,14 @@ impl fmt::Display for DecoderError {
         match *self {
             DecoderError::IoError(ref inner) => inner.fmt(fmt),
             DecoderError::FromUtf8Error(ref inner) => inner.fmt(fmt),
-            DecoderError::UnrecognizedElementType(tag) => {
-                write!(fmt, "unrecognized element type `{}`", tag)
-            }
+            DecoderError::UnrecognizedElementType {
+                ref key,
+                element_type,
+            } => write!(
+                fmt,
+                "unrecognized element type for key \"{}\": `{}`",
+                key, element_type
+            ),
             DecoderError::InvalidArrayKey(ref want, ref got) => {
                 write!(fmt, "invalid array key: expected `{}`, got `{}`", want, got)
             }
@@ -91,7 +96,7 @@ impl error::Error for DecoderError {
                 #[allow(deprecated)]
                 inner.description()
             }
-            DecoderError::UnrecognizedElementType(_) => "unrecognized element type",
+            DecoderError::UnrecognizedElementType { .. } => "unrecognized element type",
             DecoderError::InvalidArrayKey(..) => "invalid array key",
             DecoderError::ExpectedField(_) => "expected a field",
             DecoderError::UnknownField(_) => "found an unknown field",

--- a/src/decoder/error.rs
+++ b/src/decoder/error.rs
@@ -7,7 +7,7 @@ use serde::de::{self, Expected, Unexpected};
 pub enum DecoderError {
     IoError(io::Error),
     FromUtf8Error(string::FromUtf8Error),
-    UnrecognizedElementType { key: String, element_type: u8 },
+    UnrecognizedDocumentElementType { key: String, element_type: u8 },
     InvalidArrayKey(usize, String),
     // A field was expected, but none was found.
     ExpectedField(&'static str),
@@ -52,7 +52,7 @@ impl fmt::Display for DecoderError {
         match *self {
             DecoderError::IoError(ref inner) => inner.fmt(fmt),
             DecoderError::FromUtf8Error(ref inner) => inner.fmt(fmt),
-            DecoderError::UnrecognizedElementType {
+            DecoderError::UnrecognizedDocumentElementType {
                 ref key,
                 element_type,
             } => write!(
@@ -96,7 +96,7 @@ impl error::Error for DecoderError {
                 #[allow(deprecated)]
                 inner.description()
             }
-            DecoderError::UnrecognizedElementType { .. } => "unrecognized element type",
+            DecoderError::UnrecognizedDocumentElementType { .. } => "unrecognized element type",
             DecoderError::InvalidArrayKey(..) => "invalid array key",
             DecoderError::ExpectedField(_) => "expected a field",
             DecoderError::UnknownField(_) => "found an unknown field",

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -271,7 +271,7 @@ fn decode_bson_kvp<R: Read + ?Sized>(
         Some(ElementType::MinKey) => Bson::MinKey,
         None => {
             return Err(DecoderError::UnrecognizedElementType {
-                key: "".to_string(),
+                key,
                 element_type: tag,
             })
         }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -270,7 +270,7 @@ fn decode_bson_kvp<R: Read + ?Sized>(
         Some(ElementType::MaxKey) => Bson::MaxKey,
         Some(ElementType::MinKey) => Bson::MinKey,
         None => {
-            return Err(DecoderError::UnrecognizedElementType {
+            return Err(DecoderError::UnrecognizedDocumentElementType {
                 key,
                 element_type: tag,
             })


### PR DESCRIPTION
[RUST-217](https://jira.mongodb.org/browse/RUST-217)

This PR adds the key to the error returned when encountering an unsupported/corrupt BSON type.