### PR TITLE
RUST-364 Cache unique process value for oids

### DIFF
--- a/src/oid.rs
+++ b/src/oid.rs
@@ -162,7 +162,7 @@ impl ObjectId {
             };
         }
 
-        BUF.clone()
+        *BUF
     }
 
     // Gets an incremental 3-byte count.

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -153,10 +153,16 @@ impl ObjectId {
 
     // Generate a random 5-byte array.
     fn gen_process_id() -> [u8; 5] {
-        let rng = thread_rng().gen_range(0, MAX_U24) as u32;
-        let mut buf: [u8; 5] = [0; 5];
-        buf[0..4].copy_from_slice(&rng.to_be_bytes());
-        buf
+        lazy_static! {
+            static ref BUF: [u8; 5] = {
+                let rng = thread_rng().gen_range(0, MAX_U24) as u32;
+                let mut buf: [u8; 5] = [0; 5];
+                buf[0..4].copy_from_slice(&rng.to_be_bytes());
+                buf
+            };
+        }
+
+        BUF.clone()
     }
 
     // Gets an incremental 3-byte count.


### PR DESCRIPTION
We already implemented the ObjectId spec tests in RUST-484, so no new tests were added here. The only deviation from the spec I noticed was that we were generating new random bytes for each ObjectId rather than caching them per process, so I've updated the implementation here to cache them.