### PR TITLE
RUST-413 Implementing ObjectId spec tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,12 @@ hex = "0.4.2"
 md5 = "0.7.0"
 decimal = { version = "2.0.4", default_features = false, optional = true }
 base64 = "0.12.1"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 assert_matches = "1.2"
 serde_bytes = "0.11"
 pretty_assertions = "0.6.1"
-lazy_static = "1.4.0"
 
 [package.metadata.docs.rs]
 features = ["decimal128"]


### PR DESCRIPTION
1. Timestamp already tested.
2. counter overflow tested by creating an objectID with MAX counter and making sure the counter is MAX. Then created another objectID which incremented the counter to MAX + 1 and made sure it is reset to 0. Found a bug in the code. Fixed that.
3. No fork in Rust.