### PR TITLE
RUST-709 Update decimal dependency to 2.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 linked-hash-map = "0.5.3"
 hex = "0.4.2"
-decimal = { version = "2.0.4", default_features = false, optional = true }
+decimal = { version = "2.1.0", default_features = false, optional = true }
 base64 = "0.13.0"
 lazy_static = "1.4.0"
 uuid = "0.8.1"


### PR DESCRIPTION
This will fix the ARM build problem (see #132)