### PR TITLE
RUST-413 Implementing ObjectId spec tests

### DIFF
--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,5 +1,4 @@
 //! ObjectId
-
 use std::{
     error,
     fmt,
@@ -13,6 +12,7 @@ use hex::{self, FromHexError};
 
 use rand::{thread_rng, Rng};
 
+use crate::tests::LOCK;
 use chrono::Utc;
 
 const TIMESTAMP_SIZE: usize = 4;
@@ -214,9 +214,20 @@ fn count_generated_is_big_endian() {
     assert_eq!(0x33u8, oid.bytes()[COUNTER_OFFSET + 2]);
 }
 
+#[test]
+fn test_counter_overflow() {
+    // let start = MAX_U24;
+    // OID_COUNTER.store(start, Ordering::SeqCst);
+
+    // let oid = ObjectId::new();
+
+    // let counter = BigEndian::read_u24(oid.bytes()[COUNTER_OFFSET]);
+    // assert_eq!(counter, 0);
+}
+
 #[cfg(test)]
 mod test {
-    use byteorder::{ByteOrder, LittleEndian};
+    // use byteorder::{ByteOrder, LittleEndian};
     use chrono::{offset::TimeZone, Utc};
 
     #[test]
@@ -250,12 +261,5 @@ mod test {
         let id = super::ObjectId::with_string("FFFFFFFF0000000000000000").unwrap();
         // "Feb 7th, 2106 06:28:15 UTC"
         assert_eq!(Utc.ymd(2106, 2, 7).and_hms(6, 28, 15), id.timestamp());
-    }
-
-    #[test]
-    fn test_counter_overflow() {
-        let id = super::ObjectId::with_string("000000000000000000FFFFFF").unwrap();
-        let counter = LittleEndian::read_u24(&id.bytes());
-        assert_eq!(counter, 0);
     }
 }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -216,6 +216,7 @@ fn count_generated_is_big_endian() {
 
 #[cfg(test)]
 mod test {
+    use byteorder::{ByteOrder, LittleEndian};
     use chrono::{offset::TimeZone, Utc};
 
     #[test]
@@ -249,5 +250,12 @@ mod test {
         let id = super::ObjectId::with_string("FFFFFFFF0000000000000000").unwrap();
         // "Feb 7th, 2106 06:28:15 UTC"
         assert_eq!(Utc.ymd(2106, 2, 7).and_hms(6, 28, 15), id.timestamp());
+    }
+
+    #[test]
+    fn test_counter_overflow() {
+        let id = super::ObjectId::with_string("000000000000000000FFFFFF").unwrap();
+        let counter = LittleEndian::read_u24(&id.bytes());
+        assert_eq!(counter, 0);
     }
 }


### PR DESCRIPTION
1. Timestamp field already tested.
2. Counter overflow tested by checking if 0xFFFFFF overflows to 0
3. Fork doesn't have to be tested in Rust