### PR TITLE
RUST-680 Implement Copy for ObjectId

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -729,7 +729,7 @@ impl Bson {
                         if let Ok(id) = db_pointer.get_object_id("$id") {
                             return Bson::DbPointer(DbPointer {
                                 namespace: ns.into(),
-                                id: id.clone(),
+                                id: *id,
                             });
                         }
                     }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -729,7 +729,7 @@ impl Bson {
                         if let Ok(id) = db_pointer.get_object_id("$id") {
                             return Bson::DbPointer(DbPointer {
                                 namespace: ns.into(),
-                                id: *id,
+                                id,
                             });
                         }
                     }
@@ -872,9 +872,9 @@ impl Bson {
     }
 
     /// If `Bson` is `Objectid`, return its value. Returns `None` otherwise
-    pub fn as_object_id(&self) -> Option<&oid::ObjectId> {
+    pub fn as_object_id(&self) -> Option<oid::ObjectId> {
         match *self {
-            Bson::ObjectId(ref v) => Some(v),
+            Bson::ObjectId(v) => Some(v),
             _ => None,
         }
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -414,9 +414,9 @@ impl Document {
     }
 
     /// Get a reference to an object id value for this key if it exists and has the correct type.
-    pub fn get_object_id(&self, key: &str) -> ValueAccessResult<&ObjectId> {
+    pub fn get_object_id(&self, key: &str) -> ValueAccessResult<ObjectId> {
         match self.get(key) {
-            Some(&Bson::ObjectId(ref v)) => Ok(v),
+            Some(&Bson::ObjectId(v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
             None => Err(ValueAccessError::NotPresent),
         }

--- a/src/document.rs
+++ b/src/document.rs
@@ -413,7 +413,7 @@ impl Document {
         }
     }
 
-    /// Get a reference to an object id value for this key if it exists and has the correct type.
+    /// Get an object id value for this key if it exists and has the correct type.
     pub fn get_object_id(&self, key: &str) -> ValueAccessResult<ObjectId> {
         match self.get(key) {
             Some(&Bson::ObjectId(v)) => Ok(v),

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -69,7 +69,7 @@ impl error::Error for Error {
 }
 
 /// A wrapper around raw 12-byte ObjectId representations.
-#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ObjectId {
     id: [u8; 12],
 }

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -117,7 +117,7 @@ fn from_impls() {
         Bson::from(b"abcdefghijkl"),
         Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl"))
     );
-    assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
+    assert_eq!(Bson::from(oid), Bson::ObjectId(oid));
     assert_eq!(
         Bson::from(vec![1, 2, 3]),
         Bson::Array(vec![Bson::Int32(1), Bson::Int32(2), Bson::Int32(3)])

--- a/src/tests/modules/ordered.rs
+++ b/src/tests/modules/ordered.rs
@@ -146,8 +146,8 @@ fn test_getters() {
     assert_eq!(Ok(&datetime), doc.get_datetime("datetime"));
 
     let object_id = ObjectId::new();
-    doc.insert("_id".to_string(), Bson::ObjectId(object_id.clone()));
-    assert_eq!(Some(&Bson::ObjectId(object_id.clone())), doc.get("_id"));
+    doc.insert("_id".to_string(), Bson::ObjectId(object_id));
+    assert_eq!(Some(&Bson::ObjectId(object_id)), doc.get("_id"));
     assert_eq!(Ok(&object_id), doc.get_object_id("_id"));
 
     assert_eq!(

--- a/src/tests/modules/ordered.rs
+++ b/src/tests/modules/ordered.rs
@@ -148,7 +148,7 @@ fn test_getters() {
     let object_id = ObjectId::new();
     doc.insert("_id".to_string(), Bson::ObjectId(object_id));
     assert_eq!(Some(&Bson::ObjectId(object_id)), doc.get("_id"));
-    assert_eq!(Ok(&object_id), doc.get_object_id("_id"));
+    assert_eq!(Ok(object_id), doc.get_object_id("_id"));
 
     assert_eq!(
         Some(&Bson::Binary(Binary {

--- a/src/tests/modules/ser.rs
+++ b/src/tests/modules/ser.rs
@@ -182,7 +182,7 @@ fn int64() {
 fn oid() {
     let _guard = LOCK.run_concurrently();
     let oid = ObjectId::new();
-    let obj = Bson::ObjectId(oid.clone());
+    let obj = Bson::ObjectId(oid);
     let s: BTreeMap<String, String> = from_bson(obj.clone()).unwrap();
 
     let mut expected = BTreeMap::new();

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -738,7 +738,7 @@ fn test_oid_helpers() {
         oid: oid.to_string(),
     };
     let doc = to_document(&a).unwrap();
-    assert_eq!(doc.get_object_id("oid").unwrap(), &oid);
+    assert_eq!(doc.get_object_id("oid").unwrap(), oid);
 }
 
 #[test]


### PR DESCRIPTION
This implements Copy for ObjectId, cleans up places where `oid.clone()` was being used, and updates get_object_id and as_object_id to return owned values, to align with other Copy types (e.g., `.as_f64()`.  That last part is a breaking change, so I've kept it in a separate commit to make it easy to remove from the PR if that's not desired right now.