### PR TITLE
Exclude unneeded files from built package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,16 @@ homepage = "https://github.com/mongodb/bson-rust"
 documentation = "https://docs.rs/crate/bson"
 edition = "2018"
 
+# By default cargo include everything git include
+# cargo diet can help to manage what's not useful.
+include = [
+    "Cargo.toml",
+    "src/**/*",
+    "LICENSE",
+    "README.md",
+    "!**/tests/**/*"
+]
+
 [features]
 # no features by default
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,16 @@ edition = "2018"
 
 # By default cargo include everything git include
 # cargo diet can help to manage what's not useful.
-include = [
-    "Cargo.toml",
-    "src/**/*",
-    "LICENSE",
-    "README.md",
-    "!**/tests/**/*"
+exclude = [
+    "etc/**",
+    "examples/**",
+    "fuzz/**",
+    "serde-tests/**",
+    "src/tests/**",
+    "rustfmt.toml",
+    ".travis.yml",
+    ".evergreen/**",
+    ".gitignore"
 ]
 
 [features]


### PR DESCRIPTION
By default cargo publish all the content versionned by git.
following insight given by cargo diet I used an explicit approach
to exclude test dataset etc. from the final package.