### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 time = "0.1"
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"
 hex = "0.3"
 md5 = "0.6"
 decimal = { version = "2.0.4", default_features = false, optional = true }


### PR DESCRIPTION
Linked_hash_map is unsound for releases <= 0.5.2. Bumping this to `^0.5.3` 

[Advisory](https://github.com/RustSec/advisory-db/issues/298)

