### PR TITLE
RUST-438 Add more detailed documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ let array = bson!([5, false]);
 ```
 [`bson!`](https://docs.rs/bson/latest/bson/macro.bson.html) has supports both array and object literals, and it automatically converts any values specified to [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html), provided they are `Into<Bson>`.
 
-#### [`Bson`](enum.Bson.html) value unwrapping
+#### [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) value unwrapping
 
 [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) has a number of helper methods for accessing the underlying native Rust types. These helpers can be useful in circumstances in which the specific type of a BSON value
 is known ahead of time.

--- a/README.md
+++ b/README.md
@@ -108,10 +108,8 @@ BSON documents are ordered maps of UTF-8 encoded strings to BSON values. They ar
 [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html)s can be created directly either from a byte
 reader containing BSON data or via the `doc!` macro:
 ```rust
-# use bson::doc;
-# use std::io::Read;
 let mut bytes = hex::decode("0C0000001069000100000000").unwrap();
-let doc = bson::decode_document(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
+let doc = Document::decode(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
 
 let doc = doc! {
    "hello": "world",

--- a/README.md
+++ b/README.md
@@ -7,9 +7,20 @@
 
 Encoding and decoding support for BSON in Rust
 
+## Index
+- [Overview of BSON Format](#overview-of-bson-format)
+- [Usage](#usage)
+    - [BSON Values](#bson-values)
+    - [BSON Documents](#bson-documents)
+    - [Modeling BSON with strongly typed data structures](#modeling-bson-with-strongly-typed-data-structures)
+- [Breaking Changes](#breaking-changes)
+- [Contributing](#contributing)
+- [Running the Tests](#running-the-tests)
+- [Continuous Integration](#continuous-integration)
+
 ## Useful links
 - [API Documentation](https://docs.rs/bson/)
-- [Serde](https://serde.rs/)
+- [Serde Documentation](https://serde.rs/)
 
 ## Installation
 This crate works with Cargo and can be found on
@@ -20,7 +31,7 @@ This crate works with Cargo and can be found on
 bson = "0.14"
 ```
 
-## Overview
+## Overview of BSON Format
 
 BSON, short for Binary JSON, is a binary-encoded serialization of JSON-like documents.
 Like JSON, BSON supports the embedding of documents and arrays within other documents
@@ -44,20 +55,21 @@ BSON is the primary data representation for [MongoDB](https://www.mongodb.com/),
 
 For more information about BSON itself, see [bsonspec.org](http://bsonspec.org).
 
-## BSON values
+## Usage
+
+### BSON values
 
 Many different types can be represented as a BSON value, including 32-bit and 64-bit signed
 integers, 64 bit floating point numbers, strings, datetimes, embedded documents, and more. To
 see a full list of possible BSON values, see the [BSON specification](http://bsonspec.org/spec.html). The various
 possible BSON values are modeled in this crate by the [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) enum.
 
-### Creating [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) instances
+#### Creating [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) instances
 
 [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) values can be instantiated directly or via the
 [`bson!`](https://docs.rs/bson/latest/bson/macro.bson.html) macro:
 
 ```rust
-# use bson::{bson, Bson};
 let string = Bson::String("hello world".to_string());
 let int = Bson::I32(5);
 let array = Bson::Array(vec![Bson::I32(5), Bson::Boolean(false)]);
@@ -71,14 +83,13 @@ let array = bson!([5, false]);
 ```
 [`bson!`](https://docs.rs/bson/latest/bson/macro.bson.html) has supports both array and object literals, and it automatically converts any values specified to [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html), provided they are `Into<Bson>`.
 
-### [`Bson`](enum.Bson.html) value unwrapping
+#### [`Bson`](enum.Bson.html) value unwrapping
 
 [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) has a number of helper methods for accessing the underlying native Rust types. These helpers can be useful in circumstances in which the specific type of a BSON value
 is known ahead of time.
 
 e.g.:
 ```rust
-# use bson::{bson, Bson};
 let value = Bson::I32(5);
 let int = value.as_i32(); // Some(5)
 let bool = value.as_bool(); // None
@@ -87,12 +98,12 @@ let value = bson!([true]);
 let array = value.as_array(); // Some(&Vec<Bson>)
 ```
 
-## BSON documents
+### BSON documents
 
 BSON documents are ordered maps of UTF-8 encoded strings to BSON values. They are logically similar to JSON objects in that they can contain subdocuments, arrays, and values of several different types. This crate models BSON documents via the
 [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) struct.
 
-### Creating [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html)s
+#### Creating [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html)s
 
 [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html)s can be created directly either from a byte
 reader containing BSON data or via the `doc!` macro:
@@ -111,13 +122,12 @@ let doc = doc! {
 [`doc!`](https://docs.rs/bson/latest/bson/macro.doc.html) works similarly to [`bson!`](https://docs.rs/bson/latest/bson/macro.bson.html), except that it always
 returns a [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) rather than a [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html).
 
-### [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) member access
+#### [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) member access
 
 [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) has a number of methods on it to facilitate member
 access:
 
 ```rust
-# use bson::doc;
 let doc = doc! {
    "string": "string",
    "bool": true,
@@ -135,7 +145,7 @@ let subdoc = doc.get_document("doc"); // Some(Document({ "x": true }))
 let error = doc.get_i64("i32"); // Err(...)
 ```
 
-## Modeling BSON with strongly typed data structures
+### Modeling BSON with strongly typed data structures
 
 While it is possible to work with documents and BSON values directly, it will often introduce a
 lot of boilerplate for verifying the necessary keys are present and their values are the correct
@@ -144,8 +154,6 @@ automatically, removing the need for all that boilerplate.
 
 e.g.:
 ```rust
-# use serde_derive::{Deserialize, Serialize};
-# use bson::{bson, Bson};
 #[derive(Serialize, Deserialize)]
 struct Person {
     name: String,

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ let int = Bson::I32(5);
 let array = Bson::Array(vec![Bson::I32(5), Bson::Boolean(false)]);
 
 let string: Bson = "hello world".into();
-let int: Bson = (5 as i32).into();
+let int: Bson = 5i32.into();
 
 let string = bson!("hello world");
 let int = bson!(5);

--- a/README.md
+++ b/README.md
@@ -20,52 +20,168 @@ This crate works with Cargo and can be found on
 bson = "0.14"
 ```
 
-## Usage
+## Overview
 
-Prepare your struct for Serde serialization:
+BSON, short for Binary JSON, is a binary-encoded serialization of JSON-like documents.
+Like JSON, BSON supports the embedding of documents and arrays within other documents
+and arrays. BSON also contains extensions that allow representation of data types that
+are not part of the JSON spec. For example, BSON has a datetime type and a binary data type.
 
-```rust
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Person {
-    #[serde(rename = "_id")]  // Use MongoDB's special primary key field name when serializing 
-    pub id: bson::oid::ObjectId,
-    pub name: String,
-    pub age: i32
-}
+```text
+// JSON equivalent
+{"hello": "world"}
+
+// BSON encoding
+\x16\x00\x00\x00                   // total document size
+\x02                               // 0x02 = type String
+hello\x00                          // field name
+\x06\x00\x00\x00world\x00          // field value
+\x00                               // 0x00 = type EOO ('end of object')
 ```
 
-Serialize the struct:
+BSON is the primary data representation for [MongoDB](https://www.mongodb.com/), and this crate is used in the
+[`mongodb`](https://docs.rs/mongodb/0.10.0/mongodb/) driver crate in its API and implementation.
+
+For more information about BSON itself, see [bsonspec.org](http://bsonspec.org).
+
+## BSON values
+
+Many different types can be represented as a BSON value, including 32-bit and 64-bit signed
+integers, 64 bit floating point numbers, strings, datetimes, embedded documents, and more. To
+see a full list of possible BSON values, see the [BSON specification](http://bsonspec.org/spec.html). The various
+possible BSON values are modeled in this crate by the [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) enum.
+
+### Creating [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) instances
+
+[`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) values can be instantiated directly or via the
+[`bson!`](https://docs.rs/bson/latest/bson/macro.bson.html) macro:
 
 ```rust
-use bson;
+# use bson::{bson, Bson};
+let string = Bson::String("hello world".to_string());
+let int = Bson::I32(5);
+let array = Bson::Array(vec![Bson::I32(5), Bson::Boolean(false)]);
 
-let person = Person {
-    id: "12345",
-    name: "Emma",
-    age: 3
+let string: Bson = "hello world".into();
+let int: Bson = (5 as i32).into();
+
+let string = bson!("hello world");
+let int = bson!(5);
+let array = bson!([5, false]);
+```
+[`bson!`](https://docs.rs/bson/latest/bson/macro.bson.html) has supports both array and object literals, and it automatically converts any values specified to [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html), provided they are `Into<Bson>`.
+
+### [`Bson`](enum.Bson.html) value unwrapping
+
+[`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html) has a number of helper methods for accessing the underlying native Rust types. These helpers can be useful in circumstances in which the specific type of a BSON value
+is known ahead of time.
+
+e.g.:
+```rust
+# use bson::{bson, Bson};
+let value = Bson::I32(5);
+let int = value.as_i32(); // Some(5)
+let bool = value.as_bool(); // None
+
+let value = bson!([true]);
+let array = value.as_array(); // Some(&Vec<Bson>)
+```
+
+## BSON documents
+
+BSON documents are ordered maps of UTF-8 encoded strings to BSON values. They are logically similar to JSON objects in that they can contain subdocuments, arrays, and values of several different types. This crate models BSON documents via the
+[`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) struct.
+
+### Creating [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html)s
+
+[`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html)s can be created directly either from a byte
+reader containing BSON data or via the `doc!` macro:
+```rust
+# use bson::doc;
+# use std::io::Read;
+let mut bytes = hex::decode("0C0000001069000100000000").unwrap();
+let doc = bson::decode_document(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
+
+let doc = doc! {
+   "hello": "world",
+   "int": 5,
+   "subdoc": { "cat": true },
+};
+```
+[`doc!`](https://docs.rs/bson/latest/bson/macro.doc.html) works similarly to [`bson!`](https://docs.rs/bson/latest/bson/macro.bson.html), except that it always
+returns a [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) rather than a [`Bson`](https://docs.rs/bson/latest/bson/enum.Bson.html).
+
+### [`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) member access
+
+[`Document`](https://docs.rs/bson/latest/bson/document/struct.Document.html) has a number of methods on it to facilitate member
+access:
+
+```rust
+# use bson::doc;
+let doc = doc! {
+   "string": "string",
+   "bool": true,
+   "i32": 5,
+   "doc": { "x": true },
 };
 
-let serialized_person = bson::to_bson(&person)?;  // Serialize
+// attempt get values as untyped Bson
+let none = doc.get("asdfadsf"); // None
+let value = doc.get("string"); // Some(&Bson::String("string"))
 
-if let bson::Bson::Document(document) = serialized_person {
-    mongoCollection.insert_one(document, None)?;  // Insert into a MongoDB collection
-} else {
-    println!("Error converting the BSON object into a MongoDB document");
+// attempt to get values with explicit typing
+let string = doc.get_str("string"); // Ok("string")
+let subdoc = doc.get_document("doc"); // Some(Document({ "x": true }))
+let error = doc.get_i64("i32"); // Err(...)
+```
+
+## Modeling BSON with strongly typed data structures
+
+While it is possible to work with documents and BSON values directly, it will often introduce a
+lot of boilerplate for verifying the necessary keys are present and their values are the correct
+types. [`serde`](https://serde.rs/) provides a powerful way of mapping BSON data into Rust data structures largely
+automatically, removing the need for all that boilerplate.
+
+e.g.:
+```rust
+# use serde_derive::{Deserialize, Serialize};
+# use bson::{bson, Bson};
+#[derive(Serialize, Deserialize)]
+struct Person {
+    name: String,
+    age: u8,
+    phones: Vec<String>,
+}
+
+fn typed_example() {
+    // Some BSON input data as a `Bson`.
+    let bson_data: Bson = bson!({
+        "name": "John Doe",
+        "age": 43,
+        "phones": [
+            "+44 1234567",
+            "+44 2345678"
+        ]
+    });
+
+    // Deserialize the Person struct from the BSON data, automatically
+    // verifying that the necessary keys are present and that they are of
+    // the correct types.
+    let mut person: Person = bson::from_bson(bson_data).unwrap();
+
+    // Do things just like with any other Rust data structure.
+    println!("Redacting {}'s record.", person.name);
+    person.name = "REDACTED".to_string();
+
+    // Get a serialized version of the input data as a `Bson`.
+    let redacted_bson = bson::to_bson(&person).unwrap();
 }
 ```
 
-Deserialize the struct:
-
-```rust
-use bson::doc;
-
-// Read the document from a MongoDB collection
-let person_document = mongoCollection.find_one(Some(doc! { "_id":  bson::oid::ObjectId::with_string("12345").expect("Id not valid") }), None)?
-    .expect("Document not found");
-
-// Deserialize the document into a Person instance
-let person = bson::from_bson(bson::Bson::Document(person_document))?
-```
+Any types that implement `Serialize` and `Deserialize` can be used in this way. Doing so helps
+separate the "business logic" that operates over the data from the (de)serialization logic that
+translates the data to/from its serialized form. This can lead to more clear and concise code
+that is also less error prone.
 
 ## Breaking Changes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,14 @@
 pub use self::decimal128::Decimal128;
 pub use self::{
     bson::{
-        Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, TimeStamp,
+        Array,
+        Binary,
+        Bson,
+        DbPointer,
+        Document,
+        JavaScriptCodeWithScope,
+        Regex,
+        TimeStamp,
         UtcDateTime,
     },
     decoder::{from_bson, Decoder, DecoderError, DecoderResult},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! \x00                               // 0x00 = type EOO ('end of object')
 //! ```
 //!
-//! BSON is the primary data represenation for [MongoDB](https://www.mongodb.com/), and this crate is used in the
+//! BSON is the primary data representation for [MongoDB](https://www.mongodb.com/), and this crate is used in the
 //! [`mongodb`](https://docs.rs/mongodb/0.10.0/mongodb/) driver crate in its API and implementation.
 //!
 //! For more information about BSON itself, see [bsonspec.org](http://bsonspec.org).
@@ -73,7 +73,7 @@
 //! ### [`Bson`](enum.Bson.html) value unwrapping
 //!
 //! [`Bson`](enum.Bson.html) has a number of helper methods for accessing the underlying native Rust
-//! types. These helpers can be useful in cirumstances in which a the specific type of a BSON value
+//! types. These helpers can be useful in circumstances in which the specific type of a BSON value
 //! is known ahead of time.
 //!
 //! e.g.:
@@ -131,7 +131,7 @@
 //! let none = doc.get("asdfadsf"); // None
 //! let value = doc.get("string"); // Some(&Bson::String("string"))
 //!
-//! // attempt to get values with explcit typing
+//! // attempt to get values with explicit typing
 //! let string = doc.get_str("string"); // Ok("string")
 //! let subdoc = doc.get_document("doc"); // Some(Document({ "x": true }))
 //! let error = doc.get_i64("i32"); // Err(...)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,10 +98,10 @@
 //! [`Document`](document/struct.Document.html)s can be created directly either from a byte
 //! reader containing BSON data or via the `doc!` macro:
 //! ```rust
-//! # use bson::doc;
+//! # use bson::{doc, Document};
 //! # use std::io::Read;
 //! let mut bytes = hex::decode("0C0000001069000100000000").unwrap();
-//! let doc = bson::decode_document(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
+//! let doc = Document::decode(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
 //!
 //! let doc = doc! {
 //!    "hello": "world",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! let array = Bson::Array(vec![Bson::I32(5), Bson::Boolean(false)]);
 //!
 //! let string: Bson = "hello world".into();
-//! let int: Bson = (5 as i32).into();
+//! let int: Bson = 5i32.into();
 //!
 //! let string = bson!("hello world");
 //! let int = bson!(5);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,12 @@
 //! let string: Bson = "hello world".into();
 //! let int: Bson = (5 as i32).into();
 //!
-//! let string: Bson = bson!("hello world");
-//! let int: Bson = bson!(5);
+//! let string = bson!("hello world");
+//! let int = bson!(5);
 //! let array = bson!([5, false]);
 //! ```
 //! [`bson!`](macro.bson.html) has supports both array and object literals, and it automatically
-//! converts any values specified to [`Bson`](enum.Bson.html), provided they are either `Serialize`
-//! or `Into<Bson>`.
+//! converts any values specified to [`Bson`](enum.Bson.html), provided they are `Into<Bson>`.
 //!
 //! ### [`Bson`](enum.Bson.html) value unwrapping
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -178,10 +178,10 @@ macro_rules! bson {
         $crate::Bson::Document($crate::doc!{$($tt)+});
     };
 
-    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Any Into<Bson> type.
     // Must be below every other rule.
     ($other:expr) => {
-        ::std::convert::From::from($other)
+        $crate::Bson::from($other)
     };
 }
 


### PR DESCRIPTION
[RUST-438](https://jira.mongodb.org/browse/RUST-438)

This PR updates the library documentation for the `bson` crate. It is heavily influenced by [the library docs for `serde_json`](https://docs.rs/serde_json/1.0.53/serde_json/).