### PR TITLE
RUST-447 Standardize API with other serde libraries

### DIFF
--- a/examples/deserialize.rs
+++ b/examples/deserialize.rs
@@ -5,7 +5,7 @@ use bson::Document;
 fn main() {
     let mut f = File::open("examples/test.bson").unwrap();
 
-    while let Ok(deserialized) = Document::deserialize_from(&mut f) {
+    while let Ok(deserialized) = Document::from_reader(&mut f) {
         println!("{:?}", deserialized);
     }
 }

--- a/examples/deserialize.rs
+++ b/examples/deserialize.rs
@@ -5,7 +5,7 @@ use bson::Document;
 fn main() {
     let mut f = File::open("examples/test.bson").unwrap();
 
-    while let Ok(deserialized) = Document::deserialize(&mut f) {
+    while let Ok(deserialized) = Document::deserialize_from(&mut f) {
         println!("{:?}", deserialized);
     }
 }

--- a/examples/deserialize.rs
+++ b/examples/deserialize.rs
@@ -5,7 +5,7 @@ use bson::Document;
 fn main() {
     let mut f = File::open("examples/test.bson").unwrap();
 
-    while let Ok(decoded) = Document::decode(&mut f) {
-        println!("{:?}", decoded);
+    while let Ok(deserialized) = Document::deserialize(&mut f) {
+        println!("{:?}", deserialized);
     }
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -16,10 +16,10 @@ fn main() {
     doc.insert("array".to_string(), Bson::Array(arr));
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     println!("Serialized: {:?}", buf);
 
-    let doc = Document::deserialize(&mut Cursor::new(&buf[..])).unwrap();
+    let doc = Document::deserialize_from(&mut Cursor::new(&buf[..])).unwrap();
     println!("Deserialized: {:?}", doc);
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -16,10 +16,10 @@ fn main() {
     doc.insert("array".to_string(), Bson::Array(arr));
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     println!("Serialized: {:?}", buf);
 
-    let doc = Document::deserialize_from(&mut Cursor::new(&buf[..])).unwrap();
+    let doc = Document::from_reader(&mut Cursor::new(&buf[..])).unwrap();
     println!("Deserialized: {:?}", doc);
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -18,8 +18,8 @@ fn main() {
     let mut buf = Vec::new();
     doc.serialize_doc(&mut buf).unwrap();
 
-    println!("Encoded: {:?}", buf);
+    println!("Serialized: {:?}", buf);
 
     let doc = Document::deserialize(&mut Cursor::new(&buf[..])).unwrap();
-    println!("Decoded: {:?}", doc);
+    println!("Deserialized: {:?}", doc);
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -16,10 +16,10 @@ fn main() {
     doc.insert("array".to_string(), Bson::Array(arr));
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     println!("Encoded: {:?}", buf);
 
-    let doc = Document::decode(&mut Cursor::new(&buf[..])).unwrap();
+    let doc = Document::deserialize(&mut Cursor::new(&buf[..])).unwrap();
     println!("Decoded: {:?}", doc);
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,5 +22,5 @@ name = "fuzz_target_1"
 path = "fuzz_targets/fuzz_target_1.rs"
 
 [[bin]]
-name = "decode"
-path = "fuzz_targets/decode.rs"
+name = "deserialize"
+path = "fuzz_targets/deserialize.rs"

--- a/fuzz/fuzz_targets/deserialize.rs
+++ b/fuzz/fuzz_targets/deserialize.rs
@@ -6,5 +6,5 @@ use bson::Document;
 use std::io::Cursor;
 
 fuzz_target!(|buf: &[u8]| {
-    let _ = Document::decode(&mut Cursor::new(&buf[..]));
+    let _ = Document::deserialize(&mut Cursor::new(&buf[..]));
 });

--- a/fuzz/fuzz_targets/deserialize.rs
+++ b/fuzz/fuzz_targets/deserialize.rs
@@ -6,5 +6,5 @@ use bson::Document;
 use std::io::Cursor;
 
 fuzz_target!(|buf: &[u8]| {
-    let _ = Document::deserialize_from(&mut Cursor::new(&buf[..]));
+    let _ = Document::from_reader(&mut Cursor::new(&buf[..]));
 });

--- a/fuzz/fuzz_targets/deserialize.rs
+++ b/fuzz/fuzz_targets/deserialize.rs
@@ -6,5 +6,5 @@ use bson::Document;
 use std::io::Cursor;
 
 fuzz_target!(|buf: &[u8]| {
-    let _ = Document::deserialize(&mut Cursor::new(&buf[..]));
+    let _ = Document::deserialize_from(&mut Cursor::new(&buf[..]));
 });

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::cognitive_complexity)]
 
-use serde::{de::Unexpected, Deserialize, Deserializer, Serialize};
+use serde::{self, de::Unexpected, Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 
-use bson::{Bson, Decoder, DecoderError, Encoder};
+use bson::{Bson, Deserializer, Serializer};
 
 macro_rules! bson {
     ([]) => {{ bson::Bson::Array(Vec::new()) }};
@@ -58,16 +58,16 @@ macro_rules! t {
     };
 }
 
-macro_rules! encode( ($t:expr) => ({
-    let e = Encoder::new();
+macro_rules! serialize( ($t:expr) => ({
+    let e = Serializer::new();
     match $t.serialize(e) {
         Ok(b) => b,
         Err(e) => panic!("Failed to serialize: {}", e),
     }
 }) );
 
-macro_rules! decode( ($t:expr) => ({
-    let d = Decoder::new($t);
+macro_rules! deserialize( ($t:expr) => ({
+    let d = Deserializer::new($t);
     t!(Deserialize::deserialize(d))
 }) );
 
@@ -79,8 +79,8 @@ fn smoke() {
     }
 
     let v = Foo { a: 2 };
-    assert_eq!(encode!(v), bdoc! {"a" => (2 as i64)});
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! {"a" => (2 as i64)});
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -91,12 +91,12 @@ fn smoke_under() {
     }
 
     let v = Foo { a_b: 2 };
-    assert_eq!(encode!(v), bdoc! { "a_b" => (2 as i64) });
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! { "a_b" => (2 as i64) });
+    assert_eq!(v, deserialize!(serialize!(v)));
 
     let mut m = BTreeMap::new();
     m.insert("a_b".to_string(), 2 as i64);
-    assert_eq!(v, decode!(encode!(m)));
+    assert_eq!(v, deserialize!(serialize!(m)));
 }
 
 #[test]
@@ -118,7 +118,7 @@ fn nested() {
         },
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "a" => (2 as i64),
             "b" => {
@@ -126,15 +126,15 @@ fn nested() {
             }
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
-fn application_decode_error() {
+fn application_deserialize_error() {
     #[derive(PartialEq, Debug)]
     struct Range10(usize);
     impl<'de> Deserialize<'de> for Range10 {
-        fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Range10, D::Error> {
+        fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Range10, D::Error> {
             let x: usize = Deserialize::deserialize(d)?;
             if x > 10 {
                 Err(serde::de::Error::invalid_value(
@@ -146,9 +146,9 @@ fn application_decode_error() {
             }
         }
     }
-    let d_good = Decoder::new(Bson::Int64(5));
-    let d_bad1 = Decoder::new(Bson::String("not an isize".to_string()));
-    let d_bad2 = Decoder::new(Bson::Int64(11));
+    let d_good = Deserializer::new(Bson::Int64(5));
+    let d_bad1 = Deserializer::new(Bson::String("not an isize".to_string()));
+    let d_bad2 = Deserializer::new(Bson::Int64(11));
 
     assert_eq!(Range10(5), t!(Deserialize::deserialize(d_good)));
 
@@ -169,12 +169,12 @@ fn array() {
         a: vec![1, 2, 3, 4],
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "a" => [1, 2, 3, 4]
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -186,12 +186,12 @@ fn tuple() {
 
     let v = Foo { a: (1, 2, 3, 4) };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "a" => [1, 2, 3, 4]
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -221,7 +221,7 @@ fn inner_structs_with_options() {
         },
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "a" => {
                 "a" => (Bson::Null),
@@ -236,7 +236,7 @@ fn inner_structs_with_options() {
             }
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -267,7 +267,7 @@ fn inner_structs_with_skippable_options() {
         },
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "a" => {
             "b" => {
@@ -281,7 +281,7 @@ fn inner_structs_with_skippable_options() {
             }
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -306,7 +306,7 @@ fn hashmap() {
         },
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "map" => {
                 "bar" => 4,
@@ -315,7 +315,7 @@ fn hashmap() {
             "set" => ["a"]
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -331,12 +331,12 @@ fn tuple_struct() {
         whee: Foo(1, "foo".to_string(), 4.5),
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "whee" => [1, "foo", (4.5)]
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -354,12 +354,12 @@ fn table_array() {
         a: vec![Bar { a: 1 }, Bar { a: 2 }],
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! {
             "a" => [{"a" => 1}, {"a" => 2}]
         }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -369,10 +369,10 @@ fn type_conversion() {
         bar: i32,
     }
 
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "bar" => 1
     });
-    let a: Result<Foo, DecoderError> = Deserialize::deserialize(d);
+    let a: Result<Foo, bson::de::Error> = Deserialize::deserialize(d);
     assert_eq!(a.unwrap(), Foo { bar: 1 });
 }
 
@@ -383,8 +383,8 @@ fn missing_errors() {
         bar: i32,
     }
 
-    let d = Decoder::new(bdoc! {});
-    let a: Result<Foo, DecoderError> = Deserialize::deserialize(d);
+    let d = Deserializer::new(bdoc! {});
+    let a: Result<Foo, bson::de::Error> = Deserialize::deserialize(d);
 
     assert!(a.is_err());
 }
@@ -412,20 +412,20 @@ fn parse_enum() {
     }
 
     let v = Foo { a: E::Empty };
-    assert_eq!(encode!(v), bdoc! { "a" => "Empty" });
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! { "a" => "Empty" });
+    assert_eq!(v, deserialize!(serialize!(v)));
 
     let v = Foo { a: E::Bar(10) };
-    assert_eq!(encode!(v), bdoc! { "a" => { "Bar" => 10 } });
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! { "a" => { "Bar" => 10 } });
+    assert_eq!(v, deserialize!(serialize!(v)));
 
     let v = Foo { a: E::Baz(10.2) };
-    assert_eq!(encode!(v), bdoc! { "a" => { "Baz" => 10.2 } });
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! { "a" => { "Baz" => 10.2 } });
+    assert_eq!(v, deserialize!(serialize!(v)));
 
     let v = Foo { a: E::Pair(12, 42) };
-    assert_eq!(encode!(v), bdoc! { "a" => { "Pair" => [ 12, 42] } });
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! { "a" => { "Pair" => [ 12, 42] } });
+    assert_eq!(v, deserialize!(serialize!(v)));
 
     let v = Foo {
         a: E::Last(Foo2 {
@@ -433,30 +433,30 @@ fn parse_enum() {
         }),
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! { "a" => { "Last" => { "test" => "test" } } }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 
     let v = Foo {
         a: E::Vector(vec![12, 42]),
     };
-    assert_eq!(encode!(v), bdoc! { "a" => { "Vector" => [ 12, 42 ] } });
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! { "a" => { "Vector" => [ 12, 42 ] } });
+    assert_eq!(v, deserialize!(serialize!(v)));
 
     let v = Foo {
         a: E::Named { a: 12 },
     };
-    assert_eq!(encode!(v), bdoc! { "a" => { "Named" => { "a" => 12 } } });
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(serialize!(v), bdoc! { "a" => { "Named" => { "a" => 12 } } });
+    assert_eq!(v, deserialize!(serialize!(v)));
     let v = Foo {
         a: E::MultiNamed { a: 12, b: 42 },
     };
     assert_eq!(
-        encode!(v),
+        serialize!(v),
         bdoc! { "a" => { "MultiNamed" => { "a" => 12, "b" => 42 } } }
     );
-    assert_eq!(v, decode!(encode!(v)));
+    assert_eq!(v, deserialize!(serialize!(v)));
 }
 
 #[test]
@@ -467,7 +467,7 @@ fn unused_fields() {
     }
 
     let v = Foo { a: 2 };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => 2,
         "b" => 5
     });
@@ -487,7 +487,7 @@ fn unused_fields2() {
     }
 
     let v = Foo { a: Bar { a: 2 } };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => {
             "a" => 2,
             "b" => 5
@@ -509,7 +509,7 @@ fn unused_fields3() {
     }
 
     let v = Foo { a: Bar { a: 2 } };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => {
             "a" => 2
         }
@@ -527,7 +527,7 @@ fn unused_fields4() {
     let mut map = BTreeMap::new();
     map.insert("a".to_owned(), "foo".to_owned());
     let v = Foo { a: map };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => {
             "a" => "foo"
         }
@@ -545,7 +545,7 @@ fn unused_fields5() {
     let v = Foo {
         a: vec!["a".to_string()],
     };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => ["a"]
     });
     assert_eq!(v, t!(Deserialize::deserialize(d)));
@@ -559,7 +559,7 @@ fn unused_fields6() {
     }
 
     let v = Foo { a: Some(vec![]) };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => []
     });
     assert_eq!(v, t!(Deserialize::deserialize(d)));
@@ -579,7 +579,7 @@ fn unused_fields7() {
     let v = Foo {
         a: vec![Bar { a: 1 }],
     };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => [{"a" => 1, "b" => 2}]
     });
     assert_eq!(v, t!(Deserialize::deserialize(d)));
@@ -593,7 +593,7 @@ fn unused_fields_deny() {
         a: i32,
     }
 
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => 1,
         "b" => 2
     });
@@ -611,7 +611,7 @@ fn empty_arrays() {
     struct Bar;
 
     let v = Foo { a: vec![] };
-    let d = Decoder::new(bdoc! {});
+    let d = Deserializer::new(bdoc! {});
     assert_eq!(v, t!(Deserialize::deserialize(d)));
 }
 
@@ -625,11 +625,11 @@ fn empty_arrays2() {
     struct Bar;
 
     let v = Foo { a: None };
-    let d = Decoder::new(bdoc! {});
+    let d = Deserializer::new(bdoc! {});
     assert_eq!(v, t!(Deserialize::deserialize(d)));
 
     let v = Foo { a: Some(vec![]) };
-    let d = Decoder::new(bdoc! {
+    let d = Deserializer::new(bdoc! {
         "a" => []
     });
     assert_eq!(v, t!(Deserialize::deserialize(d)));

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -7,7 +7,7 @@ use serde::de;
 /// Possible errors that can arise during decoding.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum DecoderError {
+pub enum Error {
     /// A [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html) encountered while deserializing.
     IoError(io::Error),
 
@@ -45,24 +45,24 @@ pub enum DecoderError {
     },
 }
 
-impl From<io::Error> for DecoderError {
-    fn from(err: io::Error) -> DecoderError {
-        DecoderError::IoError(err)
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::IoError(err)
     }
 }
 
-impl From<string::FromUtf8Error> for DecoderError {
-    fn from(err: string::FromUtf8Error) -> DecoderError {
-        DecoderError::FromUtf8Error(err)
+impl From<string::FromUtf8Error> for Error {
+    fn from(err: string::FromUtf8Error) -> Error {
+        Error::FromUtf8Error(err)
     }
 }
 
-impl fmt::Display for DecoderError {
+impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            DecoderError::IoError(ref inner) => inner.fmt(fmt),
-            DecoderError::FromUtf8Error(ref inner) => inner.fmt(fmt),
-            DecoderError::UnrecognizedDocumentElementType {
+            Error::IoError(ref inner) => inner.fmt(fmt),
+            Error::FromUtf8Error(ref inner) => inner.fmt(fmt),
+            Error::UnrecognizedDocumentElementType {
                 ref key,
                 element_type,
             } => write!(
@@ -70,35 +70,35 @@ impl fmt::Display for DecoderError {
                 "unrecognized element type for key \"{}\": `{:#x}`",
                 key, element_type
             ),
-            DecoderError::SyntaxError { ref message } => message.fmt(fmt),
-            DecoderError::EndOfStream => fmt.write_str("end of stream"),
-            DecoderError::DeserializationError { ref message } => message.fmt(fmt),
-            DecoderError::InvalidTimestamp(ref i) => write!(fmt, "no such local time {}", i),
-            DecoderError::AmbiguousTimestamp(ref i) => write!(fmt, "ambiguous local time {}", i),
+            Error::SyntaxError { ref message } => message.fmt(fmt),
+            Error::EndOfStream => fmt.write_str("end of stream"),
+            Error::DeserializationError { ref message } => message.fmt(fmt),
+            Error::InvalidTimestamp(ref i) => write!(fmt, "no such local time {}", i),
+            Error::AmbiguousTimestamp(ref i) => write!(fmt, "ambiguous local time {}", i),
         }
     }
 }
 
-impl error::Error for DecoderError {
+impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            DecoderError::IoError(ref inner) => Some(inner),
-            DecoderError::FromUtf8Error(ref inner) => Some(inner),
+            Error::IoError(ref inner) => Some(inner),
+            Error::FromUtf8Error(ref inner) => Some(inner),
             _ => None,
         }
     }
 }
 
-impl de::Error for DecoderError {
-    fn custom<T: Display>(msg: T) -> DecoderError {
-        DecoderError::DeserializationError {
+impl de::Error for Error {
+    fn custom<T: Display>(msg: T) -> Error {
+        Error::DeserializationError {
             message: msg.to_string(),
         }
     }
 }
 
-/// Alias for `Result<T, DecoderError>`.
-pub type DecoderResult<T> = Result<T, DecoderError>;
+/// Alias for `Result<T, Error>`.
+pub type Result<T> = std::result::Result<T, Error>;
 
 impl Bson {
     /// Method for converting a given `Bson` value to a `serde::de::Unexpected` for error reporting.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -151,9 +151,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
     let val = match ElementType::from(tag) {
         Some(ElementType::Double) => Bson::Double(reader.read_f64::<LittleEndian>()?),
         Some(ElementType::String) => read_string(reader, utf8_lossy).map(Bson::String)?,
-        Some(ElementType::EmbeddedDocument) => {
-            Document::deserialize_from(reader).map(Bson::Document)?
-        }
+        Some(ElementType::EmbeddedDocument) => Document::from_reader(reader).map(Bson::Document)?,
         Some(ElementType::Array) => deserialize_array(reader, utf8_lossy).map(Bson::Array)?,
         Some(ElementType::Binary) => {
             let mut len = read_i32(reader)?;
@@ -205,7 +203,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
             read_i32(reader)?;
 
             let code = read_string(reader, utf8_lossy)?;
-            let scope = Document::deserialize_from(reader)?;
+            let scope = Document::from_reader(reader)?;
             Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope { code, scope })
         }
         Some(ElementType::Int32) => read_i32(reader).map(Bson::Int32)?,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -19,14 +19,14 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! Decoder
+//! Deserializer
 
 mod error;
 mod serde;
 
 pub use self::{
-    error::{DecoderError, DecoderResult},
-    serde::Decoder,
+    error::{Error, Result},
+    serde::Deserializer,
 };
 
 use std::io::Read;
@@ -44,16 +44,16 @@ use crate::{
     Decimal128,
 };
 
-use ::serde::de::{Deserialize, Error};
+use ::serde::de::{self, Error as SerdeError};
 
 const MAX_BSON_SIZE: i32 = 16 * 1024 * 1024;
 
-fn read_string<R: Read + ?Sized>(reader: &mut R, utf8_lossy: bool) -> DecoderResult<String> {
+fn read_string<R: Read + ?Sized>(reader: &mut R, utf8_lossy: bool) -> crate::de::Result<String> {
     let len = reader.read_i32::<LittleEndian>()?;
 
     // UTF-8 String must have at least 1 byte (the last 0x00).
     if len < 1 {
-        return Err(DecoderError::invalid_length(
+        return Err(Error::invalid_length(
             len as usize,
             &"UTF-8 string must have at least 1 byte",
         ));
@@ -73,7 +73,7 @@ fn read_string<R: Read + ?Sized>(reader: &mut R, utf8_lossy: bool) -> DecoderRes
     Ok(s)
 }
 
-fn read_cstring<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<String> {
+fn read_cstring<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<String> {
     let mut v = Vec::new();
 
     loop {
@@ -88,12 +88,12 @@ fn read_cstring<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<String> {
 }
 
 #[inline]
-pub(crate) fn read_i32<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<i32> {
+pub(crate) fn read_i32<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<i32> {
     reader.read_i32::<LittleEndian>().map_err(From::from)
 }
 
 #[inline]
-fn read_i64<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<i64> {
+fn read_i64<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<i64> {
     reader.read_i64::<LittleEndian>().map_err(From::from)
 }
 
@@ -101,7 +101,7 @@ fn read_i64<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<i64> {
 /// parsing.
 #[cfg(not(feature = "decimal128"))]
 #[inline]
-fn read_f128<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<Decimal128> {
+fn read_f128<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Decimal128> {
     let mut buf = [0u8; 128 / 8];
     reader.read_exact(&mut buf)?;
     Ok(Decimal128 { bytes: buf })
@@ -109,7 +109,7 @@ fn read_f128<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<Decimal128> {
 
 #[cfg(feature = "decimal128")]
 #[inline]
-fn read_f128<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<Decimal128> {
+fn read_f128<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Decimal128> {
     use std::mem;
 
     let mut local_buf: [u8; 16] = unsafe { mem::MaybeUninit::uninit().assume_init() };
@@ -118,7 +118,10 @@ fn read_f128<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<Decimal128> {
     Ok(val)
 }
 
-fn decode_array<R: Read + ?Sized>(reader: &mut R, utf8_lossy: bool) -> DecoderResult<Array> {
+fn deserialize_array<R: Read + ?Sized>(
+    reader: &mut R,
+    utf8_lossy: bool,
+) -> crate::de::Result<Array> {
     let mut arr = Array::new();
 
     // disregard the length: using Read::take causes infinite type recursion
@@ -130,30 +133,30 @@ fn decode_array<R: Read + ?Sized>(reader: &mut R, utf8_lossy: bool) -> DecoderRe
             break;
         }
 
-        let (_, val) = decode_bson_kvp(reader, tag, utf8_lossy)?;
+        let (_, val) = deserialize_bson_kvp(reader, tag, utf8_lossy)?;
         arr.push(val)
     }
 
     Ok(arr)
 }
 
-pub(crate) fn decode_bson_kvp<R: Read + ?Sized>(
+pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
     reader: &mut R,
     tag: u8,
     utf8_lossy: bool,
-) -> DecoderResult<(String, Bson)> {
+) -> crate::de::Result<(String, Bson)> {
     use spec::ElementType;
     let key = read_cstring(reader)?;
 
     let val = match ElementType::from(tag) {
         Some(ElementType::Double) => Bson::Double(reader.read_f64::<LittleEndian>()?),
         Some(ElementType::String) => read_string(reader, utf8_lossy).map(Bson::String)?,
-        Some(ElementType::EmbeddedDocument) => Document::decode(reader).map(Bson::Document)?,
-        Some(ElementType::Array) => decode_array(reader, utf8_lossy).map(Bson::Array)?,
+        Some(ElementType::EmbeddedDocument) => Document::deserialize(reader).map(Bson::Document)?,
+        Some(ElementType::Array) => deserialize_array(reader, utf8_lossy).map(Bson::Array)?,
         Some(ElementType::Binary) => {
             let mut len = read_i32(reader)?;
             if len < 0 || len > MAX_BSON_SIZE {
-                return Err(DecoderError::invalid_length(
+                return Err(Error::invalid_length(
                     len as usize,
                     &format!("binary length must be between 0 and {}", MAX_BSON_SIZE).as_str(),
                 ));
@@ -200,7 +203,7 @@ pub(crate) fn decode_bson_kvp<R: Read + ?Sized>(
             read_i32(reader)?;
 
             let code = read_string(reader, utf8_lossy)?;
-            let scope = Document::decode(reader)?;
+            let scope = Document::deserialize(reader)?;
             Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope { code, scope })
         }
         Some(ElementType::Int32) => read_i32(reader).map(Bson::Int32)?,
@@ -222,8 +225,8 @@ pub(crate) fn decode_bson_kvp<R: Read + ?Sized>(
             };
 
             match Utc.timestamp_opt(sec, (msec as u32) * 1_000_000) {
-                LocalResult::None => return Err(DecoderError::InvalidTimestamp(time)),
-                LocalResult::Ambiguous(..) => return Err(DecoderError::AmbiguousTimestamp(time)),
+                LocalResult::None => return Err(Error::InvalidTimestamp(time)),
+                LocalResult::Ambiguous(..) => return Err(Error::AmbiguousTimestamp(time)),
                 LocalResult::Single(t) => Bson::DateTime(t),
             }
         }
@@ -242,7 +245,7 @@ pub(crate) fn decode_bson_kvp<R: Read + ?Sized>(
         Some(ElementType::MaxKey) => Bson::MaxKey,
         Some(ElementType::MinKey) => Bson::MinKey,
         None => {
-            return Err(DecoderError::UnrecognizedDocumentElementType {
+            return Err(Error::UnrecognizedDocumentElementType {
                 key,
                 element_type: tag,
             })
@@ -253,10 +256,10 @@ pub(crate) fn decode_bson_kvp<R: Read + ?Sized>(
 }
 
 /// Decode a BSON `Value` into a `T` Deserializable.
-pub fn from_bson<'de, T>(bson: Bson) -> DecoderResult<T>
+pub fn from_bson<'de, T>(bson: Bson) -> crate::de::Result<T>
 where
-    T: Deserialize<'de>,
+    T: de::Deserialize<'de>,
 {
-    let de = Decoder::new(bson);
-    Deserialize::deserialize(de)
+    let de = Deserializer::new(bson);
+    de::Deserialize::deserialize(de)
 }

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -4,7 +4,7 @@ use serde::de::{
     self,
     Deserialize,
     DeserializeSeed,
-    Deserializer,
+    Deserializer as SerdeDeserializer,
     EnumAccess,
     Error,
     MapAccess,
@@ -14,7 +14,6 @@ use serde::de::{
     Visitor,
 };
 
-use super::error::{DecoderError, DecoderResult};
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
 use crate::{
@@ -29,7 +28,7 @@ pub struct BsonVisitor;
 impl<'de> Deserialize<'de> for ObjectId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         deserializer.deserialize_map(BsonVisitor).and_then(|bson| {
             if let Bson::ObjectId(oid) = bson {
@@ -46,7 +45,7 @@ impl<'de> Deserialize<'de> for Document {
     /// Deserialize this value given this `Deserializer`.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         deserializer.deserialize_map(BsonVisitor).and_then(|bson| {
             if let Bson::Document(doc) = bson {
@@ -63,7 +62,7 @@ impl<'de> Deserialize<'de> for Bson {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Bson, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         deserializer.deserialize_any(BsonVisitor)
     }
@@ -186,7 +185,7 @@ impl<'de> Visitor<'de> for BsonVisitor {
     #[inline]
     fn visit_some<D>(self, deserializer: D) -> Result<Bson, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         deserializer.deserialize_any(self)
     }
@@ -231,14 +230,14 @@ impl<'de> Visitor<'de> for BsonVisitor {
     }
 }
 
-/// Serde Decoder
-pub struct Decoder {
+/// Serde Deserializer
+pub struct Deserializer {
     value: Option<Bson>,
 }
 
-impl Decoder {
-    pub fn new(value: Bson) -> Decoder {
-        Decoder { value: Some(value) }
+impl Deserializer {
+    pub fn new(value: Bson) -> Deserializer {
+        Deserializer { value: Some(value) }
     }
 }
 
@@ -279,17 +278,17 @@ macro_rules! forward_to_deserialize {
     };
 }
 
-impl<'de> Deserializer<'de> for Decoder {
-    type Error = DecoderError;
+impl<'de> de::Deserializer<'de> for Deserializer {
+    type Error = crate::de::Error;
 
     #[inline]
-    fn deserialize_any<V>(mut self, visitor: V) -> DecoderResult<V::Value>
+    fn deserialize_any<V>(mut self, visitor: V) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let value = match self.value.take() {
             Some(value) => value,
-            None => return Err(DecoderError::EndOfStream),
+            None => return Err(crate::de::Error::EndOfStream),
         };
 
         match value {
@@ -297,14 +296,14 @@ impl<'de> Deserializer<'de> for Decoder {
             Bson::String(v) => visitor.visit_string(v),
             Bson::Array(v) => {
                 let len = v.len();
-                visitor.visit_seq(SeqDecoder {
+                visitor.visit_seq(SeqDeserializer {
                     iter: v.into_iter(),
                     len,
                 })
             }
             Bson::Document(v) => {
                 let len = v.len();
-                visitor.visit_map(MapDecoder {
+                visitor.visit_map(MapDeserializer {
                     iter: v.into_iter(),
                     value: None,
                     len,
@@ -318,7 +317,7 @@ impl<'de> Deserializer<'de> for Decoder {
                 subtype: BinarySubtype::Generic,
                 ref bytes,
             }) => visitor.visit_bytes(&bytes),
-            binary @ Bson::Binary(..) => visitor.visit_map(MapDecoder {
+            binary @ Bson::Binary(..) => visitor.visit_map(MapDeserializer {
                 iter: binary.to_extended_document().into_iter(),
                 value: None,
                 len: 2,
@@ -326,7 +325,7 @@ impl<'de> Deserializer<'de> for Decoder {
             _ => {
                 let doc = value.to_extended_document();
                 let len = doc.len();
-                visitor.visit_map(MapDecoder {
+                visitor.visit_map(MapDeserializer {
                     iter: doc.into_iter(),
                     value: None,
                     len,
@@ -336,14 +335,14 @@ impl<'de> Deserializer<'de> for Decoder {
     }
 
     #[inline]
-    fn deserialize_option<V>(self, visitor: V) -> DecoderResult<V::Value>
+    fn deserialize_option<V>(self, visitor: V) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
         match self.value {
             Some(Bson::Null) => visitor.visit_none(),
             Some(_) => visitor.visit_some(self),
-            None => Err(DecoderError::EndOfStream),
+            None => Err(crate::de::Error::EndOfStream),
         }
     }
 
@@ -353,26 +352,26 @@ impl<'de> Deserializer<'de> for Decoder {
         _name: &str,
         _variants: &'static [&'static str],
         visitor: V,
-    ) -> DecoderResult<V::Value>
+    ) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let value = match self.value.take() {
             Some(Bson::Document(value)) => value,
             Some(Bson::String(variant)) => {
-                return visitor.visit_enum(EnumDecoder {
+                return visitor.visit_enum(EnumDeserializer {
                     val: Bson::String(variant),
-                    decoder: VariantDecoder { val: None },
+                    deserializer: VariantDeserializer { val: None },
                 });
             }
             Some(v) => {
-                return Err(DecoderError::invalid_type(
+                return Err(crate::de::Error::invalid_type(
                     v.as_unexpected(),
                     &"expected an enum",
                 ));
             }
             None => {
-                return Err(DecoderError::EndOfStream);
+                return Err(crate::de::Error::EndOfStream);
             }
         };
 
@@ -381,7 +380,7 @@ impl<'de> Deserializer<'de> for Decoder {
         let (variant, value) = match iter.next() {
             Some(v) => v,
             None => {
-                return Err(DecoderError::SyntaxError {
+                return Err(crate::de::Error::SyntaxError {
                     message: "expected a variant name".to_owned(),
                 })
             }
@@ -389,13 +388,13 @@ impl<'de> Deserializer<'de> for Decoder {
 
         // enums are encoded in json as maps with a single key:value pair
         match iter.next() {
-            Some((k, _)) => Err(DecoderError::invalid_value(
+            Some((k, _)) => Err(crate::de::Error::invalid_value(
                 Unexpected::Map,
                 &format!("expected map with a single key, got extra key \"{}\"", k).as_str(),
             )),
-            None => visitor.visit_enum(EnumDecoder {
+            None => visitor.visit_enum(EnumDeserializer {
                 val: Bson::String(variant),
-                decoder: VariantDecoder { val: Some(value) },
+                deserializer: VariantDeserializer { val: Some(value) },
             }),
         }
     }
@@ -405,7 +404,7 @@ impl<'de> Deserializer<'de> for Decoder {
         self,
         _name: &'static str,
         visitor: V,
-    ) -> DecoderResult<V::Value>
+    ) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -441,59 +440,59 @@ impl<'de> Deserializer<'de> for Decoder {
     }
 }
 
-struct EnumDecoder {
+struct EnumDeserializer {
     val: Bson,
-    decoder: VariantDecoder,
+    deserializer: VariantDeserializer,
 }
 
-impl<'de> EnumAccess<'de> for EnumDecoder {
-    type Error = DecoderError;
-    type Variant = VariantDecoder;
-    fn variant_seed<V>(self, seed: V) -> DecoderResult<(V::Value, Self::Variant)>
+impl<'de> EnumAccess<'de> for EnumDeserializer {
+    type Error = crate::de::Error;
+    type Variant = VariantDeserializer;
+    fn variant_seed<V>(self, seed: V) -> crate::de::Result<(V::Value, Self::Variant)>
     where
         V: DeserializeSeed<'de>,
     {
-        let dec = Decoder::new(self.val);
+        let dec = Deserializer::new(self.val);
         let value = seed.deserialize(dec)?;
-        Ok((value, self.decoder))
+        Ok((value, self.deserializer))
     }
 }
 
-struct VariantDecoder {
+struct VariantDeserializer {
     val: Option<Bson>,
 }
 
-impl<'de> VariantAccess<'de> for VariantDecoder {
-    type Error = DecoderError;
+impl<'de> VariantAccess<'de> for VariantDeserializer {
+    type Error = crate::de::Error;
 
-    fn unit_variant(mut self) -> DecoderResult<()> {
+    fn unit_variant(mut self) -> crate::de::Result<()> {
         match self.val.take() {
             None => Ok(()),
-            Some(val) => Bson::deserialize(Decoder::new(val)).map(|_| ()),
+            Some(val) => Bson::deserialize(Deserializer::new(val)).map(|_| ()),
         }
     }
 
-    fn newtype_variant_seed<T>(mut self, seed: T) -> DecoderResult<T::Value>
+    fn newtype_variant_seed<T>(mut self, seed: T) -> crate::de::Result<T::Value>
     where
         T: DeserializeSeed<'de>,
     {
-        let dec = Decoder::new(self.val.take().ok_or(DecoderError::EndOfStream)?);
+        let dec = Deserializer::new(self.val.take().ok_or(crate::de::Error::EndOfStream)?);
         seed.deserialize(dec)
     }
 
-    fn tuple_variant<V>(mut self, _len: usize, visitor: V) -> DecoderResult<V::Value>
+    fn tuple_variant<V>(mut self, _len: usize, visitor: V) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        match self.val.take().ok_or(DecoderError::EndOfStream)? {
+        match self.val.take().ok_or(crate::de::Error::EndOfStream)? {
             Bson::Array(fields) => {
-                let de = SeqDecoder {
+                let de = SeqDeserializer {
                     len: fields.len(),
                     iter: fields.into_iter(),
                 };
                 de.deserialize_any(visitor)
             }
-            other => Err(DecoderError::invalid_type(
+            other => Err(crate::de::Error::invalid_type(
                 other.as_unexpected(),
                 &"expected a tuple",
             )),
@@ -504,20 +503,20 @@ impl<'de> VariantAccess<'de> for VariantDecoder {
         mut self,
         _fields: &'static [&'static str],
         visitor: V,
-    ) -> DecoderResult<V::Value>
+    ) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        match self.val.take().ok_or(DecoderError::EndOfStream)? {
+        match self.val.take().ok_or(crate::de::Error::EndOfStream)? {
             Bson::Document(fields) => {
-                let de = MapDecoder {
+                let de = MapDeserializer {
                     len: fields.len(),
                     iter: fields.into_iter(),
                     value: None,
                 };
                 de.deserialize_any(visitor)
             }
-            ref other => Err(DecoderError::invalid_type(
+            ref other => Err(crate::de::Error::invalid_type(
                 other.as_unexpected(),
                 &"expected a struct",
             )),
@@ -525,16 +524,16 @@ impl<'de> VariantAccess<'de> for VariantDecoder {
     }
 }
 
-struct SeqDecoder {
+struct SeqDeserializer {
     iter: vec::IntoIter<Bson>,
     len: usize,
 }
 
-impl<'de> Deserializer<'de> for SeqDecoder {
-    type Error = DecoderError;
+impl<'de> de::Deserializer<'de> for SeqDeserializer {
+    type Error = crate::de::Error;
 
     #[inline]
-    fn deserialize_any<V>(self, visitor: V) -> DecoderResult<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -577,10 +576,10 @@ impl<'de> Deserializer<'de> for SeqDecoder {
     }
 }
 
-impl<'de> SeqAccess<'de> for SeqDecoder {
-    type Error = DecoderError;
+impl<'de> SeqAccess<'de> for SeqDeserializer {
+    type Error = crate::de::Error;
 
-    fn next_element_seed<T>(&mut self, seed: T) -> DecoderResult<Option<T::Value>>
+    fn next_element_seed<T>(&mut self, seed: T) -> crate::de::Result<Option<T::Value>>
     where
         T: DeserializeSeed<'de>,
     {
@@ -588,7 +587,7 @@ impl<'de> SeqAccess<'de> for SeqDecoder {
             None => Ok(None),
             Some(value) => {
                 self.len -= 1;
-                let de = Decoder::new(value);
+                let de = Deserializer::new(value);
                 match seed.deserialize(de) {
                     Ok(value) => Ok(Some(value)),
                     Err(err) => Err(err),
@@ -602,16 +601,16 @@ impl<'de> SeqAccess<'de> for SeqDecoder {
     }
 }
 
-struct MapDecoder {
+struct MapDeserializer {
     iter: DocumentIntoIterator,
     value: Option<Bson>,
     len: usize,
 }
 
-impl<'de> MapAccess<'de> for MapDecoder {
-    type Error = DecoderError;
+impl<'de> MapAccess<'de> for MapDeserializer {
+    type Error = crate::de::Error;
 
-    fn next_key_seed<K>(&mut self, seed: K) -> DecoderResult<Option<K::Value>>
+    fn next_key_seed<K>(&mut self, seed: K) -> crate::de::Result<Option<K::Value>>
     where
         K: DeserializeSeed<'de>,
     {
@@ -620,7 +619,7 @@ impl<'de> MapAccess<'de> for MapDecoder {
                 self.len -= 1;
                 self.value = Some(value);
 
-                let de = Decoder::new(Bson::String(key));
+                let de = Deserializer::new(Bson::String(key));
                 match seed.deserialize(de) {
                     Ok(val) => Ok(Some(val)),
                     Err(e) => Err(e),
@@ -630,12 +629,12 @@ impl<'de> MapAccess<'de> for MapDecoder {
         }
     }
 
-    fn next_value_seed<V>(&mut self, seed: V) -> DecoderResult<V::Value>
+    fn next_value_seed<V>(&mut self, seed: V) -> crate::de::Result<V::Value>
     where
         V: DeserializeSeed<'de>,
     {
-        let value = self.value.take().ok_or(DecoderError::EndOfStream)?;
-        let de = Decoder::new(value);
+        let value = self.value.take().ok_or(crate::de::Error::EndOfStream)?;
+        let de = Deserializer::new(value);
         seed.deserialize(de)
     }
 
@@ -644,11 +643,11 @@ impl<'de> MapAccess<'de> for MapDecoder {
     }
 }
 
-impl<'de> Deserializer<'de> for MapDecoder {
-    type Error = DecoderError;
+impl<'de> de::Deserializer<'de> for MapDeserializer {
+    type Error = crate::de::Error;
 
     #[inline]
-    fn deserialize_any<V>(self, visitor: V) -> DecoderResult<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -690,7 +689,7 @@ impl<'de> Deserializer<'de> for MapDecoder {
 impl<'de> Deserialize<'de> for Timestamp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::Timestamp(timestamp) => Ok(timestamp),
@@ -702,7 +701,7 @@ impl<'de> Deserialize<'de> for Timestamp {
 impl<'de> Deserialize<'de> for Regex {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::RegularExpression(regex) => Ok(regex),
@@ -714,7 +713,7 @@ impl<'de> Deserialize<'de> for Regex {
 impl<'de> Deserialize<'de> for JavaScriptCodeWithScope {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::JavaScriptCodeWithScope(code_with_scope) => Ok(code_with_scope),
@@ -726,7 +725,7 @@ impl<'de> Deserialize<'de> for JavaScriptCodeWithScope {
 impl<'de> Deserialize<'de> for Binary {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::Binary(binary) => Ok(binary),
@@ -739,7 +738,7 @@ impl<'de> Deserialize<'de> for Binary {
 impl<'de> Deserialize<'de> for Decimal128 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::Decimal128(d128) => Ok(d128),
@@ -751,7 +750,7 @@ impl<'de> Deserialize<'de> for Decimal128 {
 impl<'de> Deserialize<'de> for DateTime {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::DateTime(dt) => Ok(DateTime(dt)),
@@ -763,7 +762,7 @@ impl<'de> Deserialize<'de> for DateTime {
 impl<'de> Deserialize<'de> for DbPointer {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
             Bson::DbPointer(db_pointer) => Ok(db_pointer),

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -4,7 +4,7 @@ use serde::de::{
     self,
     Deserialize,
     DeserializeSeed,
-    Deserializer as SerdeDeserializer,
+    Deserializer as _,
     EnumAccess,
     Error,
     MapAccess,

--- a/src/document.rs
+++ b/src/document.rs
@@ -511,7 +511,7 @@ impl Document {
     }
 
     /// Attempts to serialize the `Document` into a byte stream.
-    pub fn serialize_to<W: Write + ?Sized>(&self, writer: &mut W) -> crate::ser::Result<()> {
+    pub fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> crate::ser::Result<()> {
         let mut buf = Vec::new();
         for (key, val) in self.into_iter() {
             serialize_bson(&mut buf, key.as_ref(), val)?;
@@ -527,7 +527,7 @@ impl Document {
     }
 
     /// Attempts to deserialize a `Document` from a byte stream.
-    pub fn deserialize_from<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Document> {
+    pub fn from_reader<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Document> {
         let mut doc = Document::new();
 
         // disregard the length: using Read::take causes infinite type recursion

--- a/src/document.rs
+++ b/src/document.rs
@@ -511,7 +511,7 @@ impl Document {
     }
 
     /// Attempts to serialize the `Document` into a byte stream.
-    pub fn serialize_doc<W: Write + ?Sized>(&self, writer: &mut W) -> crate::ser::Result<()> {
+    pub fn serialize_to<W: Write + ?Sized>(&self, writer: &mut W) -> crate::ser::Result<()> {
         let mut buf = Vec::new();
         for (key, val) in self.into_iter() {
             serialize_bson(&mut buf, key.as_ref(), val)?;
@@ -527,7 +527,7 @@ impl Document {
     }
 
     /// Attempts to deserialize a `Document` from a byte stream.
-    pub fn deserialize<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Document> {
+    pub fn deserialize_from<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Document> {
         let mut doc = Document::new();
 
         // disregard the length: using Read::take causes infinite type recursion

--- a/src/document.rs
+++ b/src/document.rs
@@ -21,9 +21,9 @@ use serde::de::{self, MapAccess, Visitor};
 use crate::decimal128::Decimal128;
 use crate::{
     bson::{Array, Binary, Bson, Timestamp},
-    decoder::{decode_bson_kvp, read_i32, DecoderResult},
-    encoder::{encode_bson, write_i32, EncoderResult},
+    de::{deserialize_bson_kvp, read_i32},
     oid::ObjectId,
+    ser::{serialize_bson, write_i32},
     spec::BinarySubtype,
 };
 
@@ -510,11 +510,11 @@ impl Document {
         }
     }
 
-    /// Attempts to encode the `Document` into a byte stream.
-    pub fn encode<W: Write + ?Sized>(&self, writer: &mut W) -> EncoderResult<()> {
+    /// Attempts to serialize the `Document` into a byte stream.
+    pub fn serialize_doc<W: Write + ?Sized>(&self, writer: &mut W) -> crate::ser::Result<()> {
         let mut buf = Vec::new();
         for (key, val) in self.into_iter() {
-            encode_bson(&mut buf, key.as_ref(), val)?;
+            serialize_bson(&mut buf, key.as_ref(), val)?;
         }
 
         write_i32(
@@ -526,8 +526,8 @@ impl Document {
         Ok(())
     }
 
-    /// Attempts to decode a `Document` from a byte stream.
-    pub fn decode<R: Read + ?Sized>(reader: &mut R) -> DecoderResult<Document> {
+    /// Attempts to deserialize a `Document` from a byte stream.
+    pub fn deserialize<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Document> {
         let mut doc = Document::new();
 
         // disregard the length: using Read::take causes infinite type recursion
@@ -540,7 +540,7 @@ impl Document {
                 break;
             }
 
-            let (key, val) = decode_bson_kvp(reader, tag, false)?;
+            let (key, val) = deserialize_bson_kvp(reader, tag, false)?;
             doc.insert(key, val);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //! # use bson::{doc, Document};
 //! # use std::io::Read;
 //! let mut bytes = hex::decode("0C0000001069000100000000").unwrap();
-//! let doc = Document::deserialize(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
+//! let doc = Document::deserialize_from(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
 //!
 //! let doc = doc! {
 //!    "hello": "world",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,8 @@ pub use self::{
         Regex,
         Timestamp,
     },
-    decimal128::Decimal128,
     de::{from_bson, Deserializer},
+    decimal128::Decimal128,
     ser::{to_bson, Serializer},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //! # use bson::{doc, Document};
 //! # use std::io::Read;
 //! let mut bytes = hex::decode("0C0000001069000100000000").unwrap();
-//! let doc = Document::decode(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
+//! let doc = Document::deserialize(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
 //!
 //! let doc = doc! {
 //!    "hello": "world",
@@ -199,18 +199,17 @@ pub use self::{
         Timestamp,
     },
     decimal128::Decimal128,
-    decoder::{from_bson, Decoder, DecoderError, DecoderResult},
-    document::{ValueAccessError, ValueAccessResult},
-    encoder::{to_bson, Encoder, EncoderError, EncoderResult},
+    de::{from_bson, Deserializer},
+    ser::{to_bson, Serializer},
 };
 
 #[macro_use]
 mod macros;
 mod bson;
 pub mod compat;
+pub mod de;
 pub mod decimal128;
-mod decoder;
 pub mod document;
-mod encoder;
 pub mod oid;
+pub mod ser;
 pub mod spec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //! # use bson::{doc, Document};
 //! # use std::io::Read;
 //! let mut bytes = hex::decode("0C0000001069000100000000").unwrap();
-//! let doc = Document::deserialize_from(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
+//! let doc = Document::from_reader(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
 //!
 //! let doc = doc! {
 //!    "hello": "world",

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -104,7 +104,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
         Bson::Double(v) => write_f64(writer, v),
         Bson::String(ref v) => write_string(writer, &v),
         Bson::Array(ref v) => serialize_array(writer, &v),
-        Bson::Document(ref v) => v.serialize_to(writer),
+        Bson::Document(ref v) => v.to_writer(writer),
         Bson::Boolean(v) => writer
             .write_u8(if v { 0x01 } else { 0x00 })
             .map_err(From::from),
@@ -123,7 +123,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
         }) => {
             let mut buf = Vec::new();
             write_string(&mut buf, code)?;
-            scope.serialize_to(&mut buf)?;
+            scope.to_writer(&mut buf)?;
 
             write_i32(writer, buf.len() as i32 + 4)?;
             writer.write_all(&buf).map_err(From::from)

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     bson::{Binary, Bson, DbPointer, JavaScriptCodeWithScope, Regex},
     spec::BinarySubtype,
 };
-use ::serde::Serialize;
+use serde::Serialize;
 
 fn write_string<W: Write + ?Sized>(writer: &mut W, s: &str) -> Result<()> {
     writer.write_i32::<LittleEndian>(s.len() as i32 + 1)?;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -104,7 +104,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
         Bson::Double(v) => write_f64(writer, v),
         Bson::String(ref v) => write_string(writer, &v),
         Bson::Array(ref v) => serialize_array(writer, &v),
-        Bson::Document(ref v) => v.serialize_doc(writer),
+        Bson::Document(ref v) => v.serialize_to(writer),
         Bson::Boolean(v) => writer
             .write_u8(if v { 0x01 } else { 0x00 })
             .map_err(From::from),
@@ -123,7 +123,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
         }) => {
             let mut buf = Vec::new();
             write_string(&mut buf, code)?;
-            scope.serialize_doc(&mut buf)?;
+            scope.serialize_to(&mut buf)?;
 
             write_i32(writer, buf.len() as i32 + 4)?;
             writer.write_all(&buf).map_err(From::from)

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     bson::{Binary, Bson, DbPointer, JavaScriptCodeWithScope, Regex},
     spec::BinarySubtype,
 };
-use serde::Serialize;
+use ::serde::Serialize;
 
 fn write_string<W: Write + ?Sized>(writer: &mut W, s: &str) -> Result<()> {
     writer.write_i32::<LittleEndian>(s.len() as i32 + 1)?;

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -1,4 +1,5 @@
 use serde::ser::{
+    self,
     Serialize,
     SerializeMap,
     SerializeSeq,
@@ -7,7 +8,6 @@ use serde::ser::{
     SerializeTuple,
     SerializeTupleStruct,
     SerializeTupleVariant,
-    Serializer,
 };
 
 #[cfg(feature = "decimal128")]
@@ -28,13 +28,13 @@ use crate::{
     spec::BinarySubtype,
 };
 
-use super::{to_bson, EncoderError, EncoderResult};
+use super::{to_bson, Error};
 
 impl Serialize for ObjectId {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::ser::Serializer,
     {
         let mut ser = serializer.serialize_map(Some(1))?;
         ser.serialize_entry("$oid", &self.to_string())?;
@@ -46,7 +46,7 @@ impl Serialize for Document {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         let mut state = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
@@ -60,7 +60,7 @@ impl Serialize for Bson {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         match *self {
             Bson::Double(v) => serializer.serialize_f64(v),
@@ -83,20 +83,20 @@ impl Serialize for Bson {
     }
 }
 
-/// Serde Encoder
-pub struct Encoder;
+/// Serde Serializer
+pub struct Serializer;
 
-impl Encoder {
+impl Serializer {
     /// Construct a new `Serializer`.
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Encoder {
-        Encoder
+    pub fn new() -> Serializer {
+        Serializer
     }
 }
 
-impl Serializer for Encoder {
+impl ser::Serializer for Serializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
     type SerializeSeq = ArraySerializer;
     type SerializeTuple = TupleSerializer;
@@ -107,102 +107,102 @@ impl Serializer for Encoder {
     type SerializeStructVariant = StructVariantSerializer;
 
     #[inline]
-    fn serialize_bool(self, value: bool) -> EncoderResult<Bson> {
+    fn serialize_bool(self, value: bool) -> crate::ser::Result<Bson> {
         Ok(Bson::Boolean(value))
     }
 
     #[inline]
-    fn serialize_i8(self, value: i8) -> EncoderResult<Bson> {
+    fn serialize_i8(self, value: i8) -> crate::ser::Result<Bson> {
         self.serialize_i32(value as i32)
     }
 
     #[inline]
-    fn serialize_u8(self, _value: u8) -> EncoderResult<Bson> {
+    fn serialize_u8(self, _value: u8) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
             Ok(Bson::Int32(_value as i32))
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(EncoderError::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedType)
     }
 
     #[inline]
-    fn serialize_i16(self, value: i16) -> EncoderResult<Bson> {
+    fn serialize_i16(self, value: i16) -> crate::ser::Result<Bson> {
         self.serialize_i32(value as i32)
     }
 
     #[inline]
-    fn serialize_u16(self, _value: u16) -> EncoderResult<Bson> {
+    fn serialize_u16(self, _value: u16) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
             Ok(Bson::Int32(_value as i32))
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(EncoderError::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedType)
     }
 
     #[inline]
-    fn serialize_i32(self, value: i32) -> EncoderResult<Bson> {
+    fn serialize_i32(self, value: i32) -> crate::ser::Result<Bson> {
         Ok(Bson::Int32(value))
     }
 
     #[inline]
-    fn serialize_u32(self, _value: u32) -> EncoderResult<Bson> {
+    fn serialize_u32(self, _value: u32) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
             Ok(Bson::Int64(_value as i64))
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(EncoderError::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedType)
     }
 
     #[inline]
-    fn serialize_i64(self, value: i64) -> EncoderResult<Bson> {
+    fn serialize_i64(self, value: i64) -> crate::ser::Result<Bson> {
         Ok(Bson::Int64(value))
     }
 
     #[inline]
-    fn serialize_u64(self, _value: u64) -> EncoderResult<Bson> {
+    fn serialize_u64(self, _value: u64) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
             use std::convert::TryFrom;
 
             match i64::try_from(_value) {
                 Ok(ivalue) => Ok(Bson::Int64(ivalue)),
-                Err(_) => Err(EncoderError::UnsignedTypesValueExceedsRange(_value)),
+                Err(_) => Err(Error::UnsignedTypesValueExceedsRange(_value)),
             }
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(EncoderError::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedType)
     }
 
     #[inline]
-    fn serialize_f32(self, value: f32) -> EncoderResult<Bson> {
+    fn serialize_f32(self, value: f32) -> crate::ser::Result<Bson> {
         self.serialize_f64(value as f64)
     }
 
     #[inline]
-    fn serialize_f64(self, value: f64) -> EncoderResult<Bson> {
+    fn serialize_f64(self, value: f64) -> crate::ser::Result<Bson> {
         Ok(Bson::Double(value))
     }
 
     #[inline]
-    fn serialize_char(self, value: char) -> EncoderResult<Bson> {
+    fn serialize_char(self, value: char) -> crate::ser::Result<Bson> {
         let mut s = String::new();
         s.push(value);
         self.serialize_str(&s)
     }
 
     #[inline]
-    fn serialize_str(self, value: &str) -> EncoderResult<Bson> {
+    fn serialize_str(self, value: &str) -> crate::ser::Result<Bson> {
         Ok(Bson::String(value.to_string()))
     }
 
-    fn serialize_bytes(self, value: &[u8]) -> EncoderResult<Bson> {
+    fn serialize_bytes(self, value: &[u8]) -> crate::ser::Result<Bson> {
         // let mut state = self.serialize_seq(Some(value.len()))?;
         // for byte in value {
         //     state.serialize_element(byte)?;
@@ -215,12 +215,12 @@ impl Serializer for Encoder {
     }
 
     #[inline]
-    fn serialize_none(self) -> EncoderResult<Bson> {
+    fn serialize_none(self) -> crate::ser::Result<Bson> {
         self.serialize_unit()
     }
 
     #[inline]
-    fn serialize_some<V: ?Sized>(self, value: &V) -> EncoderResult<Bson>
+    fn serialize_some<V: ?Sized>(self, value: &V) -> crate::ser::Result<Bson>
     where
         V: Serialize,
     {
@@ -228,12 +228,12 @@ impl Serializer for Encoder {
     }
 
     #[inline]
-    fn serialize_unit(self) -> EncoderResult<Bson> {
+    fn serialize_unit(self) -> crate::ser::Result<Bson> {
         Ok(Bson::Null)
     }
 
     #[inline]
-    fn serialize_unit_struct(self, _name: &'static str) -> EncoderResult<Bson> {
+    fn serialize_unit_struct(self, _name: &'static str) -> crate::ser::Result<Bson> {
         self.serialize_unit()
     }
 
@@ -243,7 +243,7 @@ impl Serializer for Encoder {
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
-    ) -> EncoderResult<Bson> {
+    ) -> crate::ser::Result<Bson> {
         Ok(Bson::String(variant.to_string()))
     }
 
@@ -252,7 +252,7 @@ impl Serializer for Encoder {
         self,
         _name: &'static str,
         value: &T,
-    ) -> EncoderResult<Bson>
+    ) -> crate::ser::Result<Bson>
     where
         T: Serialize,
     {
@@ -266,7 +266,7 @@ impl Serializer for Encoder {
         _variant_index: u32,
         variant: &'static str,
         value: &T,
-    ) -> EncoderResult<Bson>
+    ) -> crate::ser::Result<Bson>
     where
         T: Serialize,
     {
@@ -276,14 +276,14 @@ impl Serializer for Encoder {
     }
 
     #[inline]
-    fn serialize_seq(self, len: Option<usize>) -> EncoderResult<Self::SerializeSeq> {
+    fn serialize_seq(self, len: Option<usize>) -> crate::ser::Result<Self::SerializeSeq> {
         Ok(ArraySerializer {
             inner: Array::with_capacity(len.unwrap_or(0)),
         })
     }
 
     #[inline]
-    fn serialize_tuple(self, len: usize) -> EncoderResult<Self::SerializeTuple> {
+    fn serialize_tuple(self, len: usize) -> crate::ser::Result<Self::SerializeTuple> {
         Ok(TupleSerializer {
             inner: Array::with_capacity(len),
         })
@@ -294,7 +294,7 @@ impl Serializer for Encoder {
         self,
         _name: &'static str,
         len: usize,
-    ) -> EncoderResult<Self::SerializeTupleStruct> {
+    ) -> crate::ser::Result<Self::SerializeTupleStruct> {
         Ok(TupleStructSerializer {
             inner: Array::with_capacity(len),
         })
@@ -307,7 +307,7 @@ impl Serializer for Encoder {
         _variant_index: u32,
         variant: &'static str,
         len: usize,
-    ) -> EncoderResult<Self::SerializeTupleVariant> {
+    ) -> crate::ser::Result<Self::SerializeTupleVariant> {
         Ok(TupleVariantSerializer {
             inner: Array::with_capacity(len),
             name: variant,
@@ -315,7 +315,7 @@ impl Serializer for Encoder {
     }
 
     #[inline]
-    fn serialize_map(self, _len: Option<usize>) -> EncoderResult<Self::SerializeMap> {
+    fn serialize_map(self, _len: Option<usize>) -> crate::ser::Result<Self::SerializeMap> {
         Ok(MapSerializer {
             inner: Document::new(),
             next_key: None,
@@ -327,7 +327,7 @@ impl Serializer for Encoder {
         self,
         _name: &'static str,
         _len: usize,
-    ) -> EncoderResult<Self::SerializeStruct> {
+    ) -> crate::ser::Result<Self::SerializeStruct> {
         Ok(StructSerializer {
             inner: Document::new(),
         })
@@ -340,7 +340,7 @@ impl Serializer for Encoder {
         _variant_index: u32,
         variant: &'static str,
         _len: usize,
-    ) -> EncoderResult<Self::SerializeStructVariant> {
+    ) -> crate::ser::Result<Self::SerializeStructVariant> {
         Ok(StructVariantSerializer {
             name: variant,
             inner: Document::new(),
@@ -355,14 +355,14 @@ pub struct ArraySerializer {
 
 impl SerializeSeq for ArraySerializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
-    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> EncoderResult<()> {
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> crate::ser::Result<()> {
         self.inner.push(to_bson(value)?);
         Ok(())
     }
 
-    fn end(self) -> EncoderResult<Bson> {
+    fn end(self) -> crate::ser::Result<Bson> {
         Ok(Bson::Array(self.inner))
     }
 }
@@ -374,14 +374,14 @@ pub struct TupleSerializer {
 
 impl SerializeTuple for TupleSerializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
-    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> EncoderResult<()> {
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> crate::ser::Result<()> {
         self.inner.push(to_bson(value)?);
         Ok(())
     }
 
-    fn end(self) -> EncoderResult<Bson> {
+    fn end(self) -> crate::ser::Result<Bson> {
         Ok(Bson::Array(self.inner))
     }
 }
@@ -393,14 +393,14 @@ pub struct TupleStructSerializer {
 
 impl SerializeTupleStruct for TupleStructSerializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> EncoderResult<()> {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> crate::ser::Result<()> {
         self.inner.push(to_bson(value)?);
         Ok(())
     }
 
-    fn end(self) -> EncoderResult<Bson> {
+    fn end(self) -> crate::ser::Result<Bson> {
         Ok(Bson::Array(self.inner))
     }
 }
@@ -413,14 +413,14 @@ pub struct TupleVariantSerializer {
 
 impl SerializeTupleVariant for TupleVariantSerializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> EncoderResult<()> {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> crate::ser::Result<()> {
         self.inner.push(to_bson(value)?);
         Ok(())
     }
 
-    fn end(self) -> EncoderResult<Bson> {
+    fn end(self) -> crate::ser::Result<Bson> {
         let mut tuple_variant = Document::new();
         tuple_variant.insert(self.name, self.inner);
         Ok(tuple_variant.into())
@@ -435,23 +435,23 @@ pub struct MapSerializer {
 
 impl SerializeMap for MapSerializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
-    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> EncoderResult<()> {
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> crate::ser::Result<()> {
         self.next_key = match to_bson(&key)? {
             Bson::String(s) => Some(s),
-            other => return Err(EncoderError::InvalidMapKeyType { key: other }),
+            other => return Err(Error::InvalidMapKeyType { key: other }),
         };
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> EncoderResult<()> {
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> crate::ser::Result<()> {
         let key = self.next_key.take().unwrap_or_default();
         self.inner.insert(key, to_bson(&value)?);
         Ok(())
     }
 
-    fn end(self) -> EncoderResult<Bson> {
+    fn end(self) -> crate::ser::Result<Bson> {
         Ok(Bson::from_extended_document(self.inner))
     }
 }
@@ -463,18 +463,18 @@ pub struct StructSerializer {
 
 impl SerializeStruct for StructSerializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
     fn serialize_field<T: ?Sized + Serialize>(
         &mut self,
         key: &'static str,
         value: &T,
-    ) -> EncoderResult<()> {
+    ) -> crate::ser::Result<()> {
         self.inner.insert(key, to_bson(value)?);
         Ok(())
     }
 
-    fn end(self) -> EncoderResult<Bson> {
+    fn end(self) -> crate::ser::Result<Bson> {
         Ok(Bson::from_extended_document(self.inner))
     }
 }
@@ -487,18 +487,18 @@ pub struct StructVariantSerializer {
 
 impl SerializeStructVariant for StructVariantSerializer {
     type Ok = Bson;
-    type Error = EncoderError;
+    type Error = Error;
 
     fn serialize_field<T: ?Sized + Serialize>(
         &mut self,
         key: &'static str,
         value: &T,
-    ) -> EncoderResult<()> {
+    ) -> crate::ser::Result<()> {
         self.inner.insert(key, to_bson(value)?);
         Ok(())
     }
 
-    fn end(self) -> EncoderResult<Bson> {
+    fn end(self) -> crate::ser::Result<Bson> {
         let var = Bson::from_extended_document(self.inner);
 
         let mut struct_variant = Document::new();
@@ -512,7 +512,7 @@ impl Serialize for Timestamp {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         let value = Bson::Timestamp(*self);
         value.serialize(serializer)
@@ -523,7 +523,7 @@ impl Serialize for Regex {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         let value = Bson::RegularExpression(self.clone());
         value.serialize(serializer)
@@ -534,7 +534,7 @@ impl Serialize for JavaScriptCodeWithScope {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         let value = Bson::JavaScriptCodeWithScope(self.clone());
         value.serialize(serializer)
@@ -545,7 +545,7 @@ impl Serialize for Binary {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         let value = Bson::Binary(self.clone());
         value.serialize(serializer)
@@ -557,7 +557,7 @@ impl Serialize for Decimal128 {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         let value = Bson::Decimal128(self.clone());
         value.serialize(serializer)
@@ -568,7 +568,7 @@ impl Serialize for DateTime {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         // Cloning a `DateTime` is extremely cheap
         let value = Bson::DateTime(self.0);
@@ -580,7 +580,7 @@ impl Serialize for DbPointer {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         let value = Bson::DbPointer(self.clone());
         value.serialize(serializer)

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -1,6 +1,6 @@
 mod bson;
-mod encoder_decoder;
 mod macros;
 mod oid;
 mod ordered;
 mod ser;
+mod serializer_deserializer;

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -2,13 +2,13 @@
 use bson::decimal128::Decimal128;
 use bson::{
     doc,
+    document::ValueAccessError,
     oid::ObjectId,
     spec::BinarySubtype,
     Binary,
     Bson,
     Document,
     Timestamp,
-    ValueAccessError,
 };
 use chrono::Utc;
 

--- a/tests/modules/ser.rs
+++ b/tests/modules/ser.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
-use bson::{from_bson, oid::ObjectId, to_bson, Bson, EncoderError, EncoderResult};
+use bson::{from_bson, oid::ObjectId, to_bson, Bson};
 use std::{collections::BTreeMap, u16, u32, u64, u8};
 
 #[test]
@@ -76,8 +76,8 @@ fn dec128() {
 #[test]
 #[cfg(not(feature = "u2i"))]
 fn uint8() {
-    let obj_min: EncoderResult<Bson> = to_bson(&u8::MIN);
-    assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));
+    let obj_min: bson::ser::Result<Bson> = to_bson(&u8::MIN);
+    assert_matches!(obj_min, Err(bson::ser::Error::UnsupportedUnsignedType));
 }
 
 #[test]
@@ -95,8 +95,8 @@ fn uint8_u2i() {
 #[test]
 #[cfg(not(feature = "u2i"))]
 fn uint16() {
-    let obj_min: EncoderResult<Bson> = to_bson(&u16::MIN);
-    assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));
+    let obj_min: bson::ser::Result<Bson> = to_bson(&u16::MIN);
+    assert_matches!(obj_min, Err(bson::ser::Error::UnsupportedUnsignedType));
 }
 
 #[test]
@@ -114,8 +114,8 @@ fn uint16_u2i() {
 #[test]
 #[cfg(not(feature = "u2i"))]
 fn uint32() {
-    let obj_min: EncoderResult<Bson> = to_bson(&u32::MIN);
-    assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));
+    let obj_min: bson::ser::Result<Bson> = to_bson(&u32::MIN);
+    assert_matches!(obj_min, Err(bson::ser::Error::UnsupportedUnsignedType));
 }
 
 #[test]
@@ -133,8 +133,8 @@ fn uint32_u2i() {
 #[test]
 #[cfg(not(feature = "u2i"))]
 fn uint64() {
-    let obj_min: EncoderResult<Bson> = to_bson(&u64::MIN);
-    assert_matches!(obj_min, Err(EncoderError::UnsupportedUnsignedType));
+    let obj_min: bson::ser::Result<Bson> = to_bson(&u64::MIN);
+    assert_matches!(obj_min, Err(bson::ser::Error::UnsupportedUnsignedType));
 }
 
 #[test]
@@ -144,10 +144,10 @@ fn uint64_u2i() {
     let deser_min: u64 = from_bson(obj_min).unwrap();
     assert_eq!(deser_min, u64::MIN);
 
-    let obj_max: EncoderResult<Bson> = to_bson(&u64::MAX);
+    let obj_max: bson::ser::Result<Bson> = to_bson(&u64::MAX);
     assert_matches!(
         obj_max,
-        Err(EncoderError::UnsignedTypesValueExceedsRange(u64::MAX))
+        Err(bson::ser::Error::UnsignedTypesValueExceedsRange(u64::MAX))
     );
 }
 

--- a/tests/modules/serializer_deserializer.rs
+++ b/tests/modules/serializer_deserializer.rs
@@ -27,11 +27,11 @@ fn test_serialize_deserialize_floating_point() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -46,11 +46,11 @@ fn test_serialize_deserialize_utf8_string() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -65,11 +65,11 @@ fn test_serialize_deserialize_array() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -84,11 +84,11 @@ fn test_serialize_deserialize() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -100,11 +100,11 @@ fn test_serialize_deserialize_boolean() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -116,11 +116,11 @@ fn test_serialize_deserialize_null() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -135,11 +135,11 @@ fn test_serialize_deserialize_regexp() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -151,11 +151,11 @@ fn test_serialize_deserialize_javascript_code() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -172,11 +172,11 @@ fn test_serialize_deserialize_javascript_code_with_scope() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -188,11 +188,11 @@ fn test_serialize_deserialize_i32() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -206,11 +206,11 @@ fn test_serialize_deserialize_i64() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -227,11 +227,11 @@ fn test_serialize_deserialize_timestamp() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -248,11 +248,11 @@ fn test_serialize_binary_generic() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -266,11 +266,11 @@ fn test_serialize_deserialize_object_id() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -284,11 +284,11 @@ fn test_serialize_utc_date_time() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -302,11 +302,11 @@ fn test_serialize_deserialize_symbol() {
     let doc = doc! { "key": symbol };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -323,7 +323,7 @@ fn test_deserialize_utc_date_time_overflows() {
     raw.write_all(&raw0).unwrap();
     raw.write_u8(0).unwrap();
 
-    let deserialized = Document::deserialize(&mut Cursor::new(raw)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(raw)).unwrap();
 
     let expected = doc! { "A": Utc.timestamp(1_530_492_218, 999 * 1_000_000)};
     assert_eq!(deserialized, expected);
@@ -333,14 +333,14 @@ fn test_deserialize_utc_date_time_overflows() {
 fn test_deserialize_invalid_utf8_string_issue64() {
     let buffer = b"\x13\x00\x00\x00\x02\x01\x00\x00\x00\x00\x00\x00\x00foo\x00\x13\x05\x00\x00\x00";
 
-    assert!(Document::deserialize(&mut Cursor::new(buffer)).is_err());
+    assert!(Document::deserialize_from(&mut Cursor::new(buffer)).is_err());
 }
 
 #[test]
 fn test_deserialize_multiply_overflows_issue64() {
     let buffer = b"*\xc9*\xc9\t\x00\x00\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\x01\t\x00\x00\x01\x10";
 
-    assert!(Document::deserialize(&mut Cursor::new(&buffer[..])).is_err());
+    assert!(Document::deserialize_from(&mut Cursor::new(&buffer[..])).is_err());
 }
 
 #[cfg(feature = "decimal128")]
@@ -354,11 +354,11 @@ fn test_serialize_deserialize_decimal128() {
     let doc = doc! { "key": val };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -367,7 +367,7 @@ fn test_illegal_size() {
     let buffer = [
         0x06, 0xcc, 0xf9, 0x0a, 0x05, 0x00, 0x00, 0x03, 0x00, 0xff, 0xff,
     ];
-    assert!(Document::deserialize(&mut Cursor::new(&buffer[..])).is_err());
+    assert!(Document::deserialize_from(&mut Cursor::new(&buffer[..])).is_err());
 }
 
 #[test]
@@ -378,11 +378,11 @@ fn test_serialize_deserialize_undefined() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -394,11 +394,11 @@ fn test_serialize_deserialize_min_key() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -410,11 +410,11 @@ fn test_serialize_deserialize_max_key() {
     let doc = doc! {"key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -434,10 +434,10 @@ fn test_serialize_deserialize_db_pointer() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_doc(&mut buf).unwrap();
+    doc.serialize_to(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }

--- a/tests/modules/serializer_deserializer.rs
+++ b/tests/modules/serializer_deserializer.rs
@@ -27,11 +27,11 @@ fn test_serialize_deserialize_floating_point() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -46,11 +46,11 @@ fn test_serialize_deserialize_utf8_string() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -65,11 +65,11 @@ fn test_serialize_deserialize_array() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -84,11 +84,11 @@ fn test_serialize_deserialize() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -100,11 +100,11 @@ fn test_serialize_deserialize_boolean() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -116,11 +116,11 @@ fn test_serialize_deserialize_null() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -135,11 +135,11 @@ fn test_serialize_deserialize_regexp() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -151,11 +151,11 @@ fn test_serialize_deserialize_javascript_code() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -172,11 +172,11 @@ fn test_serialize_deserialize_javascript_code_with_scope() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -188,11 +188,11 @@ fn test_serialize_deserialize_i32() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -206,11 +206,11 @@ fn test_serialize_deserialize_i64() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -227,11 +227,11 @@ fn test_serialize_deserialize_timestamp() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -248,11 +248,11 @@ fn test_serialize_binary_generic() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -266,11 +266,11 @@ fn test_serialize_deserialize_object_id() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -284,11 +284,11 @@ fn test_serialize_utc_date_time() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -302,11 +302,11 @@ fn test_serialize_deserialize_symbol() {
     let doc = doc! { "key": symbol };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -323,7 +323,7 @@ fn test_deserialize_utc_date_time_overflows() {
     raw.write_all(&raw0).unwrap();
     raw.write_u8(0).unwrap();
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(raw)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(raw)).unwrap();
 
     let expected = doc! { "A": Utc.timestamp(1_530_492_218, 999 * 1_000_000)};
     assert_eq!(deserialized, expected);
@@ -333,14 +333,14 @@ fn test_deserialize_utc_date_time_overflows() {
 fn test_deserialize_invalid_utf8_string_issue64() {
     let buffer = b"\x13\x00\x00\x00\x02\x01\x00\x00\x00\x00\x00\x00\x00foo\x00\x13\x05\x00\x00\x00";
 
-    assert!(Document::deserialize_from(&mut Cursor::new(buffer)).is_err());
+    assert!(Document::from_reader(&mut Cursor::new(buffer)).is_err());
 }
 
 #[test]
 fn test_deserialize_multiply_overflows_issue64() {
     let buffer = b"*\xc9*\xc9\t\x00\x00\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\x01\t\x00\x00\x01\x10";
 
-    assert!(Document::deserialize_from(&mut Cursor::new(&buffer[..])).is_err());
+    assert!(Document::from_reader(&mut Cursor::new(&buffer[..])).is_err());
 }
 
 #[cfg(feature = "decimal128")]
@@ -354,11 +354,11 @@ fn test_serialize_deserialize_decimal128() {
     let doc = doc! { "key": val };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -367,7 +367,7 @@ fn test_illegal_size() {
     let buffer = [
         0x06, 0xcc, 0xf9, 0x0a, 0x05, 0x00, 0x00, 0x03, 0x00, 0xff, 0xff,
     ];
-    assert!(Document::deserialize_from(&mut Cursor::new(&buffer[..])).is_err());
+    assert!(Document::from_reader(&mut Cursor::new(&buffer[..])).is_err());
 }
 
 #[test]
@@ -378,11 +378,11 @@ fn test_serialize_deserialize_undefined() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -394,11 +394,11 @@ fn test_serialize_deserialize_min_key() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -410,11 +410,11 @@ fn test_serialize_deserialize_max_key() {
     let doc = doc! {"key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }
 
@@ -434,10 +434,10 @@ fn test_serialize_deserialize_db_pointer() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.serialize_to(&mut buf).unwrap();
+    doc.to_writer(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let deserialized = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    let deserialized = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     assert_eq!(deserialized, doc);
 }

--- a/tests/modules/serializer_deserializer.rs
+++ b/tests/modules/serializer_deserializer.rs
@@ -18,7 +18,7 @@ use chrono::{offset::TimeZone, Utc};
 use serde_json::json;
 
 #[test]
-fn test_encode_decode_floating_point() {
+fn test_serialize_deserialize_floating_point() {
     let src = 1020.123;
     let dst = vec![
         18, 0, 0, 0, 1, 107, 101, 121, 0, 68, 139, 108, 231, 251, 224, 143, 64, 0,
@@ -27,16 +27,16 @@ fn test_encode_decode_floating_point() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_utf8_string() {
+fn test_serialize_deserialize_utf8_string() {
     let src = "test你好吗".to_owned();
     let dst = vec![
         28, 0, 0, 0, 2, 107, 101, 121, 0, 14, 0, 0, 0, 116, 101, 115, 116, 228, 189, 160, 229, 165,
@@ -46,16 +46,16 @@ fn test_encode_decode_utf8_string() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_array() {
+fn test_serialize_deserialize_array() {
     let src = vec![Bson::Double(1.01), Bson::String("xyz".to_owned())];
     let dst = vec![
         37, 0, 0, 0, 4, 107, 101, 121, 0, 27, 0, 0, 0, 1, 48, 0, 41, 92, 143, 194, 245, 40, 240,
@@ -65,16 +65,16 @@ fn test_encode_decode_array() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode() {
+fn test_serialize_deserialize() {
     let src = doc! { "subkey": 1 };
     let dst = vec![
         27, 0, 0, 0, 3, 107, 101, 121, 0, 17, 0, 0, 0, 16, 115, 117, 98, 107, 101, 121, 0, 1, 0, 0,
@@ -84,48 +84,48 @@ fn test_encode_decode() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_boolean() {
+fn test_serialize_deserialize_boolean() {
     let src = true;
     let dst = vec![11, 0, 0, 0, 8, 107, 101, 121, 0, 1, 0];
 
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_null() {
+fn test_serialize_deserialize_null() {
     let src = Bson::Null;
     let dst = vec![10, 0, 0, 0, 10, 107, 101, 121, 0, 0];
 
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_regexp() {
+fn test_serialize_deserialize_regexp() {
     let src = Bson::RegularExpression(Regex {
         pattern: "1".to_owned(),
         options: "2".to_owned(),
@@ -135,32 +135,32 @@ fn test_encode_decode_regexp() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_javascript_code() {
+fn test_serialize_deserialize_javascript_code() {
     let src = Bson::JavaScriptCode("1".to_owned());
     let dst = vec![16, 0, 0, 0, 13, 107, 101, 121, 0, 2, 0, 0, 0, 49, 0, 0];
 
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_javascript_code_with_scope() {
+fn test_serialize_deserialize_javascript_code_with_scope() {
     let src = Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
         code: "1".to_owned(),
         scope: doc! {},
@@ -172,32 +172,32 @@ fn test_encode_decode_javascript_code_with_scope() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_i32() {
+fn test_serialize_deserialize_i32() {
     let src = 100i32;
     let dst = vec![14, 0, 0, 0, 16, 107, 101, 121, 0, 100, 0, 0, 0, 0];
 
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_i64() {
+fn test_serialize_deserialize_i64() {
     let src = 100i64;
     let dst = vec![
         18, 0, 0, 0, 18, 107, 101, 121, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -206,16 +206,16 @@ fn test_encode_decode_i64() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_timestamp() {
+fn test_serialize_deserialize_timestamp() {
     let src = Bson::Timestamp(Timestamp {
         time: 0,
         increment: 100,
@@ -227,16 +227,16 @@ fn test_encode_decode_timestamp() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_binary_generic() {
+fn test_serialize_binary_generic() {
     let src = Binary {
         subtype: BinarySubtype::Generic,
         bytes: vec![0, 1, 2, 3, 4],
@@ -248,16 +248,16 @@ fn test_encode_binary_generic() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_object_id() {
+fn test_serialize_deserialize_object_id() {
     let src = ObjectId::with_string("507f1f77bcf86cd799439011").unwrap();
     let dst = vec![
         22, 0, 0, 0, 7, 107, 101, 121, 0, 80, 127, 31, 119, 188, 248, 108, 215, 153, 67, 144, 17, 0,
@@ -266,16 +266,16 @@ fn test_encode_decode_object_id() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_utc_date_time() {
+fn test_serialize_utc_date_time() {
     let src = Utc.timestamp(1_286_705_410, 0);
     let dst = vec![
         18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0,
@@ -284,16 +284,16 @@ fn test_encode_utc_date_time() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_symbol() {
+fn test_serialize_deserialize_symbol() {
     let symbol = Bson::Symbol("abc".to_owned());
     let dst = vec![
         18, 0, 0, 0, 14, 107, 101, 121, 0, 4, 0, 0, 0, 97, 98, 99, 0, 0,
@@ -302,16 +302,16 @@ fn test_encode_decode_symbol() {
     let doc = doc! { "key": symbol };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_decode_utc_date_time_overflows() {
+fn test_deserialize_utc_date_time_overflows() {
     let t = 1_530_492_218 * 1_000 + 999;
 
     let mut raw0 = vec![0x09, b'A', 0x00];
@@ -323,29 +323,29 @@ fn test_decode_utc_date_time_overflows() {
     raw.write_all(&raw0).unwrap();
     raw.write_u8(0).unwrap();
 
-    let decoded = Document::decode(&mut Cursor::new(raw)).unwrap();
+    let deserialized = Document::deserialize(&mut Cursor::new(raw)).unwrap();
 
     let expected = doc! { "A": Utc.timestamp(1_530_492_218, 999 * 1_000_000)};
-    assert_eq!(decoded, expected);
+    assert_eq!(deserialized, expected);
 }
 
 #[test]
-fn test_decode_invalid_utf8_string_issue64() {
+fn test_deserialize_invalid_utf8_string_issue64() {
     let buffer = b"\x13\x00\x00\x00\x02\x01\x00\x00\x00\x00\x00\x00\x00foo\x00\x13\x05\x00\x00\x00";
 
-    assert!(Document::decode(&mut Cursor::new(buffer)).is_err());
+    assert!(Document::deserialize(&mut Cursor::new(buffer)).is_err());
 }
 
 #[test]
-fn test_decode_multiply_overflows_issue64() {
+fn test_deserialize_multiply_overflows_issue64() {
     let buffer = b"*\xc9*\xc9\t\x00\x00\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\xca\x01\t\x00\x00\x01\x10";
 
-    assert!(Document::decode(&mut Cursor::new(&buffer[..])).is_err());
+    assert!(Document::deserialize(&mut Cursor::new(&buffer[..])).is_err());
 }
 
 #[cfg(feature = "decimal128")]
 #[test]
-fn test_encode_decode_decimal128() {
+fn test_serialize_deserialize_decimal128() {
     let val = Bson::Decimal128(Decimal128::from_i32(0));
     let dst = vec![
         26, 0, 0, 0, 19, 107, 101, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 34, 0,
@@ -354,12 +354,12 @@ fn test_encode_decode_decimal128() {
     let doc = doc! { "key": val };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
@@ -367,59 +367,59 @@ fn test_illegal_size() {
     let buffer = [
         0x06, 0xcc, 0xf9, 0x0a, 0x05, 0x00, 0x00, 0x03, 0x00, 0xff, 0xff,
     ];
-    assert!(Document::decode(&mut Cursor::new(&buffer[..])).is_err());
+    assert!(Document::deserialize(&mut Cursor::new(&buffer[..])).is_err());
 }
 
 #[test]
-fn test_encode_decode_undefined() {
+fn test_serialize_deserialize_undefined() {
     let src = Bson::Undefined;
     let dst = vec![10, 0, 0, 0, 6, 107, 101, 121, 0, 0];
 
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_min_key() {
+fn test_serialize_deserialize_min_key() {
     let src = Bson::MinKey;
     let dst = vec![10, 0, 0, 0, 255, 107, 101, 121, 0, 0];
 
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_max_key() {
+fn test_serialize_deserialize_max_key() {
     let src = Bson::MaxKey;
     let dst = vec![10, 0, 0, 0, 127, 107, 101, 121, 0, 0];
 
     let doc = doc! {"key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }
 
 #[test]
-fn test_encode_decode_db_pointer() {
+fn test_serialize_deserialize_db_pointer() {
     let src = Bson::from(json!({
         "$dbPointer": {
             "$ref": "db.coll",
@@ -434,10 +434,10 @@ fn test_encode_decode_db_pointer() {
     let doc = doc! { "key": src };
 
     let mut buf = Vec::new();
-    doc.encode(&mut buf).unwrap();
+    doc.serialize_doc(&mut buf).unwrap();
 
     assert_eq!(buf, dst);
 
-    let decoded = Document::decode(&mut Cursor::new(buf)).unwrap();
-    assert_eq!(decoded, doc);
+    let deserialized = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(deserialized, doc);
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -367,9 +367,9 @@ fn test_byte_vec() {
     );
 
     // let mut buf = Vec::new();
-    // b.as_document().unwrap().serialize_to(&mut buf).unwrap();
+    // b.as_document().unwrap().to_writer(&mut buf).unwrap();
 
-    // let xb = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
+    // let xb = Document::from_reader(&mut Cursor::new(buf)).unwrap();
     // assert_eq!(b.as_document().unwrap(), &xb);
 }
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::blacklisted_name)]
 
-use bson::{bson, doc, spec::BinarySubtype, Binary, Bson, Decoder, Encoder};
+use bson::{bson, doc, spec::BinarySubtype, Binary, Bson, Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
@@ -11,8 +11,8 @@ use std::collections::BTreeMap;
 fn test_ser_vec() {
     let vec = vec![1, 2, 3];
 
-    let encoder = Encoder::new();
-    let result = vec.serialize(encoder).unwrap();
+    let serializer = Serializer::new();
+    let result = vec.serialize(serializer).unwrap();
 
     let expected = bson!([1, 2, 3]);
     assert_eq!(expected, result);
@@ -24,8 +24,8 @@ fn test_ser_map() {
     map.insert("x", 0);
     map.insert("y", 1);
 
-    let encoder = Encoder::new();
-    let result = map.serialize(encoder).unwrap();
+    let serializer = Serializer::new();
+    let result = map.serialize(serializer).unwrap();
 
     let expected = bson!({ "x": 0, "y": 1 });
     assert_eq!(expected, result);
@@ -35,8 +35,8 @@ fn test_ser_map() {
 fn test_de_vec() {
     let bson = bson!([1, 2, 3]);
 
-    let decoder = Decoder::new(bson);
-    let vec = Vec::<i32>::deserialize(decoder).unwrap();
+    let deserializer = Deserializer::new(bson);
+    let vec = Vec::<i32>::deserialize(deserializer).unwrap();
 
     let expected = vec![1, 2, 3];
     assert_eq!(expected, vec);
@@ -46,8 +46,8 @@ fn test_de_vec() {
 fn test_de_map() {
     let bson = bson!({ "x": 0, "y": 1 });
 
-    let decoder = Decoder::new(bson);
-    let map = BTreeMap::<String, i32>::deserialize(decoder).unwrap();
+    let deserializer = Deserializer::new(bson);
+    let map = BTreeMap::<String, i32>::deserialize(deserializer).unwrap();
 
     let mut expected = BTreeMap::new();
     expected.insert("x".to_string(), 0);
@@ -367,9 +367,9 @@ fn test_byte_vec() {
     );
 
     // let mut buf = Vec::new();
-    // b.as_document().unwrap().encode(&mut buf).unwrap();
+    // b.as_document().unwrap().serialize_doc(&mut buf).unwrap();
 
-    // let xb = Document::decode(&mut Cursor::new(buf)).unwrap();
+    // let xb = Document::deserialize(&mut Cursor::new(buf)).unwrap();
     // assert_eq!(b.as_document().unwrap(), &xb);
 }
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -367,9 +367,9 @@ fn test_byte_vec() {
     );
 
     // let mut buf = Vec::new();
-    // b.as_document().unwrap().serialize_doc(&mut buf).unwrap();
+    // b.as_document().unwrap().serialize_to(&mut buf).unwrap();
 
-    // let xb = Document::deserialize(&mut Cursor::new(buf)).unwrap();
+    // let xb = Document::deserialize_from(&mut Cursor::new(buf)).unwrap();
     // assert_eq!(b.as_document().unwrap(), &xb);
 }
 

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -55,7 +55,7 @@ fn run_test(test: TestFile) {
     for valid in test.valid {
         let description = format!("{}: {}", test.description, valid.description);
 
-        let bson_to_native_cb = Document::deserialize_from(
+        let bson_to_native_cb = Document::from_reader(
             &mut hex::decode(&valid.canonical_bson)
                 .expect(&description)
                 .as_slice(),
@@ -64,7 +64,7 @@ fn run_test(test: TestFile) {
 
         let mut native_to_bson_bson_to_native_cv = Vec::new();
         bson_to_native_cb
-            .serialize_to(&mut native_to_bson_bson_to_native_cv)
+            .to_writer(&mut native_to_bson_bson_to_native_cv)
             .expect(&description);
 
         // TODO RUST-36: Enable decimal128 tests.
@@ -154,7 +154,7 @@ fn run_test(test: TestFile) {
             json_to_native_cej
                 .as_document()
                 .unwrap()
-                .serialize_to(&mut native_to_bson_json_to_native_cej)
+                .to_writer(&mut native_to_bson_json_to_native_cej)
                 .unwrap();
 
             // TODO RUST-36: Enable decimal128 tests.
@@ -172,12 +172,12 @@ fn run_test(test: TestFile) {
 
         if let Some(db) = valid.degenerate_bson {
             let bson_to_native_db =
-                Document::deserialize_from(&mut hex::decode(&db).expect(&description).as_slice())
+                Document::from_reader(&mut hex::decode(&db).expect(&description).as_slice())
                     .expect(&description);
 
             let mut native_to_bson_bson_to_native_db = Vec::new();
             bson_to_native_db
-                .serialize_to(&mut native_to_bson_bson_to_native_db)
+                .to_writer(&mut native_to_bson_bson_to_native_db)
                 .unwrap();
 
             assert_eq!(
@@ -215,7 +215,7 @@ fn run_test(test: TestFile) {
                 json_to_native_dej
                     .as_document()
                     .unwrap()
-                    .serialize_to(&mut native_to_bson_json_to_native_dej)
+                    .to_writer(&mut native_to_bson_json_to_native_dej)
                     .unwrap();
 
                 // TODO RUST-36: Enable decimal128 tests.

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -55,7 +55,7 @@ fn run_test(test: TestFile) {
     for valid in test.valid {
         let description = format!("{}: {}", test.description, valid.description);
 
-        let bson_to_native_cb = Document::deserialize(
+        let bson_to_native_cb = Document::deserialize_from(
             &mut hex::decode(&valid.canonical_bson)
                 .expect(&description)
                 .as_slice(),
@@ -64,7 +64,7 @@ fn run_test(test: TestFile) {
 
         let mut native_to_bson_bson_to_native_cv = Vec::new();
         bson_to_native_cb
-            .serialize_doc(&mut native_to_bson_bson_to_native_cv)
+            .serialize_to(&mut native_to_bson_bson_to_native_cv)
             .expect(&description);
 
         // TODO RUST-36: Enable decimal128 tests.
@@ -154,7 +154,7 @@ fn run_test(test: TestFile) {
             json_to_native_cej
                 .as_document()
                 .unwrap()
-                .serialize_doc(&mut native_to_bson_json_to_native_cej)
+                .serialize_to(&mut native_to_bson_json_to_native_cej)
                 .unwrap();
 
             // TODO RUST-36: Enable decimal128 tests.
@@ -172,12 +172,12 @@ fn run_test(test: TestFile) {
 
         if let Some(db) = valid.degenerate_bson {
             let bson_to_native_db =
-                Document::deserialize(&mut hex::decode(&db).expect(&description).as_slice())
+                Document::deserialize_from(&mut hex::decode(&db).expect(&description).as_slice())
                     .expect(&description);
 
             let mut native_to_bson_bson_to_native_db = Vec::new();
             bson_to_native_db
-                .serialize_doc(&mut native_to_bson_bson_to_native_db)
+                .serialize_to(&mut native_to_bson_bson_to_native_db)
                 .unwrap();
 
             assert_eq!(
@@ -215,7 +215,7 @@ fn run_test(test: TestFile) {
                 json_to_native_dej
                     .as_document()
                     .unwrap()
-                    .serialize_doc(&mut native_to_bson_json_to_native_dej)
+                    .serialize_to(&mut native_to_bson_json_to_native_dej)
                     .unwrap();
 
                 // TODO RUST-36: Enable decimal128 tests.

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -55,7 +55,7 @@ fn run_test(test: TestFile) {
     for valid in test.valid {
         let description = format!("{}: {}", test.description, valid.description);
 
-        let bson_to_native_cb = Document::decode(
+        let bson_to_native_cb = Document::deserialize(
             &mut hex::decode(&valid.canonical_bson)
                 .expect(&description)
                 .as_slice(),
@@ -64,7 +64,7 @@ fn run_test(test: TestFile) {
 
         let mut native_to_bson_bson_to_native_cv = Vec::new();
         bson_to_native_cb
-            .encode(&mut native_to_bson_bson_to_native_cv)
+            .serialize_doc(&mut native_to_bson_bson_to_native_cv)
             .expect(&description);
 
         // TODO RUST-36: Enable decimal128 tests.
@@ -154,7 +154,7 @@ fn run_test(test: TestFile) {
             json_to_native_cej
                 .as_document()
                 .unwrap()
-                .encode(&mut native_to_bson_json_to_native_cej)
+                .serialize_doc(&mut native_to_bson_json_to_native_cej)
                 .unwrap();
 
             // TODO RUST-36: Enable decimal128 tests.
@@ -172,12 +172,12 @@ fn run_test(test: TestFile) {
 
         if let Some(db) = valid.degenerate_bson {
             let bson_to_native_db =
-                Document::decode(&mut hex::decode(&db).expect(&description).as_slice())
+                Document::deserialize(&mut hex::decode(&db).expect(&description).as_slice())
                     .expect(&description);
 
             let mut native_to_bson_bson_to_native_db = Vec::new();
             bson_to_native_db
-                .encode(&mut native_to_bson_bson_to_native_db)
+                .serialize_doc(&mut native_to_bson_bson_to_native_db)
                 .unwrap();
 
             assert_eq!(
@@ -215,7 +215,7 @@ fn run_test(test: TestFile) {
                 json_to_native_dej
                     .as_document()
                     .unwrap()
-                    .encode(&mut native_to_bson_json_to_native_dej)
+                    .serialize_doc(&mut native_to_bson_json_to_native_dej)
                     .unwrap();
 
                 // TODO RUST-36: Enable decimal128 tests.


### PR DESCRIPTION
This PR updates the bson API language to use "serialize" and "deserialize" in place of "encode" and "decode" respectively.