### PR TITLE
fix: Don't use the type for constants; use std

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -636,9 +636,9 @@ impl Bson {
             }
 
             ["$numberDouble"] => match doc.get_str("$numberDouble") {
-                Ok("Infinity") => return Bson::Double(f64::INFINITY),
-                Ok("-Infinity") => return Bson::Double(f64::NEG_INFINITY),
-                Ok("NaN") => return Bson::Double(f64::NAN),
+                Ok("Infinity") => return Bson::Double(std::f64::INFINITY),
+                Ok("-Infinity") => return Bson::Double(std::f64::NEG_INFINITY),
+                Ok("NaN") => return Bson::Double(std::f64::NAN),
                 Ok(other) => {
                     if let Ok(d) = other.parse() {
                         return Bson::Double(d);
@@ -692,7 +692,7 @@ impl Bson {
 
                     if let Ok(t) = timestamp.get_i64("t") {
                         if let Ok(i) = timestamp.get_i64("i") {
-                            if t >= 0 && i >= 0 && t <= (u32::MAX as i64) && i <= (u32::MAX as i64)
+                            if t >= 0 && i >= 0 && t <= (std::u32::MAX as i64) && i <= (std::u32::MAX as i64)
                             {
                                 return Bson::Timestamp(Timestamp {
                                     time: t as u32,

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -692,7 +692,10 @@ impl Bson {
 
                     if let Ok(t) = timestamp.get_i64("t") {
                         if let Ok(i) = timestamp.get_i64("i") {
-                            if t >= 0 && i >= 0 && t <= (std::u32::MAX as i64) && i <= (std::u32::MAX as i64)
+                            if t >= 0
+                                && i >= 0
+                                && t <= (std::u32::MAX as i64)
+                                && i <= (std::u32::MAX as i64)
                             {
                                 return Bson::Timestamp(Timestamp {
                                     time: t as u32,

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -185,7 +185,7 @@ impl TryFrom<serde_json::Value> for Bson {
             serde_json::Value::Number(x) => x
                 .as_i64()
                 .map(|i| {
-                    if i >= i32::MIN as i64 && i <= i32::MAX as i64 {
+                    if i >= std::i32::MIN as i64 && i <= std::i32::MAX as i64 {
                         Bson::Int32(i as i32)
                     } else {
                         Bson::Int64(i)

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -56,9 +56,9 @@ pub(crate) struct Double {
 impl Double {
     pub(crate) fn parse(self) -> extjson::de::Result<f64> {
         match self.value.as_str() {
-            "Infinity" => Ok(f64::INFINITY),
-            "-Infinity" => Ok(f64::NEG_INFINITY),
-            "NaN" => Ok(f64::NAN),
+            "Infinity" => Ok(std::f64::INFINITY),
+            "-Infinity" => Ok(std::f64::NEG_INFINITY),
+            "NaN" => Ok(std::f64::NAN),
             other => {
                 let d: f64 = other.parse().map_err(|_| {
                     extjson::de::Error::invalid_value(


### PR DESCRIPTION
There were multiple cases where a primitive type was being used as a module, like `f64::NAN`. This was fixed by using the `std` module, like `std::f64::NAN`.

fixes #185