### PR TITLE
RUST-454 Implement error case BSON corpus tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = "1"
 chrono = "0.4"
 libc = "0.2"
 rand = "0.7"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 time = "0.1"
 linked-hash-map = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ base64 = "0.12.1"
 
 [dev-dependencies]
 assert_matches = "1.2"
-serde_derive = "1.0"
 serde_bytes = "0.11"
 pretty_assertions = "0.6.1"
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -735,31 +735,7 @@ impl Bson {
 
             ["$date"] => {
                 if let Ok(date) = doc.get_i64("$date") {
-                    let mut num_secs = date / 1000;
-                    let mut num_millis = date % 1000;
-
-                    // The chrono API only lets us create a DateTime with an i64 number of seconds
-                    // and a u32 number of nanoseconds. In the case of a negative timestamp, this
-                    // means that we need to turn the negative fractional part into a positive and
-                    // shift the number of seconds down. For example:
-                    //
-                    //     date       = -4300 ms
-                    //     num_secs   = date / 1000 = -4300 / 1000 = -4
-                    //     num_millis = date % 1000 = -4300 % 1000 = -300
-                    //
-                    // Since num_millis is less than 0:
-                    //     num_secs   = num_secs -1 = -4 - 1 = -5
-                    //     num_millis = num_nanos + 1000 = -300 + 1000 = 700
-                    //
-                    // Instead of -4 seconds and -300 milliseconds, we now have -5 seconds and +700
-                    // milliseconds, which expresses the same timestamp, but in a way we can create
-                    // a DateTime with.
-                    if num_millis < 0 {
-                        num_secs -= 1;
-                        num_millis += 1000;
-                    };
-
-                    return Bson::DateTime(Utc.timestamp(num_secs, num_millis as u32 * 1_000_000));
+                    return Bson::DateTime(DateTime::from_i64(date).into());
                 }
 
                 if let Ok(date) = doc.get_str("$date") {
@@ -1009,6 +985,37 @@ impl Timestamp {
 /// ```
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Copy, Clone)]
 pub struct DateTime(pub chrono::DateTime<Utc>);
+
+impl DateTime {
+    pub(crate) fn from_i64(date: i64) -> Self {
+        let mut num_secs = date / 1000;
+        let mut num_millis = date % 1000;
+
+        // The chrono API only lets us create a DateTime with an i64 number of seconds
+        // and a u32 number of nanoseconds. In the case of a negative timestamp, this
+        // means that we need to turn the negative fractional part into a positive and
+        // shift the number of seconds down. For example:
+        //
+        //     date       = -4300 ms
+        //     num_secs   = date / 1000 = -4300 / 1000 = -4
+        //     num_millis = date % 1000 = -4300 % 1000 = -300
+        //
+        // Since num_millis is less than 0:
+        //     num_secs   = num_secs -1 = -4 - 1 = -5
+        //     num_millis = num_nanos + 1000 = -300 + 1000 = 700
+        //
+        // Instead of -4 seconds and -300 milliseconds, we now have -5 seconds and +700
+        // milliseconds, which expresses the same timestamp, but in a way we can create
+        // a DateTime with.
+        if num_millis < 0 {
+            num_secs -= 1;
+            num_millis += 1000;
+        };
+
+        Utc.timestamp(num_secs, num_millis as u32 * 1_000_000)
+            .into()
+    }
+}
 
 impl Deref for DateTime {
     type Target = chrono::DateTime<Utc>;

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -22,23 +22,18 @@
 //! BSON definition
 
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::{self, Debug, Display},
     ops::{Deref, DerefMut},
 };
 
 use chrono::{DateTime, Datelike, SecondsFormat, TimeZone, Utc};
-use serde::de::{Error, Unexpected};
 use serde_json::{json, Value};
 
 pub use crate::document::Document;
 use crate::{
-    extjson,
     oid::{self, ObjectId},
     spec::{BinarySubtype, ElementType},
     Decimal128,
-    DecoderError,
-    DecoderResult,
 };
 
 /// Possible BSON value types.

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -300,6 +300,7 @@ impl From<DbPointer> for Bson {
     }
 }
 
+/// This will create the [relaxed Extended JSON v2](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) representation of the provided [`Bson`](../enum.Bson.html).
 impl From<Bson> for Value {
     fn from(bson: Bson) -> Self {
         bson.into_relaxed_extjson()

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -26,7 +26,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use chrono::{DateTime, Datelike, SecondsFormat, TimeZone, Utc};
+use chrono::{Datelike, SecondsFormat, TimeZone, Utc};
 use serde_json::{json, Value};
 
 pub use crate::document::Document;
@@ -203,9 +203,9 @@ impl From<Binary> for Bson {
     }
 }
 
-impl From<TimeStamp> for Bson {
-    fn from(ts: TimeStamp) -> Bson {
-        Bson::TimeStamp(ts)
+impl From<Timestamp> for Bson {
+    fn from(ts: Timestamp) -> Bson {
+        Bson::Timestamp(ts)
     }
 }
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -236,6 +236,12 @@ impl From<Binary> for Bson {
     }
 }
 
+impl From<TimeStamp> for Bson {
+    fn from(ts: TimeStamp) -> Bson {
+        Bson::TimeStamp(ts)
+    }
+}
+
 impl<T> From<&T> for Bson
 where
     T: Clone + Into<Bson>,
@@ -331,17 +337,55 @@ impl TryFrom<Value> for Bson {
     type Error = DecoderError;
 
     fn try_from(value: Value) -> DecoderResult<Self> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct ExtJsonInt64 {
+            #[serde(rename = "$numberLong")]
+            value: String,
+        }
+
+        impl ExtJsonInt64 {
+            fn parse(self) -> DecoderResult<i64> {
+                let i: i64 = self.value.parse().map_err(|_| {
+                    DecoderError::invalid_value(
+                        Unexpected::Str(self.value.as_str()),
+                        &"expected i64 as a string",
+                    )
+                })?;
+                Ok(i)
+            }
+        }
+
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct ExtJsonOid {
+            #[serde(rename = "$oid")]
+            oid: String,
+        }
+
+        impl ExtJsonOid {
+            fn parse(self) -> DecoderResult<oid::ObjectId> {
+                let oid = ObjectId::with_string(self.oid.as_str())?;
+                Ok(oid)
+            }
+        }
+
         if let Value::Object(ref obj) = value {
             if obj.contains_key("$oid") {
+                let oid: ExtJsonOid = serde_json::from_value(value.clone())?;
+                return Ok(Bson::ObjectId(oid.parse()?));
+            }
+
+            if obj.contains_key("$symbol") {
                 #[derive(Deserialize)]
                 #[serde(deny_unknown_fields)]
-                struct ExtJsonOid {
-                    #[serde(rename = "$oid")]
-                    oid: String,
+                struct ExtJsonSymbol {
+                    #[serde(rename = "$symbol")]
+                    value: String,
                 }
 
-                let oid: ExtJsonOid = serde_json::from_value(value.clone())?;
-                return Ok(Bson::ObjectId(ObjectId::with_string(oid.oid.as_str())?));
+                let symbol: ExtJsonSymbol = serde_json::from_value(value.clone())?;
+                return Ok(Bson::Symbol(symbol.value));
             }
 
             if obj.contains_key("$regularExpression") {
@@ -360,76 +404,350 @@ impl TryFrom<Value> for Bson {
                 }
 
                 let regex: ExtJsonRegex = serde_json::from_value(value.clone())?;
+
+                let mut chars: Vec<_> = regex.regular_expression.options.chars().collect();
+                chars.sort();
+                let options: String = chars.into_iter().collect();
+
                 return Ok(Regex {
                     pattern: regex.regular_expression.pattern,
-                    options: regex.regular_expression.options,
+                    options,
                 }
                 .into());
             }
 
-            return Ok(Bson::Document(
-                obj.into_iter()
-                    .map(|(k, v)| -> DecoderResult<(String, Bson)> {
-                        let value: Bson = v.clone().try_into()?;
-                        Ok((k.clone(), value))
-                    })
-                    .collect::<DecoderResult<Vec<(String, Bson)>>>()?
-                    .into_iter()
-                    .collect(),
-            ));
+            if obj.contains_key("$numberInt") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct CanonicalExtJsonInt32 {
+                    #[serde(rename = "$numberInt")]
+                    value: String,
+                }
+                let int: CanonicalExtJsonInt32 = serde_json::from_value(value.clone())?;
+                let i: i32 = int.value.parse().map_err(|_| {
+                    DecoderError::invalid_value(
+                        Unexpected::Str(int.value.as_str()),
+                        &"expected i32",
+                    )
+                })?;
+                return Ok(i.into());
+            }
+
+            if obj.contains_key("$numberLong") {
+                let int: ExtJsonInt64 = serde_json::from_value(value.clone())?;
+                return Ok(Bson::I64(int.parse()?));
+            }
+
+            if obj.contains_key("$numberDouble") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct CanonicalExtJsonDouble {
+                    #[serde(rename = "$numberDouble")]
+                    value: String,
+                }
+
+                let double: CanonicalExtJsonDouble = serde_json::from_value(value.clone())?;
+                return match double.value.as_str() {
+                    "Infinity" => Ok(Bson::FloatingPoint(f64::INFINITY)),
+                    "-Infinity" => Ok(Bson::FloatingPoint(f64::NEG_INFINITY)),
+                    "NaN" => Ok(Bson::FloatingPoint(f64::NAN)),
+                    other => {
+                        let d: f64 = other.parse().map_err(|_| {
+                            DecoderError::invalid_value(
+                                Unexpected::Str(other),
+                                &"expected bson double as string",
+                            )
+                        })?;
+                        Ok(Bson::FloatingPoint(d))
+                    }
+                };
+            }
+
+            if obj.contains_key("$binary") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonBinary {
+                    #[serde(rename = "$binary")]
+                    body: ExtJsonBinaryBody,
+                }
+
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonBinaryBody {
+                    base64: String,
+                    #[serde(rename = "subType")]
+                    subtype: String,
+                }
+
+                let binary: ExtJsonBinary = serde_json::from_value(value.clone())?;
+                let bytes = base64::decode(binary.body.base64.as_str()).map_err(|_| {
+                    DecoderError::invalid_value(
+                        Unexpected::Str(binary.body.base64.as_str()),
+                        &"base64 encoded bytes",
+                    )
+                })?;
+                let subtype = hex::decode(binary.body.subtype.as_str()).map_err(|_| {
+                    DecoderError::invalid_value(
+                        Unexpected::Str(binary.body.subtype.as_str()),
+                        &"hexadecimal number as a string",
+                    )
+                })?;
+
+                return if subtype.len() == 1 {
+                    Ok(Bson::Binary(Binary {
+                        bytes,
+                        subtype: subtype[0].into(),
+                    }))
+                } else {
+                    Err(DecoderError::invalid_value(
+                        Unexpected::Bytes(subtype.as_slice()),
+                        &"one byte subtype",
+                    ))
+                };
+            }
+
+            if obj.contains_key("$code") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonCode {
+                    #[serde(rename = "$code")]
+                    code: String,
+
+                    #[serde(rename = "$scope")]
+                    #[serde(default)]
+                    scope: Option<serde_json::Map<String, serde_json::Value>>,
+                }
+
+                let code_w_scope: ExtJsonCode = serde_json::from_value(value.clone())?;
+                return match code_w_scope.scope {
+                    Some(scope) => Ok(JavaScriptCodeWithScope {
+                        code: code_w_scope.code,
+                        scope: Document::from_ext_json(scope)?,
+                    }
+                    .into()),
+                    None => Ok(Bson::JavaScriptCode(code_w_scope.code)),
+                };
+            }
+
+            if obj.contains_key("$timestamp") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonTimestamp {
+                    #[serde(rename = "$timestamp")]
+                    body: ExtJsonTimestampBody,
+                }
+
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonTimestampBody {
+                    t: u32,
+                    i: u32,
+                }
+
+                let ts: ExtJsonTimestamp = serde_json::from_value(value.clone())?;
+                return Ok(TimeStamp {
+                    time: ts.body.t,
+                    increment: ts.body.i,
+                }
+                .into());
+            }
+
+            if obj.contains_key("$date") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonDateTime {
+                    #[serde(rename = "$date")]
+                    body: ExtJsonDateTimeBody,
+                }
+
+                #[derive(Deserialize)]
+                #[serde(untagged)]
+                enum ExtJsonDateTimeBody {
+                    Canonical(ExtJsonInt64),
+                    Relaxed(String),
+                }
+
+                let extjson_datetime: ExtJsonDateTime = serde_json::from_value(value.clone())?;
+                match extjson_datetime.body {
+                    ExtJsonDateTimeBody::Canonical(date) => {
+                        let date = date.parse()?;
+
+                        let mut num_secs = date / 1000;
+                        let mut num_millis = date % 1000;
+
+                        // The chrono API only lets us create a DateTime with an i64 number of seconds
+                        // and a u32 number of nanoseconds. In the case of a negative timestamp, this
+                        // means that we need to turn the negative fractional part into a positive and
+                        // shift the number of seconds down. For example:
+                        //
+                        //     date       = -4300 ms
+                        //     num_secs   = date / 1000 = -4300 / 1000 = -4
+                        //     num_millis = date % 1000 = -4300 % 1000 = -300
+                        //
+                        // Since num_millis is less than 0:
+                        //     num_secs   = num_secs -1 = -4 - 1 = -5
+                        //     num_millis = num_nanos + 1000 = -300 + 1000 = 700
+                        //
+                        // Instead of -4 seconds and -300 milliseconds, we now have -5 seconds and +700
+                        // milliseconds, which expresses the same timestamp, but in a way we can create
+                        // a DateTime with.
+                        if num_millis < 0 {
+                            num_secs -= 1;
+                            num_millis += 1000;
+                        };
+
+                        return Ok(Bson::UtcDatetime(
+                            Utc.timestamp(num_secs, num_millis as u32 * 1_000_000),
+                        ));
+                    }
+                    ExtJsonDateTimeBody::Relaxed(date) => {
+                        let datetime =
+                            DateTime::parse_from_rfc3339(date.as_str()).map_err(|_| {
+                                DecoderError::invalid_value(
+                                    Unexpected::Str(date.as_str()),
+                                    &"rfc3339 formatted utc datetime",
+                                )
+                            })?;
+                        return Ok(Bson::UtcDatetime(datetime.into()));
+                    }
+                }
+            }
+
+            if obj.contains_key("$minKey") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonMinKey {
+                    #[serde(rename = "$minKey")]
+                    value: u8,
+                }
+                let min_key: ExtJsonMinKey = serde_json::from_value(value.clone())?;
+                return if min_key.value == 1 {
+                    Ok(Bson::MinKey)
+                } else {
+                    Err(DecoderError::invalid_value(
+                        Unexpected::Unsigned(min_key.value as u64),
+                        &"value of $minKey should always be 1",
+                    ))
+                };
+            }
+
+            if obj.contains_key("$maxKey") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonMaxKey {
+                    #[serde(rename = "$maxKey")]
+                    value: u8,
+                }
+                let max_key: ExtJsonMaxKey = serde_json::from_value(value.clone())?;
+                return if max_key.value == 1 {
+                    Ok(Bson::MaxKey)
+                } else {
+                    Err(DecoderError::invalid_value(
+                        Unexpected::Unsigned(max_key.value as u64),
+                        &"value of $maxKey should always be 1",
+                    ))
+                };
+            }
+
+            if obj.contains_key("$dbPointer") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonDbPointer {
+                    #[serde(rename = "$dbPointer")]
+                    body: ExtJsonDbPointerBody,
+                }
+
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonDbPointerBody {
+                    #[serde(rename = "$ref")]
+                    ref_ns: String,
+
+                    #[serde(rename = "$id")]
+                    id: ExtJsonOid,
+                }
+                let db_ptr: ExtJsonDbPointer = serde_json::from_value(value.clone())?;
+
+                return Ok(Bson::DbPointer(DbPointer {
+                    namespace: db_ptr.body.ref_ns,
+                    id: db_ptr.body.id.parse()?,
+                }));
+            }
+
+            if obj.contains_key("$numberDecimal") {
+                #[cfg(feature = "decimal128")]
+                {
+                    #[derive(Deserialize)]
+                    #[serde(deny_unknown_fields)]
+                    struct ExtJsonDecimal128 {
+                        #[serde(rename = "$numberDecimal")]
+                        value: String,
+                    }
+                    let decimal: ExtJsonDecimal128 = serde_json::from_value(value.clone())?;
+                    let decimal128: Decimal128 = decimal.value.parse().map_err(|_| {
+                        DecoderError::invalid_value(
+                            Unexpected::Str(decimal.value.as_str()),
+                            &"decimal128 value as a string",
+                        )
+                    })?;
+                    return Ok(Bson::Decimal128(decimal128));
+                }
+
+                #[cfg(not(feature = "decimal128"))]
+                return Err(DecoderError::custom(
+                    "decimal128 extjson support not implemented",
+                ));
+            }
+
+            if obj.contains_key("$undefined") {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct ExtJsonUndefined {
+                    #[serde(rename = "$undefined")]
+                    value: bool,
+                }
+                let undefined: ExtJsonUndefined = serde_json::from_value(value.clone())?;
+                return if undefined.value {
+                    Ok(Bson::Undefined)
+                } else {
+                    Err(DecoderError::invalid_value(
+                        Unexpected::Bool(false),
+                        &"$undefined should always be true",
+                    ))
+                };
+            }
+
+            return Ok(Bson::Document(Document::from_ext_json(obj.clone())?));
         }
 
-        match Bson::from_value_no_parse(value) {
-            Bson::Document(doc) => Bson::try_from_extended_document(doc),
-            other => Ok(other),
+        match value {
+            Value::Number(x) => x
+                .as_i64()
+                .map(|i| {
+                    if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                        Bson::I32(i as i32)
+                    } else {
+                        Bson::I64(i)
+                    }
+                })
+                .or_else(|| x.as_u64().map(Bson::from))
+                .or_else(|| x.as_f64().map(Bson::from))
+                .ok_or_else(|| {
+                    DecoderError::invalid_value(
+                        Unexpected::Other(format!("{}", x).as_str()),
+                        &"a number that could fit in i32, i64, or f64",
+                    )
+                }),
+            Value::String(x) => Ok(x.into()),
+            Value::Bool(x) => Ok(x.into()),
+            Value::Array(x) => Ok(Bson::Array(
+                x.into_iter()
+                    .map(Bson::try_from)
+                    .collect::<DecoderResult<Vec<Bson>>>()?,
+            )),
+            Value::Null => Ok(Bson::Null),
+            _ => panic!("woo"),
         }
-
-        // match value {
-        //     Value::Number(x) => x
-        //         .as_i64()
-        //         .map(|i| {
-        //             if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
-        //                 Bson::I32(i as i32)
-        //             } else {
-        //                 Bson::I64(i)
-        //             }
-        //         })
-        //         .or_else(|| x.as_u64().map(Bson::from))
-        //         .or_else(|| x.as_f64().map(Bson::from))
-        //         .ok_or_else(|| {
-        //             DecoderError::invalid_value(
-        //                 Unexpected::Other(format!("{}", x).as_str()),
-        //                 &"a number that could fit in i32, i64, or f64",
-        //             )
-        //         }),
-        //     Value::String(x) => Ok(x.into()),
-        //     Value::Bool(x) => Ok(x.into()),
-        //     Value::Array(x) => Ok(Bson::Array(
-        //         x.into_iter()
-        //             .map(Bson::try_from)
-        //             .collect::<DecoderResult<Vec<Bson>>>()?,
-        //     )),
-        //     Value::Object(x) => Bson::try_from_extended_document(
-        //         x.into_iter()
-        //             .map(|(k, v)| (k, Bson::try_from(v).unwrap()))
-        //             .collect(),
-        //     ),
-        //     Value::Null => Ok(Bson::Null),
-        //     Ok(Bson::Document(
-        //     doc.into_iter()
-        //         .map(|(k, v)| -> DecoderResult<(String, Bson)> {
-        //             let v = match v {
-        //                 Bson::Document(v) => Bson::try_from_extended_document(v)?,
-        //                 other => other,
-        //             };
-
-        //             Ok((k, v))
-        //         })
-        //         .collect::<DecoderResult<Vec<(String, Bson)>>>()?
-        //         .into_iter()
-        //         .collect(),
-        // ))
-        //    }
     }
 }
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -997,7 +997,7 @@ impl Timestamp {
 ///
 /// Just a helper for convenience
 ///
-/// ```rust,ignore
+/// ```rust
 /// use serde::{Serialize, Deserialize};
 /// use bson::DateTime;
 ///

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -1,6 +1,6 @@
 use std::{error, fmt, fmt::Display, io, string};
 
-use serde::de::{self, Error as _, Unexpected};
+use serde::de::{self, Unexpected};
 
 use crate::Bson;
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -2,7 +2,7 @@ use std::{error, fmt, fmt::Display, io, string};
 
 use serde::de::{self, Error as _, Unexpected};
 
-use crate::{document::ValueAccessError, oid, Bson};
+use crate::Bson;
 
 /// Possible errors that can arise during decoding.
 #[derive(Debug)]
@@ -26,9 +26,7 @@ pub enum Error {
     },
 
     /// There was an error with the syntactical structure of the BSON.
-    SyntaxError {
-        message: String,
-    },
+    SyntaxError { message: String },
 
     /// The end of the BSON input was reached too soon.
     EndOfStream,
@@ -39,16 +37,12 @@ pub enum Error {
     /// An ambiguous timestamp was encountered while decoding.
     AmbiguousTimestamp(i64),
 
-    InvalidObjectId(oid::Error),
-
     /// A general error encountered during deserialization.
     /// See: https://docs.serde.rs/serde/de/trait.Error.html
     DeserializationError {
         /// A message describing the error.
         message: String,
     },
-
-    ExtendedJsonParseError(serde_json::Error),
 }
 
 impl From<io::Error> for Error {
@@ -60,27 +54,6 @@ impl From<io::Error> for Error {
 impl From<string::FromUtf8Error> for Error {
     fn from(err: string::FromUtf8Error) -> Error {
         Error::FromUtf8Error(err)
-    }
-}
-
-impl From<crate::document::ValueAccessError> for Error {
-    fn from(err: crate::document::ValueAccessError) -> Self {
-        match err {
-            ValueAccessError::NotPresent => Error::custom("missing"),
-            ValueAccessError::UnexpectedType => Error::custom("unexpected"),
-        }
-    }
-}
-
-impl From<oid::Error> for Error {
-    fn from(err: oid::Error) -> Error {
-        Error::InvalidObjectId(err)
-    }
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Error {
-        Error::ExtendedJsonParseError(err)
     }
 }
 
@@ -102,7 +75,6 @@ impl fmt::Display for Error {
             Error::DeserializationError { ref message } => message.fmt(fmt),
             Error::InvalidTimestamp(ref i) => write!(fmt, "no such local time {}", i),
             Error::AmbiguousTimestamp(ref i) => write!(fmt, "ambiguous local time {}", i),
-            _ => panic!(""),
         }
     }
 }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -1,8 +1,8 @@
 use std::{error, fmt, fmt::Display, io, string};
 
-use crate::Bson;
+use crate::{document::ValueAccessError, oid, Bson};
 use de::Unexpected;
-use serde::de;
+use serde::de::{self, Error as _};
 
 /// Possible errors that can arise during decoding.
 #[derive(Debug)]
@@ -26,7 +26,9 @@ pub enum Error {
     },
 
     /// There was an error with the syntactical structure of the BSON.
-    SyntaxError { message: String },
+    SyntaxError {
+        message: String,
+    },
 
     /// The end of the BSON input was reached too soon.
     EndOfStream,
@@ -37,12 +39,16 @@ pub enum Error {
     /// An ambiguous timestamp was encountered while decoding.
     AmbiguousTimestamp(i64),
 
+    InvalidObjectId(oid::Error),
+
     /// A general error encountered during deserialization.
     /// See: https://docs.serde.rs/serde/de/trait.Error.html
     DeserializationError {
         /// A message describing the error.
         message: String,
     },
+
+    ExtendedJsonParseError(serde_json::Error),
 }
 
 impl From<io::Error> for Error {
@@ -54,6 +60,27 @@ impl From<io::Error> for Error {
 impl From<string::FromUtf8Error> for Error {
     fn from(err: string::FromUtf8Error) -> Error {
         Error::FromUtf8Error(err)
+    }
+}
+
+impl From<crate::document::ValueAccessError> for Error {
+    fn from(err: crate::document::ValueAccessError) -> Self {
+        match err {
+            ValueAccessError::NotPresent => Error::custom("missing"),
+            ValueAccessError::UnexpectedType => Error::custom("unexpected"),
+        }
+    }
+}
+
+impl From<oid::Error> for Error {
+    fn from(err: oid::Error) -> Error {
+        Error::InvalidObjectId(err)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Error {
+        Error::ExtendedJsonParseError(err)
     }
 }
 
@@ -75,6 +102,7 @@ impl fmt::Display for Error {
             Error::DeserializationError { ref message } => message.fmt(fmt),
             Error::InvalidTimestamp(ref i) => write!(fmt, "no such local time {}", i),
             Error::AmbiguousTimestamp(ref i) => write!(fmt, "ambiguous local time {}", i),
+            _ => panic!(""),
         }
     }
 }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -1,8 +1,8 @@
 use std::{error, fmt, fmt::Display, io, string};
 
+use serde::de::{self, Error as _, Unexpected};
+
 use crate::{document::ValueAccessError, oid, Bson};
-use de::Unexpected;
-use serde::de::{self, Error as _};
 
 /// Possible errors that can arise during decoding.
 #[derive(Debug)]

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,7 +1,6 @@
 //! A BSON document represented as an associative HashMap with insertion ordering.
 
 use std::{
-    convert::{TryFrom, TryInto},
     error,
     fmt::{self, Debug, Display, Formatter},
     io::{Read, Write},
@@ -100,22 +99,6 @@ impl Display for Document {
 impl Debug for Document {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Document({:?})", self.inner)
-    }
-}
-
-impl TryFrom<serde_json::Map<String, serde_json::Value>> for Document {
-    type Error = extjson::de::Error;
-
-    fn try_from(obj: serde_json::Map<String, serde_json::Value>) -> extjson::de::Result<Self> {
-        Ok(obj
-            .into_iter()
-            .map(|(k, v)| -> extjson::de::Result<(String, Bson)> {
-                let value: Bson = v.try_into()?;
-                Ok((k, value))
-            })
-            .collect::<extjson::de::Result<Vec<(String, Bson)>>>()?
-            .into_iter()
-            .collect())
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -23,6 +23,7 @@ use crate::decimal128::Decimal128;
 use crate::{
     bson::{Array, Binary, Bson, Timestamp},
     de::{deserialize_bson_kvp, read_i32, MIN_BSON_DOCUMENT_SIZE},
+    extjson,
     oid::ObjectId,
     ser::{serialize_bson, write_i32},
     spec::BinarySubtype,
@@ -103,16 +104,16 @@ impl Debug for Document {
 }
 
 impl TryFrom<serde_json::Map<String, serde_json::Value>> for Document {
-    type Error = DecoderError;
+    type Error = extjson::de::Error;
 
-    fn try_from(obj: serde_json::Map<String, serde_json::Value>) -> DecoderResult<Self> {
+    fn try_from(obj: serde_json::Map<String, serde_json::Value>) -> extjson::de::Result<Self> {
         Ok(obj
             .into_iter()
-            .map(|(k, v)| -> DecoderResult<(String, Bson)> {
+            .map(|(k, v)| -> extjson::de::Result<(String, Bson)> {
                 let value: Bson = v.try_into()?;
                 Ok((k, value))
             })
-            .collect::<DecoderResult<Vec<(String, Bson)>>>()?
+            .collect::<extjson::de::Result<Vec<(String, Bson)>>>()?
             .into_iter()
             .collect())
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -118,13 +118,6 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for Document {
     }
 }
 
-// impl TryFrom<serde_json::Value> for Document {
-//     type Error = crate::DecoderError;
-//     fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-//         unimplemented!()
-//     }
-// }
-
 /// An iterator over Document entries.
 pub struct DocumentIntoIterator {
     inner: LinkedHashMap<String, Bson>,

--- a/src/document.rs
+++ b/src/document.rs
@@ -109,8 +109,8 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for Document {
         Ok(obj
             .into_iter()
             .map(|(k, v)| -> DecoderResult<(String, Bson)> {
-                let value: Bson = v.clone().try_into()?;
-                Ok((k.clone(), value))
+                let value: Bson = v.try_into()?;
+                Ok((k, value))
             })
             .collect::<DecoderResult<Vec<(String, Bson)>>>()?
             .into_iter()

--- a/src/document.rs
+++ b/src/document.rs
@@ -22,7 +22,6 @@ use crate::decimal128::Decimal128;
 use crate::{
     bson::{Array, Binary, Bson, Timestamp},
     de::{deserialize_bson_kvp, ensure_read_exactly, read_i32, MIN_BSON_DOCUMENT_SIZE},
-    extjson,
     oid::ObjectId,
     ser::{serialize_bson, write_i32},
     spec::BinarySubtype,

--- a/src/document.rs
+++ b/src/document.rs
@@ -15,13 +15,13 @@ use chrono::{DateTime, Utc};
 
 use linked_hash_map::{self, LinkedHashMap};
 
-use serde::de::{self, MapAccess, Visitor};
+use serde::de::{self, Error, MapAccess, Visitor};
 
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
 use crate::{
     bson::{Array, Binary, Bson, Timestamp},
-    de::{deserialize_bson_kvp, read_i32},
+    de::{deserialize_bson_kvp, read_i32, MIN_BSON_DOCUMENT_SIZE},
     oid::ObjectId,
     ser::{serialize_bson, write_i32},
     spec::BinarySubtype,
@@ -530,18 +530,34 @@ impl Document {
     pub fn from_reader<R: Read + ?Sized>(reader: &mut R) -> crate::de::Result<Document> {
         let mut doc = Document::new();
 
-        // disregard the length: using Read::take causes infinite type recursion
-        read_i32(reader)?;
+        let length = read_i32(reader)?;
+        if length < MIN_BSON_DOCUMENT_SIZE {
+            return Err(crate::de::Error::invalid_length(
+                length as usize,
+                &"document length must be at least 5",
+            ));
+        }
 
+        let mut buf = vec![0u8; (length as usize) - 4];
+        reader.read_exact(&mut buf)?;
+
+        let mut cursor = std::io::Cursor::new(buf);
         loop {
-            let tag = reader.read_u8()?;
+            let tag = cursor.read_u8()?;
 
             if tag == 0 {
                 break;
             }
 
-            let (key, val) = deserialize_bson_kvp(reader, tag, false)?;
+            let (key, val) = deserialize_bson_kvp(&mut cursor, tag, false)?;
             doc.insert(key, val);
+        }
+
+        if cursor.position() != (length - 4) as u64 {
+            return Err(crate::de::Error::invalid_length(
+                length as usize,
+                &"document length longer than contents",
+            ));
         }
 
         Ok(doc)

--- a/src/document.rs
+++ b/src/document.rs
@@ -102,10 +102,10 @@ impl Debug for Document {
     }
 }
 
-impl Document {
-    pub(crate) fn from_ext_json(
-        obj: serde_json::Map<String, serde_json::Value>,
-    ) -> DecoderResult<Self> {
+impl TryFrom<serde_json::Map<String, serde_json::Value>> for Document {
+    type Error = DecoderError;
+
+    fn try_from(obj: serde_json::Map<String, serde_json::Value>) -> DecoderResult<Self> {
         Ok(obj
             .into_iter()
             .map(|(k, v)| -> DecoderResult<(String, Bson)> {

--- a/src/extjson.rs
+++ b/src/extjson.rs
@@ -1,11 +1,12 @@
 //! A module defining serde models for the extended JSON representations of the various BSON types.
 
-use crate::{oid, Bson, DecoderError, DecoderResult};
 use chrono::{TimeZone, Utc};
 use serde::{
     de::{Error, Unexpected},
     Deserialize,
 };
+
+use crate::{oid, Bson, DecoderError, DecoderResult};
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/extjson.rs
+++ b/src/extjson.rs
@@ -194,8 +194,7 @@ impl Timestamp {
         Ok(crate::TimeStamp {
             time: self.body.t,
             increment: self.body.i,
-        }
-        .into())
+        })
     }
 }
 
@@ -243,9 +242,9 @@ impl DateTime {
                     num_millis += 1000;
                 };
 
-                return Ok(Utc
+                Ok(Utc
                     .timestamp(num_secs, num_millis as u32 * 1_000_000)
-                    .into());
+                    .into())
             }
             DateTimeBody::Relaxed(date) => {
                 let datetime: chrono::DateTime<Utc> =
@@ -257,7 +256,7 @@ impl DateTime {
                             )
                         })?
                         .into();
-                return Ok(datetime.into());
+                Ok(datetime.into())
             }
         }
     }

--- a/src/extjson.rs
+++ b/src/extjson.rs
@@ -1,0 +1,369 @@
+use crate::{oid, Bson, DecoderError, DecoderResult};
+use chrono::{TimeZone, Utc};
+use serde::{
+    de::{Error, Unexpected},
+    Deserialize,
+};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Int32 {
+    #[serde(rename = "$numberInt")]
+    value: String,
+}
+
+impl Int32 {
+    pub(crate) fn parse(self) -> DecoderResult<i32> {
+        let i: i32 = self.value.parse().map_err(|_| {
+            DecoderError::invalid_value(
+                Unexpected::Str(self.value.as_str()),
+                &"expected i32 as a string",
+            )
+        })?;
+        Ok(i)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Int64 {
+    #[serde(rename = "$numberLong")]
+    value: String,
+}
+
+impl Int64 {
+    pub(crate) fn parse(self) -> DecoderResult<i64> {
+        let i: i64 = self.value.parse().map_err(|_| {
+            DecoderError::invalid_value(
+                Unexpected::Str(self.value.as_str()),
+                &"expected i64 as a string",
+            )
+        })?;
+        Ok(i)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Double {
+    #[serde(rename = "$numberDouble")]
+    value: String,
+}
+
+impl Double {
+    pub(crate) fn parse(self) -> DecoderResult<f64> {
+        match self.value.as_str() {
+            "Infinity" => Ok(f64::INFINITY),
+            "-Infinity" => Ok(f64::NEG_INFINITY),
+            "NaN" => Ok(f64::NAN),
+            other => {
+                let d: f64 = other.parse().map_err(|_| {
+                    DecoderError::invalid_value(
+                        Unexpected::Str(other),
+                        &"expected bson double as string",
+                    )
+                })?;
+                Ok(d)
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ObjectId {
+    #[serde(rename = "$oid")]
+    oid: String,
+}
+
+impl ObjectId {
+    pub(crate) fn parse(self) -> DecoderResult<oid::ObjectId> {
+        let oid = oid::ObjectId::with_string(self.oid.as_str())?;
+        Ok(oid)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Symbol {
+    #[serde(rename = "$symbol")]
+    pub(crate) value: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Regex {
+    #[serde(rename = "$regularExpression")]
+    body: RegexBody,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RegexBody {
+    pattern: String,
+    options: String,
+}
+
+impl Regex {
+    pub(crate) fn parse(self) -> DecoderResult<crate::Regex> {
+        let mut chars: Vec<_> = self.body.options.chars().collect();
+        chars.sort();
+        let options: String = chars.into_iter().collect();
+
+        Ok(crate::Regex {
+            pattern: self.body.pattern,
+            options,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Binary {
+    #[serde(rename = "$binary")]
+    body: BinaryBody,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BinaryBody {
+    base64: String,
+    #[serde(rename = "subType")]
+    subtype: String,
+}
+
+impl Binary {
+    pub(crate) fn parse(self) -> DecoderResult<crate::Binary> {
+        let bytes = base64::decode(self.body.base64.as_str()).map_err(|_| {
+            DecoderError::invalid_value(
+                Unexpected::Str(self.body.base64.as_str()),
+                &"base64 encoded bytes",
+            )
+        })?;
+
+        let subtype = hex::decode(self.body.subtype.as_str()).map_err(|_| {
+            DecoderError::invalid_value(
+                Unexpected::Str(self.body.subtype.as_str()),
+                &"hexadecimal number as a string",
+            )
+        })?;
+
+        if subtype.len() == 1 {
+            Ok(crate::Binary {
+                bytes,
+                subtype: subtype[0].into(),
+            })
+        } else {
+            Err(DecoderError::invalid_value(
+                Unexpected::Bytes(subtype.as_slice()),
+                &"one byte subtype",
+            ))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct JavaScriptCodeWithScope {
+    #[serde(rename = "$code")]
+    pub(crate) code: String,
+
+    #[serde(rename = "$scope")]
+    #[serde(default)]
+    pub(crate) scope: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Timestamp {
+    #[serde(rename = "$timestamp")]
+    body: TimestampBody,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TimestampBody {
+    t: u32,
+    i: u32,
+}
+
+impl Timestamp {
+    pub(crate) fn parse(self) -> DecoderResult<crate::TimeStamp> {
+        Ok(crate::TimeStamp {
+            time: self.body.t,
+            increment: self.body.i,
+        }
+        .into())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DateTime {
+    #[serde(rename = "$date")]
+    body: DateTimeBody,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum DateTimeBody {
+    Canonical(Int64),
+    Relaxed(String),
+}
+
+impl DateTime {
+    pub(crate) fn parse(self) -> DecoderResult<crate::UtcDateTime> {
+        match self.body {
+            DateTimeBody::Canonical(date) => {
+                let date = date.parse()?;
+
+                let mut num_secs = date / 1000;
+                let mut num_millis = date % 1000;
+
+                // The chrono API only lets us create a DateTime with an i64 number of seconds
+                // and a u32 number of nanoseconds. In the case of a negative timestamp, this
+                // means that we need to turn the negative fractional part into a positive and
+                // shift the number of seconds down. For example:
+                //
+                //     date       = -4300 ms
+                //     num_secs   = date / 1000 = -4300 / 1000 = -4
+                //     num_millis = date % 1000 = -4300 % 1000 = -300
+                //
+                // Since num_millis is less than 0:
+                //     num_secs   = num_secs -1 = -4 - 1 = -5
+                //     num_millis = num_nanos + 1000 = -300 + 1000 = 700
+                //
+                // Instead of -4 seconds and -300 milliseconds, we now have -5 seconds and +700
+                // milliseconds, which expresses the same timestamp, but in a way we can create
+                // a DateTime with.
+                if num_millis < 0 {
+                    num_secs -= 1;
+                    num_millis += 1000;
+                };
+
+                return Ok(Utc
+                    .timestamp(num_secs, num_millis as u32 * 1_000_000)
+                    .into());
+            }
+            DateTimeBody::Relaxed(date) => {
+                let datetime: chrono::DateTime<Utc> =
+                    chrono::DateTime::parse_from_rfc3339(date.as_str())
+                        .map_err(|_| {
+                            DecoderError::invalid_value(
+                                Unexpected::Str(date.as_str()),
+                                &"rfc3339 formatted utc datetime",
+                            )
+                        })?
+                        .into();
+                return Ok(datetime.into());
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct MinKey {
+    #[serde(rename = "$minKey")]
+    value: u8,
+}
+
+impl MinKey {
+    pub(crate) fn parse(self) -> DecoderResult<Bson> {
+        if self.value == 1 {
+            Ok(Bson::MinKey)
+        } else {
+            Err(DecoderError::invalid_value(
+                Unexpected::Unsigned(self.value as u64),
+                &"value of $minKey should always be 1",
+            ))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct MaxKey {
+    #[serde(rename = "$maxKey")]
+    value: u8,
+}
+
+impl MaxKey {
+    pub(crate) fn parse(self) -> DecoderResult<Bson> {
+        if self.value == 1 {
+            Ok(Bson::MaxKey)
+        } else {
+            Err(DecoderError::invalid_value(
+                Unexpected::Unsigned(self.value as u64),
+                &"value of $maxKey should always be 1",
+            ))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DbPointer {
+    #[serde(rename = "$dbPointer")]
+    body: DbPointerBody,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DbPointerBody {
+    #[serde(rename = "$ref")]
+    ref_ns: String,
+
+    #[serde(rename = "$id")]
+    id: ObjectId,
+}
+
+impl DbPointer {
+    pub(crate) fn parse(self) -> DecoderResult<crate::DbPointer> {
+        Ok(crate::DbPointer {
+            namespace: self.body.ref_ns,
+            id: self.body.id.parse()?,
+        })
+    }
+}
+
+#[cfg(feature = "decimal128")]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Decimal128 {
+    #[serde(rename = "$numberDecimal")]
+    value: String,
+}
+
+#[cfg(feature = "decimal128")]
+impl Decimal128 {
+    pub(crate) fn parse(self) -> DecoderResult<crate::Decimal128> {
+        let decimal128: crate::Decimal128 = self.value.parse().map_err(|_| {
+            DecoderError::invalid_value(
+                Unexpected::Str(self.value.as_str()),
+                &"decimal128 value as a string",
+            )
+        })?;
+        Ok(decimal128)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Undefined {
+    #[serde(rename = "$undefined")]
+    value: bool,
+}
+
+impl Undefined {
+    pub(crate) fn parse(self) -> DecoderResult<Bson> {
+        if self.value {
+            Ok(Bson::Undefined)
+        } else {
+            Err(DecoderError::invalid_value(
+                Unexpected::Bool(false),
+                &"$undefined should always be true",
+            ))
+        }
+    }
+}

--- a/src/extjson.rs
+++ b/src/extjson.rs
@@ -1,3 +1,5 @@
+//! A module defining serde models for the extended JSON representations of the various BSON types.
+
 use crate::{oid, Bson, DecoderError, DecoderResult};
 use chrono::{TimeZone, Utc};
 use serde::{

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -2,9 +2,9 @@
 //!
 //! ## Usage
 //!
-//! Extended JSON can be deserialized using `Bson`'s `TryFrom<serde_json::Value>` implementation.
-//! This implementation accepts both canonical and relaxed extJSON, and the two modes can even be
-//! mixed within a single representation.
+//! Extended JSON can be deserialized using [`Bson`](../../enum.Bson.html)'s
+//! `TryFrom<serde_json::Value>` implementation. This implementation accepts both canonical and
+//! relaxed extJSON, and the two modes can even be mixed within a single representation.
 //!
 //! e.g.
 //! ```rust

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -99,17 +99,17 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for Bson {
 
         if obj.contains_key("$numberInt") {
             let int: models::Int32 = serde_json::from_value(obj.into())?;
-            return Ok(Bson::I32(int.parse()?));
+            return Ok(Bson::Int32(int.parse()?));
         }
 
         if obj.contains_key("$numberLong") {
             let int: models::Int64 = serde_json::from_value(obj.into())?;
-            return Ok(Bson::I64(int.parse()?));
+            return Ok(Bson::Int64(int.parse()?));
         }
 
         if obj.contains_key("$numberDouble") {
             let double: models::Double = serde_json::from_value(obj.into())?;
-            return Ok(Bson::FloatingPoint(double.parse()?));
+            return Ok(Bson::Double(double.parse()?));
         }
 
         if obj.contains_key("$binary") {
@@ -136,7 +136,7 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for Bson {
 
         if obj.contains_key("$date") {
             let extjson_datetime: models::DateTime = serde_json::from_value(obj.into())?;
-            return Ok(Bson::UtcDatetime(extjson_datetime.parse()?.0));
+            return Ok(Bson::DateTime(extjson_datetime.parse()?.0));
         }
 
         if obj.contains_key("$minKey") {
@@ -186,9 +186,9 @@ impl TryFrom<serde_json::Value> for Bson {
                 .as_i64()
                 .map(|i| {
                     if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
-                        Bson::I32(i as i32)
+                        Bson::Int32(i as i32)
                     } else {
-                        Bson::I64(i)
+                        Bson::Int64(i)
                     }
                 })
                 .or_else(|| x.as_u64().map(Bson::from))

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -1,0 +1,208 @@
+//! Deserializing [MongoDB Extended JSON v2](https://docs.mongodb.com/manual/reference/mongodb-extended-json/)
+//!
+//! ## Usage
+//!
+//! Extended JSON can be deserialized using `Bson`'s `TryFrom<serde_json::Value>` implementation.
+//! This implementation accepts both canonical and relaxed extJSON, and the two modes can even be
+//! mixed within a single representation.
+//!
+//! e.g.
+//! ```rust
+//! # use bson::Bson;
+//! # use serde_json::json;
+//! # use std::convert::{TryFrom, TryInto};
+//! let json_doc = json!({ "x": 5i32, "y": { "$numberInt": "5" }, "z": { "subdoc": "hello" } });
+//! let bson: Bson = json_doc.try_into().unwrap(); // Bson::Document(...)
+//!
+//! let json_date = json!({ "$date": { "$numberLong": "1590972160292" } });
+//! let bson_date: Bson = json_date.try_into().unwrap(); // Bson::DateTime(...)
+//!
+//! let invalid_ext_json = json!({ "$numberLong": 5 });
+//! Bson::try_from(invalid_ext_json).expect_err("5 should be a string");
+//! ```
+
+use std::convert::{TryFrom, TryInto};
+
+use serde::de::Error as _;
+
+use crate::{extjson::models, Bson};
+
+#[derive(Debug)]
+#[non_exhaustive]
+/// Error cases that can occur during deserialization from [extended JSON](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+pub enum Error {
+    /// Errors that can occur during OID construction and generation from the input data.
+    InvalidObjectId(crate::oid::Error),
+
+    /// A general error encountered during deserialization.
+    /// See: https://docs.serde.rs/serde/de/trait.Error.html
+    DeserializationError { message: String },
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::InvalidObjectId(ref err) => err.fmt(fmt),
+            Self::DeserializationError { ref message } => message.fmt(fmt),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl serde::de::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: std::fmt::Display,
+    {
+        Self::DeserializationError {
+            message: format!("{}", msg),
+        }
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Self::DeserializationError {
+            message: err.to_string(),
+        }
+    }
+}
+
+impl From<crate::oid::Error> for Error {
+    fn from(err: crate::oid::Error) -> Self {
+        Self::InvalidObjectId(err)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// This converts from the input JSON object as if it were [MongoDB Extended JSON v2](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+impl TryFrom<serde_json::Map<String, serde_json::Value>> for Bson {
+    type Error = Error;
+
+    fn try_from(obj: serde_json::Map<String, serde_json::Value>) -> Result<Self> {
+        if obj.contains_key("$oid") {
+            let oid: models::ObjectId = serde_json::from_value(obj.into())?;
+            return Ok(Bson::ObjectId(oid.parse()?));
+        }
+
+        if obj.contains_key("$symbol") {
+            let symbol: models::Symbol = serde_json::from_value(obj.into())?;
+            return Ok(Bson::Symbol(symbol.value));
+        }
+
+        if obj.contains_key("$regularExpression") {
+            let regex: models::Regex = serde_json::from_value(obj.into())?;
+            return Ok(regex.parse()?.into());
+        }
+
+        if obj.contains_key("$numberInt") {
+            let int: models::Int32 = serde_json::from_value(obj.into())?;
+            return Ok(Bson::I32(int.parse()?));
+        }
+
+        if obj.contains_key("$numberLong") {
+            let int: models::Int64 = serde_json::from_value(obj.into())?;
+            return Ok(Bson::I64(int.parse()?));
+        }
+
+        if obj.contains_key("$numberDouble") {
+            let double: models::Double = serde_json::from_value(obj.into())?;
+            return Ok(Bson::FloatingPoint(double.parse()?));
+        }
+
+        if obj.contains_key("$binary") {
+            let binary: models::Binary = serde_json::from_value(obj.into())?;
+            return Ok(Bson::Binary(binary.parse()?));
+        }
+
+        if obj.contains_key("$code") {
+            let code_w_scope: models::JavaScriptCodeWithScope = serde_json::from_value(obj.into())?;
+            return match code_w_scope.scope {
+                Some(scope) => Ok(crate::JavaScriptCodeWithScope {
+                    code: code_w_scope.code,
+                    scope: scope.try_into()?,
+                }
+                .into()),
+                None => Ok(Bson::JavaScriptCode(code_w_scope.code)),
+            };
+        }
+
+        if obj.contains_key("$timestamp") {
+            let ts: models::Timestamp = serde_json::from_value(obj.into())?;
+            return Ok(ts.parse()?.into());
+        }
+
+        if obj.contains_key("$date") {
+            let extjson_datetime: models::DateTime = serde_json::from_value(obj.into())?;
+            return Ok(Bson::UtcDatetime(extjson_datetime.parse()?.0));
+        }
+
+        if obj.contains_key("$minKey") {
+            let min_key: models::MinKey = serde_json::from_value(obj.into())?;
+            return Ok(min_key.parse()?);
+        }
+
+        if obj.contains_key("$maxKey") {
+            let max_key: models::MaxKey = serde_json::from_value(obj.into())?;
+            return Ok(max_key.parse()?);
+        }
+
+        if obj.contains_key("$dbPointer") {
+            let db_ptr: models::DbPointer = serde_json::from_value(obj.into())?;
+            return Ok(db_ptr.parse()?.into());
+        }
+
+        if obj.contains_key("$numberDecimal") {
+            #[cfg(feature = "decimal128")]
+            {
+                let decimal: models::Decimal128 = serde_json::from_value(obj.into())?;
+                return Ok(Bson::Decimal128(decimal.parse()?));
+            }
+
+            #[cfg(not(feature = "decimal128"))]
+            return Err(Error::custom(
+                "decimal128 models support not implemented".to_string(),
+            ));
+        }
+
+        if obj.contains_key("$undefined") {
+            let undefined: models::Undefined = serde_json::from_value(obj.into())?;
+            return Ok(undefined.parse()?);
+        }
+
+        Ok(Bson::Document(obj.try_into()?))
+    }
+}
+
+/// This converts from the input JSON as if it were [MongoDB Extended JSON v2](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+impl TryFrom<serde_json::Value> for Bson {
+    type Error = Error;
+
+    fn try_from(value: serde_json::Value) -> Result<Self> {
+        match value {
+            serde_json::Value::Number(x) => x
+                .as_i64()
+                .map(|i| {
+                    if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                        Bson::I32(i as i32)
+                    } else {
+                        Bson::I64(i)
+                    }
+                })
+                .or_else(|| x.as_u64().map(Bson::from))
+                .or_else(|| x.as_f64().map(Bson::from))
+                .ok_or_else(|| panic!("a number that could fit in i32, i64, or f64")),
+            serde_json::Value::String(x) => Ok(x.into()),
+            serde_json::Value::Bool(x) => Ok(x.into()),
+            serde_json::Value::Array(x) => Ok(Bson::Array(
+                x.into_iter()
+                    .map(Bson::try_from)
+                    .collect::<Result<Vec<Bson>>>()?,
+            )),
+            serde_json::Value::Null => Ok(Bson::Null),
+            serde_json::Value::Object(map) => map.try_into(),
+        }
+    }
+}

--- a/src/extjson/mod.rs
+++ b/src/extjson/mod.rs
@@ -19,16 +19,28 @@
 //!
 //! All MongoDB drivers and BSON libraries interpret and produce extJSON, so it can serve as a
 //! useful tool for communicating between applications where raw BSON bytes cannot be used (e.g. via
-//! REST APIs). It's also useful for representing BSON data as a string.
+//! JSON REST APIs). It's also useful for representing BSON data as a string.
 //!
-//! There are two forms of extJSON: "Canonical" and "Relaxed". They are the same except for that in
-//! relaxed mode, all BSON numbers are represented by the JSON number type, rather than the object
-//! convention.
+//! ### Canonical and Relaxed Modes
+//!
+//! There are two modes of extJSON: "Canonical" and "Relaxed". They are the same except for the
+//! following differences:
+//!   - In relaxed mode, all BSON numbers are represented by the JSON number type, rather than the
+//!     object
+//! notation.
+//!   - In relaxed mode, the string in the datetime object notation is ISO-8601 formatted (if the
+//!     date is after 1970).
 //!
 //! e.g.
-//! ```text
-//! in relaxed: doc! { "x": 5 } => "{ "x": 5 }"
-//! in canonical: doc! { "x": 5 } => "{ "x": { "$numberInt": "5" } }"
+//! ```rust
+//! # use bson::bson;
+//! let doc = bson!({ "x": 5, "d": chrono::Utc::now() });
+//!
+//! println!("relaxed: {}", doc.clone().into_relaxed_extjson());
+//! // relaxed: "{"x":5,"d":{"$date":"2020-06-01T22:19:13.075Z"}}"
+//!
+//! println!("canonical: {}", doc.into_canonical_extjson());
+//! // canonical: {"x":{"$numberInt":"5"},"d":{"$date":{"$numberLong":"1591050020711"}}}
 //! ```
 //!
 //! Canonical mode is useful when BSON values need to be round tripped without losing any type

--- a/src/extjson/mod.rs
+++ b/src/extjson/mod.rs
@@ -1,0 +1,79 @@
+//! Deserialization and serialization of [MongoDB Extended JSON v2](https://docs.mongodb.com/manual/reference/mongodb-extended-json/)
+//!
+//! ## Overview of Extended JSON
+//!
+//! MongoDB Extended JSON (abbreviated extJSON) is format of JSON that allows for the encoding of
+//! BSON type information. Normal JSON cannot unambiguously represent all BSON types losslessly, so
+//! an extension was designed to include conventions for representing those types.
+//!
+//! For example, a BSON binary is represented by the following format:
+//! ```text
+//! {
+//!    "$binary": {
+//!        "base64": <base64 encoded payload as a string>,
+//!        "subType": <subtype as a one or two character hex string>,
+//!    }
+//! }
+//! ```
+//! For more information on extJSON and the complete list of translations, see the [official MongoDB documentation](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+//!
+//! All MongoDB drivers and BSON libraries interpret and produce extJSON, so it can serve as a
+//! useful tool for communicating between applications where raw BSON bytes cannot be used (e.g. via
+//! REST APIs). It's also useful for representing BSON data as a string.
+//!
+//! There are two forms of extJSON: "Canonical" and "Relaxed". They are the same except for that in
+//! relaxed mode, all BSON numbers are represented by the JSON number type, rather than the object
+//! convention.
+//!
+//! e.g.
+//! ```text
+//! in relaxed: doc! { "x": 5 } => "{ "x": 5 }"
+//! in canonical: doc! { "x": 5 } => "{ "x": { "$numberInt": "5" } }"
+//! ```
+//!
+//! Canonical mode is useful when BSON values need to be round tripped without losing any type
+//! information. Relaxed mode is more useful when debugging or logging BSON data.
+//!
+//! ## Deserializing Extended JSON
+//!
+//! Extended JSON can be deserialized using `Bson`'s `TryFrom<serde_json::Value>` implementation.
+//! This implementation accepts both canonical and relaxed extJSON, and the two modes can even be
+//! mixed within a single representation.
+//!
+//! e.g.
+//! ```rust
+//! # use bson::Bson;
+//! # use serde_json::json;
+//! # use std::convert::{TryFrom, TryInto};
+//! let json_doc = json!({ "x": 5i32, "y": { "$numberInt": "5" }, "z": { "subdoc": "hello" } });
+//! let bson: Bson = json_doc.try_into().unwrap(); // Bson::Document(...)
+//!
+//! let json_date = json!({ "$date": { "$numberLong": "1590972160292" } });
+//! let bson_date: Bson = json_date.try_into().unwrap(); // Bson::DateTime(...)
+//!
+//! let invalid_ext_json = json!({ "$numberLong": 5 });
+//! Bson::try_from(invalid_ext_json).expect_err("5 should be a string");
+//! ```
+//!
+//! ## Serializing to Extended JSON
+//!
+//! Extended JSON can be created via `Bson`'s `TryInto<serde_json::Value>` implementation and
+//! through `Bson::into_relaxed_extjson` and `Bson::into_canonical_extjson`.
+//!
+//! e.g.
+//! ```rust
+//! # use bson::{bson, oid};
+//! let doc = bson!({ "x": 5i32, "_id": oid::ObjectId::new() });
+//!
+//! let relaxed_extjson: serde_json::Value = doc.clone().into();
+//! println!("{}", relaxed_extjson); // { "x": 5, "_id": { "$oid": <hexstring> } }
+//!
+//! let relaxed_extjson = doc.clone().into_relaxed_extjson();
+//! println!("{}", relaxed_extjson); // { "x": 5, "_id": { "$oid": <hexstring> } }
+//!
+//! let canonical_extjson = doc.into_canonical_extjson();
+//! println!("{}", canonical_extjson); // { "x": { "$numberInt": "5" }, "_id": { "$oid": <hexstring> } }
+//! ```
+
+pub mod de;
+mod models;

--- a/src/extjson/mod.rs
+++ b/src/extjson/mod.rs
@@ -36,9 +36,9 @@
 //!
 //! ## Deserializing Extended JSON
 //!
-//! Extended JSON can be deserialized using `Bson`'s `TryFrom<serde_json::Value>` implementation.
-//! This implementation accepts both canonical and relaxed extJSON, and the two modes can even be
-//! mixed within a single representation.
+//! Extended JSON can be deserialized using [`Bson`](../enum.Bson.html)'s
+//! `TryFrom<serde_json::Value>` implementation. This implementation accepts both canonical and
+//! relaxed extJSON, and the two modes can even be mixed within a single representation.
 //!
 //! e.g.
 //! ```rust
@@ -57,8 +57,10 @@
 //!
 //! ## Serializing to Extended JSON
 //!
-//! Extended JSON can be created via `Bson`'s `TryInto<serde_json::Value>` implementation and
-//! through `Bson::into_relaxed_extjson` and `Bson::into_canonical_extjson`.
+//! Extended JSON can be created via [`Bson`](../enum.Bson.html)'s `Into<serde_json::Value>`
+//! implementation (which will create relaxed extJSON),
+//! [`Bson::into_relaxed_extjson`](../enum.Bson.html#method.into_relaxed_extjson), and
+//! [`Bson::into_canonical_extjson`](../enum.Bson.html#method.into_canonical_extjson).
 //!
 //! e.g.
 //! ```rust

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -191,8 +191,8 @@ pub(crate) struct TimestampBody {
 }
 
 impl Timestamp {
-    pub(crate) fn parse(self) -> extjson::de::Result<crate::TimeStamp> {
-        Ok(crate::TimeStamp {
+    pub(crate) fn parse(self) -> extjson::de::Result<crate::Timestamp> {
+        Ok(crate::Timestamp {
             time: self.body.t,
             increment: self.body.i,
         })
@@ -214,7 +214,7 @@ enum DateTimeBody {
 }
 
 impl DateTime {
-    pub(crate) fn parse(self) -> extjson::de::Result<crate::UtcDateTime> {
+    pub(crate) fn parse(self) -> extjson::de::Result<crate::DateTime> {
         match self.body {
             DateTimeBody::Canonical(date) => {
                 let date = date.parse()?;

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -6,7 +6,7 @@ use serde::{
     Deserialize,
 };
 
-use crate::{extjson, oid, Bson, DecoderError};
+use crate::{extjson, oid, Bson};
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub mod compat;
 pub mod de;
 pub mod decimal128;
 pub mod document;
-mod extjson;
+pub mod extjson;
 pub mod oid;
 pub mod ser;
 pub mod spec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,14 +188,7 @@
 
 pub use self::{
     bson::{
-        Array,
-        Binary,
-        Bson,
-        DateTime,
-        DbPointer,
-        Document,
-        JavaScriptCodeWithScope,
-        Regex,
+        Array, Binary, Bson, DateTime, DbPointer, Document, JavaScriptCodeWithScope, Regex,
         Timestamp,
     },
     de::{from_bson, Deserializer},
@@ -210,6 +203,7 @@ pub mod compat;
 pub mod de;
 pub mod decimal128;
 pub mod document;
+mod extjson;
 pub mod oid;
 pub mod ser;
 pub mod spec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,14 @@
 
 pub use self::{
     bson::{
-        Array, Binary, Bson, DateTime, DbPointer, Document, JavaScriptCodeWithScope, Regex,
+        Array,
+        Binary,
+        Bson,
+        DateTime,
+        DbPointer,
+        Document,
+        JavaScriptCodeWithScope,
+        Regex,
         Timestamp,
     },
     de::{from_bson, Deserializer},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@
 //!
 //! e.g.:
 //! ```rust
-//! # use serde_derive::{Deserialize, Serialize};
+//! # use serde::{Deserialize, Serialize};
 //! # use bson::{bson, Bson};
 //! #[derive(Serialize, Deserialize)]
 //! struct Person {

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -1,12 +1,5 @@
 use bson::{
-    doc,
-    oid::ObjectId,
-    spec::BinarySubtype,
-    Binary,
-    Bson,
-    Document,
-    JavaScriptCodeWithScope,
-    Regex,
+    doc, oid::ObjectId, spec::BinarySubtype, Binary, Bson, Document, JavaScriptCodeWithScope, Regex,
 };
 use serde_json::{json, Value};
 
@@ -57,86 +50,86 @@ fn document_default() {
     assert_eq!(doc1, Document::new());
 }
 
-#[test]
-fn from_impls() {
-    assert_eq!(Bson::from(1.5f32), Bson::Double(1.5));
-    assert_eq!(Bson::from(2.25f64), Bson::Double(2.25));
-    assert_eq!(Bson::from("data"), Bson::String(String::from("data")));
-    assert_eq!(
-        Bson::from(String::from("data")),
-        Bson::String(String::from("data"))
-    );
-    assert_eq!(Bson::from(doc! {}), Bson::Document(Document::new()));
-    assert_eq!(Bson::from(false), Bson::Boolean(false));
-    assert_eq!(
-        Bson::from(Regex {
-            pattern: String::from("\\s+$"),
-            options: String::from("i")
-        }),
-        Bson::RegularExpression(Regex {
-            pattern: String::from("\\s+$"),
-            options: String::from("i")
-        })
-    );
-    assert_eq!(
-        Bson::from(JavaScriptCodeWithScope {
-            code: String::from("alert(\"hi\");"),
-            scope: doc! {}
-        }),
-        Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
-            code: String::from("alert(\"hi\");"),
-            scope: doc! {}
-        })
-    );
-    //
-    assert_eq!(
-        Bson::from(Binary {
-            subtype: BinarySubtype::Generic,
-            bytes: vec![1, 2, 3]
-        }),
-        Bson::Binary(Binary {
-            subtype: BinarySubtype::Generic,
-            bytes: vec![1, 2, 3]
-        })
-    );
-    assert_eq!(Bson::from(-48i32), Bson::Int32(-48));
-    assert_eq!(Bson::from(-96i64), Bson::Int64(-96));
-    assert_eq!(Bson::from(152u32), Bson::Int32(152));
-    assert_eq!(Bson::from(4096u64), Bson::Int64(4096));
+// #[test]
+// fn from_impls() {
+//     assert_eq!(Bson::from(1.5f32), Bson::FloatingPoint(1.5));
+//     assert_eq!(Bson::from(2.25f64), Bson::FloatingPoint(2.25));
+//     assert_eq!(Bson::from("data"), Bson::String(String::from("data")));
+//     assert_eq!(
+//         Bson::from(String::from("data")),
+//         Bson::String(String::from("data"))
+//     );
+//     assert_eq!(Bson::from(doc! {}), Bson::Document(Document::new()));
+//     assert_eq!(Bson::from(false), Bson::Boolean(false));
+//     assert_eq!(
+//         Bson::from(Regex {
+//             pattern: String::from("\\s+$"),
+//             options: String::from("i")
+//         }),
+//         Bson::Regex(Regex {
+//             pattern: String::from("\\s+$"),
+//             options: String::from("i")
+//         })
+//     );
+//     assert_eq!(
+//         Bson::from(JavaScriptCodeWithScope {
+//             code: String::from("alert(\"hi\");"),
+//             scope: doc! {}
+//         }),
+//         Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
+//             code: String::from("alert(\"hi\");"),
+//             scope: doc! {}
+//         })
+//     );
+//     //
+//     assert_eq!(
+//         Bson::from(Binary {
+//             subtype: BinarySubtype::Generic,
+//             bytes: vec![1, 2, 3]
+//         }),
+//         Bson::Binary(Binary {
+//             subtype: BinarySubtype::Generic,
+//             bytes: vec![1, 2, 3]
+//         })
+//     );
+//     assert_eq!(Bson::from(-48i32), Bson::I32(-48));
+//     assert_eq!(Bson::from(-96i64), Bson::I64(-96));
+//     assert_eq!(Bson::from(152u32), Bson::I32(152));
+//     assert_eq!(Bson::from(4096u64), Bson::I64(4096));
 
-    let oid = ObjectId::new();
-    assert_eq!(
-        Bson::from(b"abcdefghijkl"),
-        Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl"))
-    );
-    assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
-    assert_eq!(
-        Bson::from(vec![1, 2, 3]),
-        Bson::Array(vec![Bson::Int32(1), Bson::Int32(2), Bson::Int32(3)])
-    );
-    assert_eq!(
-        Bson::from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})),
-        Bson::Document(doc! {"_id": &oid, "name": ["bson-rs"]})
-    );
+//     let oid = ObjectId::new();
+//     assert_eq!(
+//         Bson::from(b"abcdefghijkl"),
+//         Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl"))
+//     );
+//     assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
+//     assert_eq!(
+//         Bson::from(vec![1, 2, 3]),
+//         Bson::Array(vec![Bson::I32(1), Bson::I32(2), Bson::I32(3)])
+//     );
+//     assert_eq!(
+//         Bson::from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})),
+//         Bson::Document(doc! {"_id": &oid, "name": ["bson-rs"]})
+//     );
 
-    // References
-    assert_eq!(Bson::from(&24i32), Bson::Int32(24));
-    assert_eq!(
-        Bson::from(&String::from("data")),
-        Bson::String(String::from("data"))
-    );
-    assert_eq!(Bson::from(&oid), Bson::ObjectId(oid));
-    assert_eq!(
-        Bson::from(&doc! {"a": "b"}),
-        Bson::Document(doc! {"a": "b"})
-    );
+//     // References
+//     assert_eq!(Bson::from(&24i32), Bson::I32(24));
+//     assert_eq!(
+//         Bson::from(&String::from("data")),
+//         Bson::String(String::from("data"))
+//     );
+//     assert_eq!(Bson::from(&oid), Bson::ObjectId(oid));
+//     assert_eq!(
+//         Bson::from(&doc! {"a": "b"}),
+//         Bson::Document(doc! {"a": "b"})
+//     );
 
-    let db_pointer = Bson::from(json!({
-        "$dbPointer": {
-            "$ref": "db.coll",
-            "$id": { "$oid": "507f1f77bcf86cd799439011" },
-        }
-    }));
-    let db_pointer = db_pointer.as_db_pointer().unwrap();
-    assert_eq!(Bson::from(db_pointer), Bson::DbPointer(db_pointer.clone()));
-}
+//     let db_pointer = Bson::from(json!({
+//         "$dbPointer": {
+//             "$ref": "db.coll",
+//             "$id": { "$oid": "507f1f77bcf86cd799439011" },
+//         }
+//     }));
+//     let db_pointer = db_pointer.as_db_pointer().unwrap();
+//     assert_eq!(Bson::from(db_pointer), Bson::DbPointer(db_pointer.clone()));
+// }

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -61,8 +61,8 @@ fn document_default() {
 
 #[test]
 fn from_impls() {
-    assert_eq!(Bson::from(1.5f32), Bson::FloatingPoint(1.5));
-    assert_eq!(Bson::from(2.25f64), Bson::FloatingPoint(2.25));
+    assert_eq!(Bson::from(1.5f32), Bson::Double(1.5));
+    assert_eq!(Bson::from(2.25f64), Bson::Double(2.25));
     assert_eq!(Bson::from("data"), Bson::String(String::from("data")));
     assert_eq!(
         Bson::from(String::from("data")),
@@ -75,7 +75,7 @@ fn from_impls() {
             pattern: String::from("\\s+$"),
             options: String::from("i")
         }),
-        Bson::Regex(Regex {
+        Bson::RegularExpression(Regex {
             pattern: String::from("\\s+$"),
             options: String::from("i")
         })
@@ -101,10 +101,10 @@ fn from_impls() {
             bytes: vec![1, 2, 3]
         })
     );
-    assert_eq!(Bson::from(-48i32), Bson::I32(-48));
-    assert_eq!(Bson::from(-96i64), Bson::I64(-96));
-    assert_eq!(Bson::from(152u32), Bson::I32(152));
-    assert_eq!(Bson::from(4096u64), Bson::I64(4096));
+    assert_eq!(Bson::from(-48i32), Bson::Int32(-48));
+    assert_eq!(Bson::from(-96i64), Bson::Int64(-96));
+    assert_eq!(Bson::from(152u32), Bson::Int32(152));
+    assert_eq!(Bson::from(4096u64), Bson::Int64(4096));
 
     let oid = ObjectId::new();
     assert_eq!(
@@ -114,7 +114,7 @@ fn from_impls() {
     assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
     assert_eq!(
         Bson::from(vec![1, 2, 3]),
-        Bson::Array(vec![Bson::I32(1), Bson::I32(2), Bson::I32(3)])
+        Bson::Array(vec![Bson::Int32(1), Bson::Int32(2), Bson::Int32(3)])
     );
     assert_eq!(
         Bson::try_from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})).unwrap(),
@@ -122,7 +122,7 @@ fn from_impls() {
     );
 
     // References
-    assert_eq!(Bson::from(&24i32), Bson::I32(24));
+    assert_eq!(Bson::from(&24i32), Bson::Int32(24));
     assert_eq!(
         Bson::try_from(&String::from("data")).unwrap(),
         Bson::String(String::from("data"))

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -1,5 +1,14 @@
+use std::convert::TryFrom;
+
 use bson::{
-    doc, oid::ObjectId, spec::BinarySubtype, Binary, Bson, Document, JavaScriptCodeWithScope, Regex,
+    doc,
+    oid::ObjectId,
+    spec::BinarySubtype,
+    Binary,
+    Bson,
+    Document,
+    JavaScriptCodeWithScope,
+    Regex,
 };
 use serde_json::{json, Value};
 
@@ -50,86 +59,87 @@ fn document_default() {
     assert_eq!(doc1, Document::new());
 }
 
-// #[test]
-// fn from_impls() {
-//     assert_eq!(Bson::from(1.5f32), Bson::FloatingPoint(1.5));
-//     assert_eq!(Bson::from(2.25f64), Bson::FloatingPoint(2.25));
-//     assert_eq!(Bson::from("data"), Bson::String(String::from("data")));
-//     assert_eq!(
-//         Bson::from(String::from("data")),
-//         Bson::String(String::from("data"))
-//     );
-//     assert_eq!(Bson::from(doc! {}), Bson::Document(Document::new()));
-//     assert_eq!(Bson::from(false), Bson::Boolean(false));
-//     assert_eq!(
-//         Bson::from(Regex {
-//             pattern: String::from("\\s+$"),
-//             options: String::from("i")
-//         }),
-//         Bson::Regex(Regex {
-//             pattern: String::from("\\s+$"),
-//             options: String::from("i")
-//         })
-//     );
-//     assert_eq!(
-//         Bson::from(JavaScriptCodeWithScope {
-//             code: String::from("alert(\"hi\");"),
-//             scope: doc! {}
-//         }),
-//         Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
-//             code: String::from("alert(\"hi\");"),
-//             scope: doc! {}
-//         })
-//     );
-//     //
-//     assert_eq!(
-//         Bson::from(Binary {
-//             subtype: BinarySubtype::Generic,
-//             bytes: vec![1, 2, 3]
-//         }),
-//         Bson::Binary(Binary {
-//             subtype: BinarySubtype::Generic,
-//             bytes: vec![1, 2, 3]
-//         })
-//     );
-//     assert_eq!(Bson::from(-48i32), Bson::I32(-48));
-//     assert_eq!(Bson::from(-96i64), Bson::I64(-96));
-//     assert_eq!(Bson::from(152u32), Bson::I32(152));
-//     assert_eq!(Bson::from(4096u64), Bson::I64(4096));
+#[test]
+fn from_impls() {
+    assert_eq!(Bson::from(1.5f32), Bson::FloatingPoint(1.5));
+    assert_eq!(Bson::from(2.25f64), Bson::FloatingPoint(2.25));
+    assert_eq!(Bson::from("data"), Bson::String(String::from("data")));
+    assert_eq!(
+        Bson::from(String::from("data")),
+        Bson::String(String::from("data"))
+    );
+    assert_eq!(Bson::from(doc! {}), Bson::Document(Document::new()));
+    assert_eq!(Bson::from(false), Bson::Boolean(false));
+    assert_eq!(
+        Bson::from(Regex {
+            pattern: String::from("\\s+$"),
+            options: String::from("i")
+        }),
+        Bson::Regex(Regex {
+            pattern: String::from("\\s+$"),
+            options: String::from("i")
+        })
+    );
+    assert_eq!(
+        Bson::from(JavaScriptCodeWithScope {
+            code: String::from("alert(\"hi\");"),
+            scope: doc! {}
+        }),
+        Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
+            code: String::from("alert(\"hi\");"),
+            scope: doc! {}
+        })
+    );
+    //
+    assert_eq!(
+        Bson::from(Binary {
+            subtype: BinarySubtype::Generic,
+            bytes: vec![1, 2, 3]
+        }),
+        Bson::Binary(Binary {
+            subtype: BinarySubtype::Generic,
+            bytes: vec![1, 2, 3]
+        })
+    );
+    assert_eq!(Bson::from(-48i32), Bson::I32(-48));
+    assert_eq!(Bson::from(-96i64), Bson::I64(-96));
+    assert_eq!(Bson::from(152u32), Bson::I32(152));
+    assert_eq!(Bson::from(4096u64), Bson::I64(4096));
 
-//     let oid = ObjectId::new();
-//     assert_eq!(
-//         Bson::from(b"abcdefghijkl"),
-//         Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl"))
-//     );
-//     assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
-//     assert_eq!(
-//         Bson::from(vec![1, 2, 3]),
-//         Bson::Array(vec![Bson::I32(1), Bson::I32(2), Bson::I32(3)])
-//     );
-//     assert_eq!(
-//         Bson::from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})),
-//         Bson::Document(doc! {"_id": &oid, "name": ["bson-rs"]})
-//     );
+    let oid = ObjectId::new();
+    assert_eq!(
+        Bson::from(b"abcdefghijkl"),
+        Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl"))
+    );
+    assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
+    assert_eq!(
+        Bson::from(vec![1, 2, 3]),
+        Bson::Array(vec![Bson::I32(1), Bson::I32(2), Bson::I32(3)])
+    );
+    assert_eq!(
+        Bson::try_from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})).unwrap(),
+        Bson::Document(doc! {"_id": &oid, "name": ["bson-rs"]})
+    );
 
-//     // References
-//     assert_eq!(Bson::from(&24i32), Bson::I32(24));
-//     assert_eq!(
-//         Bson::from(&String::from("data")),
-//         Bson::String(String::from("data"))
-//     );
-//     assert_eq!(Bson::from(&oid), Bson::ObjectId(oid));
-//     assert_eq!(
-//         Bson::from(&doc! {"a": "b"}),
-//         Bson::Document(doc! {"a": "b"})
-//     );
+    // References
+    assert_eq!(Bson::from(&24i32), Bson::I32(24));
+    assert_eq!(
+        Bson::try_from(&String::from("data")).unwrap(),
+        Bson::String(String::from("data"))
+    );
+    assert_eq!(Bson::from(&oid), Bson::ObjectId(oid));
+    assert_eq!(
+        Bson::from(&doc! {"a": "b"}),
+        Bson::Document(doc! {"a": "b"})
+    );
 
-//     let db_pointer = Bson::from(json!({
-//         "$dbPointer": {
-//             "$ref": "db.coll",
-//             "$id": { "$oid": "507f1f77bcf86cd799439011" },
-//         }
-//     }));
-//     let db_pointer = db_pointer.as_db_pointer().unwrap();
-//     assert_eq!(Bson::from(db_pointer), Bson::DbPointer(db_pointer.clone()));
-// }
+    let db_pointer = Bson::try_from(json!({
+        "$dbPointer": {
+            "$ref": "db.coll",
+            "$id": { "$oid": "507f1f77bcf86cd799439011" },
+        }
+    }))
+    .unwrap();
+    let db_pointer = db_pointer.as_db_pointer().unwrap();
+    assert_eq!(Bson::from(db_pointer), Bson::DbPointer(db_pointer.clone()));
+}

--- a/tests/modules/serializer_deserializer.rs
+++ b/tests/modules/serializer_deserializer.rs
@@ -1,17 +1,13 @@
-use std::io::{Cursor, Write};
+use std::{
+    convert::TryFrom,
+    io::{Cursor, Write},
+};
 
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
 use bson::{
-    doc,
-    oid::ObjectId,
-    spec::BinarySubtype,
-    Binary,
-    Bson,
-    Document,
-    JavaScriptCodeWithScope,
-    Regex,
-    Timestamp,
+    doc, oid::ObjectId, spec::BinarySubtype, Binary, Bson, Document, JavaScriptCodeWithScope,
+    Regex, Timestamp,
 };
 use byteorder::{LittleEndian, WriteBytesExt};
 use chrono::{offset::TimeZone, Utc};
@@ -420,12 +416,13 @@ fn test_serialize_deserialize_max_key() {
 
 #[test]
 fn test_serialize_deserialize_db_pointer() {
-    let src = Bson::from(json!({
+    let src = Bson::try_from(json!({
         "$dbPointer": {
             "$ref": "db.coll",
             "$id": { "$oid": "507f1f77bcf86cd799439011" },
         }
-    }));
+    }))
+    .unwrap();
     let dst = vec![
         34, 0, 0, 0, 12, 107, 101, 121, 0, 8, 0, 0, 0, 100, 98, 46, 99, 111, 108, 108, 0, 80, 127,
         31, 119, 188, 248, 108, 215, 153, 67, 144, 17, 0,

--- a/tests/modules/serializer_deserializer.rs
+++ b/tests/modules/serializer_deserializer.rs
@@ -6,8 +6,15 @@ use std::{
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
 use bson::{
-    doc, oid::ObjectId, spec::BinarySubtype, Binary, Bson, Document, JavaScriptCodeWithScope,
-    Regex, Timestamp,
+    doc,
+    oid::ObjectId,
+    spec::BinarySubtype,
+    Binary,
+    Bson,
+    Document,
+    JavaScriptCodeWithScope,
+    Regex,
+    Timestamp,
 };
 use byteorder::{LittleEndian, WriteBytesExt};
 use chrono::{offset::TimeZone, Utc};

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,10 +2,10 @@
 
 use bson::{bson, doc, spec::BinarySubtype, Binary, Bson, Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
-use serde_derive::{Deserialize, Serialize};
+// use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 #[test]
 fn test_ser_vec() {
@@ -474,12 +474,13 @@ fn test_ser_db_pointer() {
         db_pointer: DbPointer,
     }
 
-    let db_pointer = Bson::from(json!({
+    let db_pointer = Bson::try_from(json!({
         "$dbPointer": {
             "$ref": "db.coll",
             "$id": { "$oid": "507f1f77bcf86cd799439011" },
         }
-    }));
+    }))
+    .unwrap();
 
     let db_pointer = db_pointer.as_db_pointer().unwrap();
 
@@ -506,12 +507,13 @@ fn test_de_db_pointer() {
         db_pointer: DbPointer,
     }
 
-    let db_pointer = Bson::from(json!({
+    let db_pointer = Bson::try_from(json!({
         "$dbPointer": {
             "$ref": "db.coll",
             "$id": { "$oid": "507f1f77bcf86cd799439011" },
         }
-    }));
+    }))
+    .unwrap();
     let db_pointer = db_pointer.as_db_pointer().unwrap();
 
     let foo: Foo = bson::from_bson(Bson::Document(

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,7 +2,6 @@
 
 use bson::{bson, doc, spec::BinarySubtype, Binary, Bson, Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
-// use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
 
 use std::{collections::BTreeMap, convert::TryFrom};

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -5,7 +5,7 @@ use std::{
 
 use bson::{Bson, Document};
 use pretty_assertions::assert_eq;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 use super::run_spec_test;
 

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -56,7 +56,6 @@ struct ParseError {
 
 fn run_test(test: TestFile) {
     for valid in test.valid {
-        continue;
         let description = format!("{}: {}", test.description, valid.description);
 
         let bson_to_native_cb = Document::from_reader(
@@ -253,8 +252,6 @@ fn run_test(test: TestFile) {
     }
 
     for decode_error in test.decode_errors {
-        continue;
-
         // No meaningful definition of "byte count" for an arbitrary reader.
         if decode_error.description
             == "Stated length less than byte count, with garbage after envelope"
@@ -271,8 +268,18 @@ fn run_test(test: TestFile) {
             continue;
         }
 
-        println!("parse error test: {}", parse_error.description);
+        // no special support for dbref convention
+        if parse_error.description.contains("DBRef") {
+            continue;
+        }
 
+        if !cfg!(feature = "decimal128") && parse_error.description.contains("$numberDecimal") {
+            continue;
+        }
+
+        println!("==\n{}", parse_error.description);
+
+        // println!("{}", parse_error.string);
         let json: serde_json::Value =
             serde_json::from_str(parse_error.string.as_str()).expect(&parse_error.description);
 

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -260,7 +260,7 @@ fn run_test(test: TestFile) {
         }
 
         let bson = hex::decode(decode_error.bson).expect("should decode from hex");
-        Document::decode(&mut bson.as_slice()).expect_err(decode_error.description.as_str());
+        Document::from_reader(&mut bson.as_slice()).expect_err(decode_error.description.as_str());
     }
 
     for parse_error in test.parse_errors {

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -264,6 +264,7 @@ fn run_test(test: TestFile) {
     }
 
     for parse_error in test.parse_errors {
+        // TODO RUST-36: Enable decimal128 tests.
         if test.bson_type == "0x13" {
             continue;
         }
@@ -273,6 +274,7 @@ fn run_test(test: TestFile) {
             continue;
         }
 
+        // TODO RUST-36: Enable decimal128 tests.
         if !cfg!(feature = "decimal128") && parse_error.description.contains("$numberDecimal") {
             continue;
         }

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -247,6 +247,18 @@ fn run_test(test: TestFile) {
             );
         }
     }
+
+    for decode_error in test.decode_errors {
+        // No meaningful definition of "byte count" for an arbitrary reader.
+        if decode_error.description
+            == "Stated length less than byte count, with garbage after envelope"
+        {
+            continue;
+        }
+        println!("{}", decode_error.description);
+        let bson = hex::decode(decode_error.bson).expect("should decode from hex");
+        Document::decode(&mut bson.as_slice()).expect_err(decode_error.description.as_str());
+    }
 }
 
 #[test]

--- a/tests/spec/corpus.rs
+++ b/tests/spec/corpus.rs
@@ -258,7 +258,7 @@ fn run_test(test: TestFile) {
         {
             continue;
         }
-        println!("{}", decode_error.description);
+
         let bson = hex::decode(decode_error.bson).expect("should decode from hex");
         Document::decode(&mut bson.as_slice()).expect_err(decode_error.description.as_str());
     }
@@ -277,13 +277,8 @@ fn run_test(test: TestFile) {
             continue;
         }
 
-        println!("==\n{}", parse_error.description);
-
-        // println!("{}", parse_error.string);
         let json: serde_json::Value =
             serde_json::from_str(parse_error.string.as_str()).expect(&parse_error.description);
-
-        println!("got value: {}", json);
 
         Bson::try_from(json).expect_err(&parse_error.description);
     }

--- a/tests/spec/mod.rs
+++ b/tests/spec/mod.rs
@@ -1,6 +1,7 @@
 mod corpus;
 
 use std::{
+    convert::TryFrom,
     ffi::OsStr,
     fs::{self, File},
     path::PathBuf,
@@ -36,6 +37,6 @@ where
         let json: Value =
             serde_json::from_reader(File::open(test_file_full_path.as_path()).unwrap()).unwrap();
 
-        run_test_file(bson::from_bson(Bson::from(json)).unwrap())
+        run_test_file(bson::from_bson(Bson::try_from(json).unwrap()).unwrap())
     }
 }


### PR DESCRIPTION
[RUST-454](https://jira.mongodb.org/browse/RUST-454)

This PR implements the "decode errors" and "parse errors" sections of the BSON corpus spec tests.

As part of implementing the parse tests, there ended up being far more changes (both in implementation and API) than I would have liked, but I believe they were all necessary. The changes stem from the fact that our current extJSON parser would not fail if extJSON wasn't formatted properly--it would just parse it as a document. The spec's indicate we should actually reject such inputs, which required adding failability to all the extJSON parsing mechanisms (`From<Value> for Bson => TryFrom<Value> for Bson`).

To implement these changes, I started by trying to modify `from_extended_document` to shake the boat as little as possible, but I quickly realized that doing the error checking there would require a ton of boilerplate. I instead opted to leverage `serde` as much as possible by defining models for the various extJSON representations of things, while still leaving `from_extended_document` around so as to not break the `serde` implementation.

From an API perspective, I needed a new error type for extJSON parsing errors. To that end, I added an `extjson` and `extjson::de` module to house that type. In the future, I think we could add further generic functions for extJSON deserialization/serialization in there too.