### PR TITLE
Fix code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ e.g.:
 #[derive(Serialize, Deserialize)]
 struct Person {
     name: String,
-    // Unsigned integer types are not supported. See the "Breaking Changes" section below.
     age: i32,
     phones: Vec<String>,
 }
@@ -240,4 +239,3 @@ bash .evergreen/check-clippy.sh && bash .evergreen/check-rustfmt.sh
 
 ## Continuous Integration
 Commits to master are run automatically on [evergreen](https://evergreen.mongodb.com/waterfall/rust-bson).
-

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ e.g.:
 #[derive(Serialize, Deserialize)]
 struct Person {
     name: String,
-    age: u8,
+    // Unsigned integer types are not supported. See the "Breaking Changes" section below.
+    age: i32,
     phones: Vec<String>,
 }
 

--- a/README.md
+++ b/README.md
@@ -159,29 +159,27 @@ struct Person {
     phones: Vec<String>,
 }
 
-fn typed_example() {
-    // Some BSON input data as a `Bson`.
-    let bson_data: Bson = bson!({
-        "name": "John Doe",
-        "age": 43,
-        "phones": [
-            "+44 1234567",
-            "+44 2345678"
-        ]
-    });
+// Some BSON input data as a `Bson`.
+let bson_data: Bson = bson!({
+    "name": "John Doe",
+    "age": 43,
+    "phones": [
+        "+44 1234567",
+        "+44 2345678"
+    ]
+});
 
-    // Deserialize the Person struct from the BSON data, automatically
-    // verifying that the necessary keys are present and that they are of
-    // the correct types.
-    let mut person: Person = bson::from_bson(bson_data).unwrap();
+// Deserialize the Person struct from the BSON data, automatically
+// verifying that the necessary keys are present and that they are of
+// the correct types.
+let mut person: Person = bson::from_bson(bson_data).unwrap();
 
-    // Do things just like with any other Rust data structure.
-    println!("Redacting {}'s record.", person.name);
-    person.name = "REDACTED".to_string();
+// Do things just like with any other Rust data structure.
+println!("Redacting {}'s record.", person.name);
+person.name = "REDACTED".to_string();
 
-    // Get a serialized version of the input data as a `Bson`.
-    let redacted_bson = bson::to_bson(&person).unwrap();
-}
+// Get a serialized version of the input data as a `Bson`.
+let redacted_bson = bson::to_bson(&person).unwrap();
 ```
 
 Any types that implement `Serialize` and `Deserialize` can be used in this way. Doing so helps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,31 +154,27 @@
 //!     phones: Vec<String>,
 //! }
 //!
-//! fn typed_example() {
-//!     // Some BSON input data as a `Bson`.
-//!     let bson_data: Bson = bson!({
-//!         "name": "John Doe",
-//!         "age": 43,
-//!         "phones": [
-//!             "+44 1234567",
-//!             "+44 2345678"
-//!         ]
-//!     });
+//! // Some BSON input data as a `Bson`.
+//! let bson_data: Bson = bson!({
+//!     "name": "John Doe",
+//!     "age": 43,
+//!     "phones": [
+//!         "+44 1234567",
+//!         "+44 2345678"
+//!     ]
+//! });
 //!
-//!     // Deserialize the Person struct from the BSON data, automatically
-//!     // verifying that the necessary keys are present and that they are of
-//!     // the correct types.
-//!     let mut person: Person = bson::from_bson(bson_data).unwrap();
+//! // Deserialize the Person struct from the BSON data, automatically
+//! // verifying that the necessary keys are present and that they are of
+//! // the correct types.
+//! let mut person: Person = bson::from_bson(bson_data).unwrap();
 //!
-//!     // Do things just like with any other Rust data structure.
-//!     println!("Redacting {}'s record.", person.name);
-//!     person.name = "REDACTED".to_string();
+//! // Do things just like with any other Rust data structure.
+//! println!("Redacting {}'s record.", person.name);
+//! person.name = "REDACTED".to_string();
 //!
-//!     // Get a serialized version of the input data as a `Bson`.
-//!     let redacted_bson = bson::to_bson(&person).unwrap();
-//! }
-//!
-//! typed_example();
+//! // Get a serialized version of the input data as a `Bson`.
+//! let redacted_bson = bson::to_bson(&person).unwrap();
 //! ```
 //!
 //! Any types that implement `Serialize` and `Deserialize` can be used in this way. Doing so helps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@
 //! #[derive(Serialize, Deserialize)]
 //! struct Person {
 //!     name: String,
-//!     age: u8,
+//!     age: i32,
 //!     phones: Vec<String>,
 //! }
 //!
@@ -177,6 +177,8 @@
 //!     // Get a serialized version of the input data as a `Bson`.
 //!     let redacted_bson = bson::to_bson(&person).unwrap();
 //! }
+//!
+//! typed_example();
 //! ```
 //!
 //! Any types that implement `Serialize` and `Deserialize` can be used in this way. Doing so helps


### PR DESCRIPTION
The code in the README doesn't work because of the breaking change in 0.8.0. This PR fixes the code so causes less confusion. 

I tested the change by running the code in a small program.