### PR TITLE
RUST-283 Replace linked-hash-map with indexmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ chrono = "0.4"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-linked-hash-map = "0.5.3"
+indexmap = "1.6.2"
 hex = "0.4.2"
 decimal = { version = "2.1.0", default_features = false, optional = true }
 base64 = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ decimal128 = ["decimal"]
 name = "bson"
 
 [dependencies]
+ahash = "0.7.2"
 chrono = "0.4"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/document.rs
+++ b/src/document.rs
@@ -456,14 +456,14 @@ impl Document {
     }
 
     /// Gets a collection of all keys in the document.
-    pub fn keys<'a>(&'a self) -> Keys<'a> {
+    pub fn keys(&self) -> Keys {
         Keys {
             inner: self.inner.keys(),
         }
     }
 
     /// Gets a collection of all values in the document.
-    pub fn values<'a>(&'a self) -> Values<'a> {
+    pub fn values(&self) -> Values {
         Values {
             inner: self.inner.values(),
         }
@@ -585,7 +585,7 @@ impl<'a> Entry<'a> {
         }
     }
 
-    fn to_indexmap_entry(self) -> indexmap::map::Entry<'a, String, Bson> {
+    fn into_indexmap_entry(self) -> indexmap::map::Entry<'a, String, Bson> {
         match self {
             Self::Occupied(o) => indexmap::map::Entry::Occupied(o.inner),
             Self::Vacant(v) => indexmap::map::Entry::Vacant(v.inner),
@@ -595,14 +595,14 @@ impl<'a> Entry<'a> {
     /// Inserts the given default value in the entry if it is vacant and returns a mutable reference
     /// to it. Otherwise a mutable reference to an already existent value is returned.
     pub fn or_insert(self, default: Bson) -> &'a mut Bson {
-        self.to_indexmap_entry().or_insert(default)
+        self.into_indexmap_entry().or_insert(default)
     }
 
     /// Inserts the result of the `default` function in the entry if it is vacant and returns a
     /// mutable reference to it. Otherwise a mutable reference to an already existent value is
     /// returned.
     pub fn or_insert_with<F: FnOnce() -> Bson>(self, default: F) -> &'a mut Bson {
-        self.to_indexmap_entry().or_insert_with(default)
+        self.into_indexmap_entry().or_insert_with(default)
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -9,6 +9,7 @@ use std::{
     mem,
 };
 
+use ahash::RandomState;
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 use serde::de::{self, Error, MapAccess, Visitor};
@@ -62,7 +63,7 @@ impl error::Error for ValueAccessError {}
 /// A BSON document represented as an associative HashMap with insertion ordering.
 #[derive(Clone, PartialEq)]
 pub struct Document {
-    inner: IndexMap<String, Bson>,
+    inner: IndexMap<String, Bson, RandomState>,
 }
 
 impl Default for Document {
@@ -185,7 +186,7 @@ impl Document {
     /// Creates a new empty Document.
     pub fn new() -> Document {
         Document {
-            inner: IndexMap::new(),
+            inner: IndexMap::default(),
         }
     }
 
@@ -664,8 +665,8 @@ impl<'de> Visitor<'de> for DocumentVisitor {
         V: MapAccess<'de>,
     {
         let mut inner = match visitor.size_hint() {
-            Some(size) => IndexMap::with_capacity(size),
-            None => IndexMap::new(),
+            Some(size) => IndexMap::with_capacity_and_hasher(size, RandomState::default()),
+            None => IndexMap::default(),
         };
 
         while let Some((key, value)) = visitor.next_entry()? {

--- a/src/document.rs
+++ b/src/document.rs
@@ -487,8 +487,9 @@ impl Document {
     }
 
     /// Takes the value of the entry out of the document, and returns it.
+    /// Computes in **O(n)** time (average).
     pub fn remove(&mut self, key: &str) -> Option<Bson> {
-        self.inner.remove(key)
+        self.inner.shift_remove(key)
     }
 
     pub fn entry(&mut self, k: String) -> Entry {

--- a/src/tests/modules/ordered.rs
+++ b/src/tests/modules/ordered.rs
@@ -163,18 +163,34 @@ fn test_getters() {
 #[test]
 fn remove() {
     let _guard = LOCK.run_concurrently();
+
     let mut doc = Document::new();
-    doc.insert("first", Bson::Int32(1));
-    doc.insert("second", Bson::String("foo".to_owned()));
-    doc.insert("alphanumeric", Bson::String("bar".to_owned()));
+    doc.insert("first", 1i32);
+    doc.insert("second", "foo");
+    doc.insert("third", "bar".to_owned());
+    doc.insert("fourth", "bar".to_owned());
 
-    assert!(doc.remove("second").is_some());
-    assert!(doc.remove("none").is_none());
-
-    let expected_keys = vec!["first", "alphanumeric"];
+    let mut expected_keys = vec![
+        "first".to_owned(),
+        "second".to_owned(),
+        "third".to_owned(),
+        "fourth".to_owned(),
+    ];
 
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);
+
+    assert_eq!(doc.remove("none"), None);
+
+    assert!(doc.remove("second").is_some());
+    expected_keys.remove(1);
+    let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
+    assert_eq!(keys, expected_keys);
+
+    assert!(doc.remove("first").is_some());
+    expected_keys.remove(0);
+    let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
+    assert_eq!(keys, expected_keys);
 }
 
 #[test]


### PR DESCRIPTION
RUST-283

This PR updates `Document` to wrap an `IndexMap` (from the `indexmap` crate) instead of `LinkedHashMap` from the now defunct `linked-hash-map` crate.

As part of that, I also updated the `Entry` API to match that of `IndexMap` / `std::HashMap`, since ours used to be slightly different.