### PR TITLE
RUST-453 bson-rust is missing binary subtype 6

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -52,6 +52,7 @@ const BINARY_SUBTYPE_BINARY_OLD: u8 = 0x02;
 const BINARY_SUBTYPE_UUID_OLD: u8 = 0x03;
 const BINARY_SUBTYPE_UUID: u8 = 0x04;
 const BINARY_SUBTYPE_MD5: u8 = 0x05;
+const BINARY_SUBTYPE_ENCRYPTED: u8 = 0x06;
 
 /// All available BSON element types.
 ///
@@ -148,6 +149,7 @@ pub enum BinarySubtype {
     UuidOld,
     Uuid,
     Md5,
+    Encrypted,
     UserDefined(u8),
 }
 
@@ -161,6 +163,7 @@ impl From<BinarySubtype> for u8 {
             BinarySubtype::UuidOld => BINARY_SUBTYPE_UUID_OLD,
             BinarySubtype::Uuid => BINARY_SUBTYPE_UUID,
             BinarySubtype::Md5 => BINARY_SUBTYPE_MD5,
+            BinarySubtype::Encrypted => BINARY_SUBTYPE_ENCRYPTED,
             BinarySubtype::UserDefined(x) => x,
         }
     }
@@ -176,6 +179,7 @@ impl From<u8> for BinarySubtype {
             BINARY_SUBTYPE_UUID_OLD => BinarySubtype::UuidOld,
             BINARY_SUBTYPE_UUID => BinarySubtype::Uuid,
             BINARY_SUBTYPE_MD5 => BinarySubtype::Md5,
+            BINARY_SUBTYPE_ENCRYPTED => BinarySubtype::Encrypted,
             _ => BinarySubtype::UserDefined(t),
         }
     }

--- a/tests/modules/macros.rs
+++ b/tests/modules/macros.rs
@@ -30,6 +30,7 @@ fn standard_format() {
         "i64": -55,
         "timestamp": Bson::TimeStamp(TimeStamp { time: 0, increment: 229_999_444 }),
         "binary": Binary { subtype: BinarySubtype::Md5, bytes: "thingies".to_owned().into_bytes() },
+        "encrypted": Binary { subtype: BinarySubtype::Encrypted, bytes: "secret".to_owned().into_bytes() },
         "_id": id,
         "date": Bson::UtcDatetime(date),
     };
@@ -38,9 +39,10 @@ fn standard_format() {
         "{{ float: 2.4, string: \"hello\", array: [\"testing\", 1, true, [1, 2]], doc: {{ fish: \
          \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, \
          with_wrapped_parens: -20, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, \
-         timestamp: Timestamp(0, 229999444), binary: BinData(5, 0x{}), _id: ObjectId(\"{}\"), \
-         date: Date(\"{}\") }}",
+         timestamp: Timestamp(0, 229999444), binary: BinData(5, 0x{}), encrypted: BinData(6, \
+         0x{}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}",
         base64::encode("thingies"),
+        base64::encode("secret"),
         hex::encode(id_string),
         date
     );


### PR DESCRIPTION
 bson-rust is missing the new binary subtype 6. This adds support for recognizing BSON with the new subtype. The BSON library is not responsible for encryption so there is not a need for more support.

Ran
cargo test
bash .evergreen/check-clippy.sh
bash .evergreen/check-rustfmt.sh