### PR TITLE
Add ObjectIdRepr that deconstruct an ObjectId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ decimal128 = ["decimal"]
 name = "bson"
 
 [dependencies]
+byteorder = "1"
 chrono = "0.4"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
I have the need to use `ObjectId` counter so maybe this could be useful to add some helper. As `ObjectId` is documented to have a specific representation I see no reason to not add this. https://docs.mongodb.com/manual/reference/method/ObjectId/#description

Note: I add byteorder as dependencies to make it simple, I think I could remove this dependencies but before doing some annoying code I prefer to see if this is useful or not.