### PR TITLE
RUST-648 Reintroduce Document decoding w/ lossy UTF-8 conversion

### DIFF
--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -65,6 +65,21 @@ fn test_serialize_deserialize_utf8_string() {
 }
 
 #[test]
+fn test_encode_decode_utf8_string_invalid() {
+    let bytes = b"\x80\xae".to_vec();
+    let src = unsafe { String::from_utf8_unchecked(bytes) };
+
+    let doc = doc! { "key": src };
+
+    let mut buf = Vec::new();
+    doc.to_writer(&mut buf).unwrap();
+
+    let expected = doc! { "key": "��" };
+    let decoded = Document::from_reader_utf8_lossy(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(decoded, expected);
+}
+
+#[test]
 fn test_serialize_deserialize_array() {
     let _guard = LOCK.run_concurrently();
     let src = vec![Bson::Double(1.01), Bson::String("xyz".to_owned())];


### PR DESCRIPTION
RUST-648 and #226 

This PR reintroduces support for decoding a `Document` from a stream of bytes that may contain invalid UTF-8 strings. This is useful when reading raw BSON returned from the server, which in rare cases may invalidly truncate it ([SERVER-24007](https://jira.mongodb.org/browse/SERVER-24007)).