### PR TITLE
Replace linked-hash-map with ritelinked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ chrono = "0.4"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-linked-hash-map = "0.5.3"
+ritelinked = "0.2.2"
 hex = "0.4.2"
 decimal = { version = "2.0.4", default_features = false, optional = true }
 base64 = "0.13.0"


### PR DESCRIPTION
[RiteLinked](https://github.com/ritedb/ritelinked) provides more up to date versions of `LinkedHashMap` & `LinkedHashSet` . You can easily use it on std or no_std environment.

**Changes**

- Replace `linked-hash-map` with `ritelinked`
- Customize `or_insert` & `or_insert_with` to ensure that the test passes

**Reason** 

- Because of the `linked-hash-map` declaration
    > WARNING: THIS PROJECT IS IN MAINTENANCE MODE, DUE TO INSUFFICIENT MAINTAINER RESOURCES
- The compatibility of `ritelinked` and `linked-hash-map` is very good, and in some cases `ritelinked` has better performance
- I am currently developing a series of related projects, so I can provide long-term support

**Related**

- #134 
- #135 
- [Rust-283 Investigate replacing `linked-hash-map` with `indexmap`](https://jira.mongodb.org/browse/RUST-283)