### PR TITLE
Various error improvements

### DIFF
--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -586,6 +586,21 @@ fn unused_fields7() {
 }
 
 #[test]
+fn unused_fields_deny() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(deny_unknown_fields)]
+    struct Foo {
+        a: i32,
+    }
+
+    let d = Decoder::new(bdoc! {
+        "a" => 1,
+        "b" => 2
+    });
+    Foo::deserialize(d).expect_err("extra fields should cause failure");
+}
+
+#[test]
 fn empty_arrays() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Foo {

--- a/src/decoder/error.rs
+++ b/src/decoder/error.rs
@@ -100,27 +100,6 @@ impl fmt::Display for DecoderError {
 }
 
 impl error::Error for DecoderError {
-    fn description(&self) -> &str {
-        match *self {
-            DecoderError::IoError(ref inner) =>
-            {
-                #[allow(deprecated)]
-                inner.description()
-            }
-            DecoderError::FromUtf8Error(ref inner) =>
-            {
-                #[allow(deprecated)]
-                inner.description()
-            }
-            DecoderError::UnrecognizedDocumentElementType { .. } => "unrecognized element type",
-            DecoderError::InvalidArrayKey { .. } => "invalid array key",
-            DecoderError::SyntaxError { ref message } => message.as_str(),
-            DecoderError::EndOfStream => "end of stream",
-            DecoderError::DeserializationError { ref message } => message.as_str(),
-            DecoderError::InvalidTimestamp(..) => "no such local time",
-            DecoderError::AmbiguousTimestamp(..) => "ambiguous local time",
-        }
-    }
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             DecoderError::IoError(ref inner) => Some(inner),

--- a/src/decoder/error.rs
+++ b/src/decoder/error.rs
@@ -1,8 +1,9 @@
 use std::{error, fmt, fmt::Display, io, string};
 
-use serde::de::{self, Expected, Unexpected};
+use crate::Bson;
+use de::Unexpected;
+use serde::de;
 
-// TODO: eliminate serde duplication?
 /// Possible errors that can arise during decoding.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -48,67 +49,9 @@ pub enum DecoderError {
         expected_key: usize,
     },
 
-    /// A field was expected during deserialization, but none was found.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.missing_field
-    MissingField(&'static str),
-
-    /// An unexpected field was found during deserialization.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.unknown_field
-    UnknownField {
-        /// The name of the field that was encountered in the input data.
-        actual_field: String,
-
-        /// The list of expected field names.
-        expected_fields: Vec<String>,
-    },
-
-    /// A value was expected to have a certain type but it had a different one instead.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.invalid_type
-    InvalidType {
-        /// Information about the type that was encountered in the input data.
-        actual_type: String,
-
-        /// Information about the type that was expected.
-        expected_type: String,
-    },
-
-    /// A sequence or map and the input data contained too many or too few elements.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.invalid_length
-    InvalidLength {
-        /// The length of the sequence or map in the input data.
-        actual_length: usize,
-
-        /// Information about the length that was expected.
-        expected_length: String,
-    },
-
-    /// A field was repeated.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.duplicate_field
-    DuplicatedField(&'static str),
-
-    /// An unknown variant name was encountered when deserializing an enum.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.unknown_variant
-    UnknownVariant {
-        /// The variant name that was encountered in the input data.
-        actual_variant: String,
-
-        /// The list of expected variants names.
-        expected_variants: Vec<String>,
-    },
-
-    /// A value of the right type was received, but it was wrong for some other reason.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.invalid_value
-    InvalidValue {
-        /// Information about the value that was received from the input data.
-        actual_value: String,
-
-        /// Information about the value that was expected.
-        expected_value: String,
-    },
-
     /// A general error encountered during deserialization.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html#tymethod.custom
-    Custom {
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html
+    DeserializationError {
         /// A message describing the error.
         message: String,
     },
@@ -147,39 +90,9 @@ impl fmt::Display for DecoderError {
                 "invalid array key: expected `{}`, got `{}`",
                 expected_key, actual_key
             ),
-            DecoderError::MissingField(field_type) => {
-                write!(fmt, "expected a field of type `{}`", field_type)
-            }
-            DecoderError::UnknownField {
-                ref expected_fields,
-                ref actual_field,
-            } => write!(
-                fmt,
-                "unknown field `{}`. Expected one of {:?}",
-                actual_field, expected_fields
-            ),
-            DecoderError::SyntaxError { message } => message.fmt(fmt),
+            DecoderError::SyntaxError { ref message } => message.fmt(fmt),
             DecoderError::EndOfStream => fmt.write_str("end of stream"),
-            DecoderError::InvalidType {
-                actual_type,
-                expected_type,
-            } => write!(
-                fmt,
-                "invalid type \"{}\". expected {}",
-                actual_type, expected_type
-            ),
-            DecoderError::InvalidLength {
-                ref actual_length,
-                ref expected_length,
-            } => write!(
-                fmt,
-                "invalid length {}, expected {}",
-                actual_length, expected_length
-            ),
-            DecoderError::DuplicatedField(ref field) => write!(fmt, "duplicated field `{}`", field),
-            DecoderError::UnknownVariant(ref var) => write!(fmt, "unknown variant `{}`", var),
-            DecoderError::InvalidValue(ref desc) => desc.fmt(fmt),
-            DecoderError::Custom { ref message } => message.fmt(fmt),
+            DecoderError::DeserializationError { ref message } => message.fmt(fmt),
             DecoderError::InvalidTimestamp(ref i) => write!(fmt, "no such local time {}", i),
             DecoderError::AmbiguousTimestamp(ref i) => write!(fmt, "ambiguous local time {}", i),
         }
@@ -200,17 +113,10 @@ impl error::Error for DecoderError {
                 inner.description()
             }
             DecoderError::UnrecognizedDocumentElementType { .. } => "unrecognized element type",
-            DecoderError::InvalidArrayKey(..) => "invalid array key",
-            DecoderError::MissingField(_) => "expected a field",
-            DecoderError::UnknownField(_) => "found an unknown field",
-            DecoderError::SyntaxError(ref inner) => inner,
+            DecoderError::InvalidArrayKey { .. } => "invalid array key",
+            DecoderError::SyntaxError { ref message } => message.as_str(),
             DecoderError::EndOfStream => "end of stream",
-            DecoderError::InvalidType(ref desc) => desc,
-            DecoderError::InvalidLength(_, ref desc) => desc,
-            DecoderError::DuplicatedField(_) => "duplicated field",
-            DecoderError::UnknownVariant(_) => "unknown variant",
-            DecoderError::InvalidValue(ref desc) => desc,
-            DecoderError::Unknown(ref inner) => inner,
+            DecoderError::DeserializationError { ref message } => message.as_str(),
             DecoderError::InvalidTimestamp(..) => "no such local time",
             DecoderError::AmbiguousTimestamp(..) => "ambiguous local time",
         }
@@ -226,37 +132,41 @@ impl error::Error for DecoderError {
 
 impl de::Error for DecoderError {
     fn custom<T: Display>(msg: T) -> DecoderError {
-        DecoderError::Unknown(msg.to_string())
-    }
-
-    fn invalid_type(_unexp: Unexpected, exp: &dyn Expected) -> DecoderError {
-        DecoderError::InvalidType(exp.to_string())
-    }
-
-    fn invalid_value(_unexp: Unexpected, exp: &dyn Expected) -> DecoderError {
-        DecoderError::InvalidValue(exp.to_string())
-    }
-
-    fn invalid_length(len: usize, exp: &dyn Expected) -> DecoderError {
-        DecoderError::InvalidLength(len, exp.to_string())
-    }
-
-    fn unknown_variant(variant: &str, _expected: &'static [&'static str]) -> DecoderError {
-        DecoderError::UnknownVariant(variant.to_string())
-    }
-
-    fn unknown_field(field: &str, _expected: &'static [&'static str]) -> DecoderError {
-        DecoderError::UnknownField(String::from(field))
-    }
-
-    fn missing_field(field: &'static str) -> DecoderError {
-        DecoderError::MissingField(field)
-    }
-
-    fn duplicate_field(field: &'static str) -> DecoderError {
-        DecoderError::DuplicatedField(field)
+        DecoderError::DeserializationError {
+            message: msg.to_string(),
+        }
     }
 }
 
 /// Alias for `Result<T, DecoderError>`.
 pub type DecoderResult<T> = Result<T, DecoderError>;
+
+impl Bson {
+    /// Method for converting a given `Bson` value to a `serde::de::Unexpected` for error reporting.
+    pub(crate) fn as_unexpected(&self) -> Unexpected {
+        match self {
+            Bson::Array(_) => Unexpected::Seq,
+            Bson::Binary(b) => Unexpected::Bytes(b.bytes.as_slice()),
+            Bson::Boolean(b) => Unexpected::Bool(*b),
+            Bson::DbPointer(_) => Unexpected::Other("dbpointer"),
+            Bson::Document(_) => Unexpected::Map,
+            Bson::FloatingPoint(f) => Unexpected::Float(*f),
+            Bson::I32(i) => Unexpected::Signed(*i as i64),
+            Bson::I64(i) => Unexpected::Signed(*i),
+            Bson::JavaScriptCode(_) => Unexpected::Other("javascript code"),
+            Bson::JavaScriptCodeWithScope(_) => Unexpected::Other("javascript code with scope"),
+            Bson::MaxKey => Unexpected::Other("maxkey"),
+            Bson::MinKey => Unexpected::Other("minkey"),
+            Bson::Null => Unexpected::Unit,
+            Bson::Undefined => Unexpected::Other("undefined"),
+            Bson::ObjectId(_) => Unexpected::Other("objectid"),
+            Bson::Regex(_) => Unexpected::Other("regex"),
+            Bson::String(s) => Unexpected::Str(s.as_str()),
+            Bson::Symbol(_) => Unexpected::Other("symbol"),
+            Bson::TimeStamp(_) => Unexpected::Other("timestamp"),
+            Bson::UtcDatetime(_) => Unexpected::Other("datetime"),
+            #[cfg(feature = "decimal128")]
+            Bson::Decimal128(_) => Unexpected::Other("decimal128"),
+        }
+    }
+}

--- a/src/decoder/error.rs
+++ b/src/decoder/error.rs
@@ -2,38 +2,116 @@ use std::{error, fmt, fmt::Display, io, string};
 
 use serde::de::{self, Expected, Unexpected};
 
+// TODO: eliminate serde duplication?
 /// Possible errors that can arise during decoding.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum DecoderError {
+    /// A `std::io::Error` encountered while deserializing.
     IoError(io::Error),
+
+    /// A `std::string::FromUtf8Error` encountered while decoding a UTF-8 String from the input
+    /// data.
     FromUtf8Error(string::FromUtf8Error),
-    UnrecognizedDocumentElementType { key: String, element_type: u8 },
-    InvalidArrayKey(usize, String),
-    // A field was expected, but none was found.
-    ExpectedField(&'static str),
-    // An unexpected field was found.
-    UnknownField(String),
-    // There was an error with the syntactical structure of the BSON.
-    SyntaxError(String),
-    // The end of the BSON input was reached too soon.
+
+    /// While decoding a `Document` from bytes, an unexpected or unsupported element type was
+    /// encountered.
+    UnrecognizedDocumentElementType {
+        /// The key at which an unexpected/unsupported element type was encountered.
+        key: String,
+
+        /// The encountered element type.
+        element_type: u8,
+    },
+
+    /// There was an error with the syntactical structure of the BSON.
+    SyntaxError { message: String },
+
+    /// The end of the BSON input was reached too soon.
     EndOfStream,
-    // Invalid Type
-    InvalidType(String),
-    // Invalid Length
-    InvalidLength(usize, String),
-    // Duplicated Field
-    DuplicatedField(&'static str),
-    // Unknown Variant
-    UnknownVariant(String),
-    // Invalid value
-    InvalidValue(String),
-    // Invalid timestamp
+
+    /// An invalid timestamp was encountered while decoding.
     InvalidTimestamp(i64),
-    // Ambiguous timestamp
+
+    /// An ambiguous timestamp was encountered while decoding.
     AmbiguousTimestamp(i64),
 
-    Unknown(String),
+    /// Returned when an index into an array was expected, but got a something else instead.
+    /// BSON arrays are expected to be stored as subdocuments with numbered keys. If the input data
+    /// contains one which is stored with a different format for its keys, this error will be
+    /// returned.
+    InvalidArrayKey {
+        /// The key that was encountered in the input data.
+        actual_key: String,
+
+        /// The index the key was expected to correspond to.
+        expected_key: usize,
+    },
+
+    /// A field was expected during deserialization, but none was found.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.missing_field
+    MissingField(&'static str),
+
+    /// An unexpected field was found during deserialization.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.unknown_field
+    UnknownField {
+        /// The name of the field that was encountered in the input data.
+        actual_field: String,
+
+        /// The list of expected field names.
+        expected_fields: Vec<String>,
+    },
+
+    /// A value was expected to have a certain type but it had a different one instead.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.invalid_type
+    InvalidType {
+        /// Information about the type that was encountered in the input data.
+        actual_type: String,
+
+        /// Information about the type that was expected.
+        expected_type: String,
+    },
+
+    /// A sequence or map and the input data contained too many or too few elements.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.invalid_length
+    InvalidLength {
+        /// The length of the sequence or map in the input data.
+        actual_length: usize,
+
+        /// Information about the length that was expected.
+        expected_length: String,
+    },
+
+    /// A field was repeated.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.duplicate_field
+    DuplicatedField(&'static str),
+
+    /// An unknown variant name was encountered when deserializing an enum.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.unknown_variant
+    UnknownVariant {
+        /// The variant name that was encountered in the input data.
+        actual_variant: String,
+
+        /// The list of expected variants names.
+        expected_variants: Vec<String>,
+    },
+
+    /// A value of the right type was received, but it was wrong for some other reason.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#method.invalid_value
+    InvalidValue {
+        /// Information about the value that was received from the input data.
+        actual_value: String,
+
+        /// Information about the value that was expected.
+        expected_value: String,
+    },
+
+    /// A general error encountered during deserialization.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html#tymethod.custom
+    Custom {
+        /// A message describing the error.
+        message: String,
+    },
 }
 
 impl From<io::Error> for DecoderError {
@@ -61,23 +139,47 @@ impl fmt::Display for DecoderError {
                 "unrecognized element type for key \"{}\": `{}`",
                 key, element_type
             ),
-            DecoderError::InvalidArrayKey(ref want, ref got) => {
-                write!(fmt, "invalid array key: expected `{}`, got `{}`", want, got)
-            }
-            DecoderError::ExpectedField(field_type) => {
+            DecoderError::InvalidArrayKey {
+                ref actual_key,
+                ref expected_key,
+            } => write!(
+                fmt,
+                "invalid array key: expected `{}`, got `{}`",
+                expected_key, actual_key
+            ),
+            DecoderError::MissingField(field_type) => {
                 write!(fmt, "expected a field of type `{}`", field_type)
             }
-            DecoderError::UnknownField(ref field) => write!(fmt, "unknown field `{}`", field),
-            DecoderError::SyntaxError(ref inner) => inner.fmt(fmt),
+            DecoderError::UnknownField {
+                ref expected_fields,
+                ref actual_field,
+            } => write!(
+                fmt,
+                "unknown field `{}`. Expected one of {:?}",
+                actual_field, expected_fields
+            ),
+            DecoderError::SyntaxError { message } => message.fmt(fmt),
             DecoderError::EndOfStream => fmt.write_str("end of stream"),
-            DecoderError::InvalidType(ref desc) => desc.fmt(fmt),
-            DecoderError::InvalidLength(ref len, ref desc) => {
-                write!(fmt, "expecting length {}, {}", len, desc)
-            }
+            DecoderError::InvalidType {
+                actual_type,
+                expected_type,
+            } => write!(
+                fmt,
+                "invalid type \"{}\". expected {}",
+                actual_type, expected_type
+            ),
+            DecoderError::InvalidLength {
+                ref actual_length,
+                ref expected_length,
+            } => write!(
+                fmt,
+                "invalid length {}, expected {}",
+                actual_length, expected_length
+            ),
             DecoderError::DuplicatedField(ref field) => write!(fmt, "duplicated field `{}`", field),
             DecoderError::UnknownVariant(ref var) => write!(fmt, "unknown variant `{}`", var),
             DecoderError::InvalidValue(ref desc) => desc.fmt(fmt),
-            DecoderError::Unknown(ref inner) => inner.fmt(fmt),
+            DecoderError::Custom { ref message } => message.fmt(fmt),
             DecoderError::InvalidTimestamp(ref i) => write!(fmt, "no such local time {}", i),
             DecoderError::AmbiguousTimestamp(ref i) => write!(fmt, "ambiguous local time {}", i),
         }
@@ -99,7 +201,7 @@ impl error::Error for DecoderError {
             }
             DecoderError::UnrecognizedDocumentElementType { .. } => "unrecognized element type",
             DecoderError::InvalidArrayKey(..) => "invalid array key",
-            DecoderError::ExpectedField(_) => "expected a field",
+            DecoderError::MissingField(_) => "expected a field",
             DecoderError::UnknownField(_) => "found an unknown field",
             DecoderError::SyntaxError(ref inner) => inner,
             DecoderError::EndOfStream => "end of stream",
@@ -148,7 +250,7 @@ impl de::Error for DecoderError {
     }
 
     fn missing_field(field: &'static str) -> DecoderError {
-        DecoderError::ExpectedField(field)
+        DecoderError::MissingField(field)
     }
 
     fn duplicate_field(field: &'static str) -> DecoderError {

--- a/src/decoder/error.rs
+++ b/src/decoder/error.rs
@@ -8,11 +8,11 @@ use serde::de;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum DecoderError {
-    /// A `std::io::Error` encountered while deserializing.
+    /// A [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html) encountered while deserializing.
     IoError(io::Error),
 
-    /// A `std::string::FromUtf8Error` encountered while decoding a UTF-8 String from the input
-    /// data.
+    /// A [`std::string::FromUtf8Error`](https://doc.rust-lang.org/std/string/struct.FromUtf8Error.html) encountered
+    /// while decoding a UTF-8 String from the input data.
     FromUtf8Error(string::FromUtf8Error),
 
     /// While decoding a `Document` from bytes, an unexpected or unsupported element type was

--- a/src/document.rs
+++ b/src/document.rs
@@ -55,11 +55,7 @@ impl Display for ValueAccessError {
     }
 }
 
-impl error::Error for ValueAccessError {
-    fn description(&self) -> &str {
-        "Error to indicate that either a value was empty or it contained an unexpected type"
-    }
-}
+impl error::Error for ValueAccessError {}
 
 /// A BSON document represented as an associative HashMap with insertion ordering.
 #[derive(Clone, PartialEq)]

--- a/src/encoder/error.rs
+++ b/src/encoder/error.rs
@@ -8,7 +8,7 @@ use crate::bson::Bson;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum EncoderError {
-    /// A `std::io::Error` encountered while serializing.
+    /// A [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html) encountered while serializing.
     IoError(io::Error),
 
     /// A key could not be serialized to a BSON string.

--- a/src/encoder/error.rs
+++ b/src/encoder/error.rs
@@ -68,25 +68,6 @@ impl fmt::Display for EncoderError {
 }
 
 impl error::Error for EncoderError {
-    fn description(&self) -> &str {
-        match *self {
-            EncoderError::IoError(ref inner) =>
-            {
-                #[allow(deprecated)]
-                inner.description()
-            }
-            EncoderError::InvalidMapKeyType { .. } => "Invalid map key type",
-            EncoderError::SerializationError { ref message } => message.as_str(),
-            #[cfg(not(feature = "u2i"))]
-            EncoderError::UnsupportedUnsignedType => "BSON does not support unsigned type",
-            #[cfg(feature = "u2i")]
-            EncoderError::UnsignedTypesValueExceedsRange(_) => {
-                "BSON does not support unsigned types.
-                 An attempt to encode the value in a signed type failed due to the values size."
-            }
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             EncoderError::IoError(ref inner) => Some(inner),

--- a/src/encoder/error.rs
+++ b/src/encoder/error.rs
@@ -8,10 +8,32 @@ use crate::bson::Bson;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum EncoderError {
+    /// A `std::io::Error` encountered while serializing.
     IoError(io::Error),
-    InvalidMapKeyType(Bson),
-    Unknown(String),
+
+    /// A key could not be serialized to a BSON string.
+    InvalidMapKeyType {
+        /// The value that could not be used as a key.
+        key: Bson,
+    },
+
+    /// A general error that ocurred during serialization.
+    /// See: https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom
+    SerializationError {
+        /// A message describing the error.
+        message: String,
+    },
+
+    #[cfg(not(feature = "u2i"))]
+    /// Returned when serialization of an unsigned integer was attempted. BSON only supports
+    /// 32-bit and 64-bit signed integers.
+    ///
+    /// To allow serialization of unsigned integers as signed integers, enable the "u2i" feature
+    /// flag.
     UnsupportedUnsignedType,
+
+    #[cfg(feature = "u2i")]
+    /// An unsigned integer type could not fit into a signed integer type.
     UnsignedTypesValueExceedsRange(u64),
 }
 
@@ -25,13 +47,15 @@ impl fmt::Display for EncoderError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             EncoderError::IoError(ref inner) => inner.fmt(fmt),
-            EncoderError::InvalidMapKeyType(ref bson) => {
-                write!(fmt, "Invalid map key type: {:?}", bson)
+            EncoderError::InvalidMapKeyType { ref key } => {
+                write!(fmt, "Invalid map key type: {}", key)
             }
-            EncoderError::Unknown(ref inner) => inner.fmt(fmt),
+            EncoderError::SerializationError { ref message } => message.fmt(fmt),
+            #[cfg(not(feature = "u2i"))]
             EncoderError::UnsupportedUnsignedType => {
                 fmt.write_str("BSON does not support unsigned type")
             }
+            #[cfg(feature = "u2i")]
             EncoderError::UnsignedTypesValueExceedsRange(value) => write!(
                 fmt,
                 "BSON does not support unsigned types.
@@ -51,12 +75,14 @@ impl error::Error for EncoderError {
                 #[allow(deprecated)]
                 inner.description()
             }
-            EncoderError::InvalidMapKeyType(_) => "Invalid map key type",
-            EncoderError::Unknown(ref inner) => inner,
+            EncoderError::InvalidMapKeyType { .. } => "Invalid map key type",
+            EncoderError::SerializationError { ref message } => message.as_str(),
+            #[cfg(not(feature = "u2i"))]
             EncoderError::UnsupportedUnsignedType => "BSON does not support unsigned type",
+            #[cfg(feature = "u2i")]
             EncoderError::UnsignedTypesValueExceedsRange(_) => {
                 "BSON does not support unsigned types.
-                 An attempt to encode the value: {} in a signed type failed due to the values size."
+                 An attempt to encode the value in a signed type failed due to the values size."
             }
         }
     }
@@ -71,7 +97,9 @@ impl error::Error for EncoderError {
 
 impl ser::Error for EncoderError {
     fn custom<T: Display>(msg: T) -> EncoderError {
-        EncoderError::Unknown(msg.to_string())
+        EncoderError::SerializationError {
+            message: msg.to_string(),
+        }
     }
 }
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -52,17 +52,6 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::ArgumentError(ref inner) => &inner,
-            Error::FromHexError(ref inner) =>
-            {
-                #[allow(deprecated)]
-                inner.description()
-            }
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::ArgumentError(_) => None,

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -29,7 +29,10 @@ static OID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
-    ArgumentError(String),
+    /// An invalid argument was passed in.
+    ArgumentError { message: String },
+
+    /// An error occured parsing a hex string.
     FromHexError(FromHexError),
 }
 
@@ -45,7 +48,7 @@ pub type Result<T> = result::Result<T, Error>;
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::ArgumentError(ref inner) => inner.fmt(fmt),
+            Error::ArgumentError { ref message } => message.fmt(fmt),
             Error::FromHexError(ref inner) => inner.fmt(fmt),
         }
     }
@@ -54,7 +57,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            Error::ArgumentError(_) => None,
+            Error::ArgumentError { .. } => None,
             Error::FromHexError(ref inner) => Some(inner),
         }
     }
@@ -101,9 +104,9 @@ impl ObjectId {
     pub fn with_string(s: &str) -> Result<ObjectId> {
         let bytes: Vec<u8> = hex::decode(s.as_bytes())?;
         if bytes.len() != 12 {
-            Err(Error::ArgumentError(
-                "Provided string must be a 12-byte hexadecimal string.".to_owned(),
-            ))
+            Err(Error::ArgumentError {
+                message: "Provided string must be a 12-byte hexadecimal string.".to_owned(),
+            })
         } else {
             let mut byte_array: [u8; 12] = [0; 12];
             byte_array[..].copy_from_slice(&bytes[..]);

--- a/tests/modules/ser.rs
+++ b/tests/modules/ser.rs
@@ -69,7 +69,7 @@ fn dec128() {
 }
 
 #[test]
-#[cfg_attr(feature = "u2i", ignore)]
+#[cfg(not(feature = "u2i"))]
 fn uint8() {
     let obj_min: EncoderResult<Bson> = to_bson(&u8::MIN);
     assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));
@@ -88,7 +88,7 @@ fn uint8_u2i() {
 }
 
 #[test]
-#[cfg_attr(feature = "u2i", ignore)]
+#[cfg(not(feature = "u2i"))]
 fn uint16() {
     let obj_min: EncoderResult<Bson> = to_bson(&u16::MIN);
     assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));
@@ -107,7 +107,7 @@ fn uint16_u2i() {
 }
 
 #[test]
-#[cfg_attr(feature = "u2i", ignore)]
+#[cfg(not(feature = "u2i"))]
 fn uint32() {
     let obj_min: EncoderResult<Bson> = to_bson(&u32::MIN);
     assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));
@@ -126,7 +126,7 @@ fn uint32_u2i() {
 }
 
 #[test]
-#[cfg_attr(feature = "u2i", ignore)]
+#[cfg(not(feature = "u2i"))]
 fn uint64() {
     let obj_min: EncoderResult<Bson> = to_bson(&u64::MIN);
     assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));


### PR DESCRIPTION
[RUST-430](https://jira.mongodb.org/browse/RUST-430) / [RUST-437](https://jira.mongodb.org/browse/RUST-437) / [RUST-443](https://jira.mongodb.org/browse/RUST-443) / [RUST-444](https://jira.mongodb.org/browse/RUST-444) / [RUST-312](https://jira.mongodb.org/browse/RUST-312)

This PR makes a number of improvements to the errors in the BSON library. It also fixes a bug where the serde `deny_unknown_fields` attribute was being ignored.