### PR TITLE
RUST-511 Require DeserializeOwned in from_bson

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 
 use ::serde::{
-    de::{Error as _, Unexpected},
+    de::{DeserializeOwned, Error as _, Unexpected},
     Deserialize,
 };
 
@@ -348,9 +348,9 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
 }
 
 /// Decode a BSON `Value` into a `T` Deserializable.
-pub fn from_bson<'de, T>(bson: Bson) -> Result<T>
+pub fn from_bson<T>(bson: Bson) -> Result<T>
 where
-    T: Deserialize<'de>,
+    T: DeserializeOwned,
 {
     let de = Deserializer::new(bson);
     Deserialize::deserialize(de)

--- a/src/tests/spec/mod.rs
+++ b/src/tests/spec/mod.rs
@@ -8,13 +8,13 @@ use std::{
 };
 
 use crate::{from_bson, Bson};
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-pub(crate) fn run_spec_test<'a, T, F>(spec: &[&str], run_test_file: F)
+pub(crate) fn run_spec_test<T, F>(spec: &[&str], run_test_file: F)
 where
     F: Fn(T),
-    T: Deserialize<'a>,
+    T: DeserializeOwned,
 {
     let base_path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "src", "tests", "spec", "json"]
         .iter()


### PR DESCRIPTION
RUST-511

This PR updates the trait requirement in `from_bson` to be `DeserializeOwned` instead of `Deserialize<'de>`. Since the function accepts an owned `Bson`, the lifetime constraint wasn't being used, and in fact it was allowing structs that could not be deserialized successfully to be passed to this function and fail at runtime (see #165).

This change is technically breaking, but due to the low probability of this actually affecting user code and its presence basically being a bug, we have decided to make the change. We'll first release it as part of a beta for our next minor version and monitor the community for any instances of breakage.