### PR TITLE
RUST-589 Implement FromStr for ObjectId

### DIFF
--- a/src/oid.rs
+++ b/src/oid.rs
@@ -5,6 +5,7 @@ use std::{
     error,
     fmt,
     result,
+    str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
     time::SystemTime,
 };
@@ -76,6 +77,14 @@ pub struct ObjectId {
 impl Default for ObjectId {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl FromStr for ObjectId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Self::with_string(s)
     }
 }
 

--- a/src/tests/modules/oid.rs
+++ b/src/tests/modules/oid.rs
@@ -47,3 +47,13 @@ fn counter_increasing() {
     let oid2_bytes = ObjectId::new().bytes();
     assert!(oid1_bytes[11] < oid2_bytes[11]);
 }
+
+#[test]
+fn fromstr_oid() {
+    let _guard = LOCK.run_concurrently();
+    let s = "123456789012123456789012";
+    let oid_res = s.parse::<ObjectId>();
+    assert!(oid_res.is_ok(), "oid parse failed");
+    let actual_s = hex::encode(oid_res.unwrap().bytes());
+    assert_eq!(s, &actual_s, "parsed and expected oids differ");
+}


### PR DESCRIPTION
This makes it easier to parse ObjectId in places that expect T: FromStr.