### PR TITLE
RUST-747 Add serde helper to deserialize hex string from ObjectId

### DIFF
--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -2,9 +2,7 @@
 
 use std::{convert::TryFrom, result::Result};
 
-use serde::{ser, Serialize, Serializer};
-
-use crate::oid::ObjectId;
+use serde::{ser, Serializer};
 
 pub use bson_datetime_as_iso_string::{
     deserialize as deserialize_bson_datetime_from_iso_string,
@@ -14,25 +12,22 @@ pub use chrono_datetime_as_bson_datetime::{
     deserialize as deserialize_chrono_datetime_from_bson_datetime,
     serialize as serialize_chrono_datetime_as_bson_datetime,
 };
-pub use iso_string_as_bson_datetime::{
-    deserialize as deserialize_iso_string_from_bson_datetime,
-    serialize as serialize_iso_string_as_bson_datetime,
-};
 pub use hex_string_as_object_id::{
     deserialize as deserialize_hex_string_from_object_id,
     serialize as serialize_hex_string_as_object_id,
 };
+pub use iso_string_as_bson_datetime::{
+    deserialize as deserialize_iso_string_from_bson_datetime,
+    serialize as serialize_iso_string_as_bson_datetime,
+};
 pub use timestamp_as_u32::{
-    deserialize as deserialize_timestamp_from_u32,
-    serialize as serialize_timestamp_as_u32,
+    deserialize as deserialize_timestamp_from_u32, serialize as serialize_timestamp_as_u32,
 };
 pub use u32_as_timestamp::{
-    deserialize as deserialize_u32_from_timestamp,
-    serialize as serialize_u32_as_timestamp,
+    deserialize as deserialize_u32_from_timestamp, serialize as serialize_u32_as_timestamp,
 };
 pub use uuid_as_binary::{
-    deserialize as deserialize_uuid_from_binary,
-    serialize as serialize_uuid_as_binary,
+    deserialize as deserialize_uuid_from_binary, serialize as serialize_uuid_as_binary,
 };
 
 /// Attempts to serialize a u32 as an i32. Errors if an exact conversion is not possible.

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -208,21 +208,6 @@ pub mod hex_string_as_object_id {
     }
 }
 
-/// Serializes a hex string as an ObjectId.
-#[deprecated]
-pub fn serialize_hex_string_as_object_id<S: Serializer>(
-    val: &str,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    match ObjectId::with_string(val) {
-        Ok(oid) => oid.serialize(serializer),
-        Err(_) => Err(ser::Error::custom(format!(
-            "cannot convert {} to ObjectId",
-            val
-        ))),
-    }
-}
-
 /// Contains functions to serialize a Uuid as a bson::Binary and deserialize a Uuid from a
 /// bson::Binary.
 ///

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -172,7 +172,7 @@ pub mod bson_datetime_as_iso_string {
 }
 
 /// Contains functions to serialize a hex string as an ObjectId and deserialize a
-/// a hex string from an ObjectId
+/// hex string from an ObjectId
 ///
 /// ```rust
 /// # use serde::{Serialize, Deserialize};

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -9,6 +9,7 @@ use crate::{
     oid::ObjectId,
     serde_helpers,
     serde_helpers::{
+        hex_string_as_object_id,
         bson_datetime_as_iso_string,
         chrono_datetime_as_bson_datetime,
         iso_string_as_bson_datetime,
@@ -727,18 +728,18 @@ fn test_datetime_helpers() {
 fn test_oid_helpers() {
     let _guard = LOCK.run_concurrently();
 
-    #[derive(Serialize)]
+    #[derive(Serialize, Deserialize)]
     struct A {
-        #[serde(serialize_with = "serde_helpers::serialize_hex_string_as_object_id")]
+        #[serde(with = "hex_string_as_object_id")]
         oid: String,
     }
 
     let oid = ObjectId::new();
-    let a = A {
-        oid: oid.to_string(),
-    };
+    let a = A { oid: oid.to_string() };
     let doc = to_document(&a).unwrap();
-    assert_eq!(doc.get_object_id("oid").unwrap(), oid);
+    assert_eq!(doc.get_object_id("oid").unwrap(), oid); 
+    let a: A = from_document(doc).unwrap();
+    assert_eq!(a.oid, oid.to_string());
 }
 
 #[test]


### PR DESCRIPTION
This PR tries to solve an issue I had in a project recently, where 
serializing a String as an ObjectId works fine using the already provided serde_helper function,
but (implicitly) deserializing said ObjectId back to a String would fail.

You can quickly test this by setting up a project with
```rust
[dependencies]
bson = "1.2.2"
serde = "1.0.125"
```

and 

```rust
use bson::serde_helpers::*;
use serde::{Deserialize, Serialize};

#[derive(Debug, Serialize, Deserialize)]
struct Test {
    #[serde(serialize_with = "serialize_hex_string_as_object_id")]
    id: String,
}

fn main() {
    let test_struct = Test {
        id: "6079529e00b3405c004ea780".to_string(),
    };

    let doc = bson::to_document(&test_struct).unwrap();
    println!("{:#?}", &doc);

    let deser_struct: Test = bson::from_document(doc).unwrap();
    println!("{:#?}", &deser_struct);
}
```

Above code will panic with a `DeserializationError { message: "invalid type: map, expected a string" }` at the second `unwrap()`.

In my project, I solved this using my own deserializer function,
which I then implemented similarly in serde_helpers:
```rust
pub fn deserialize_object_id_to_hex_string<'de, D>(deserializer: D) -> Result<String, D::Error>
where
    D: Deserializer<'de>,
{
    let object_id = ObjectId::deserialize(deserializer)?;
    Ok(object_id.to_hex())
}
```

Since this is my first Rust PR, I would like to ask for assistance in two things:
- the previously provided function `serialize_hex_string_as_object_id()` already uses the name I would like to use as the name for the exported function, to follow the naming convention of the rest. (This is also why the PR build will fail for now). However, renaming the existing function would be a breaking change. How would we deal with this?

- I marked the existing function as deprecated, I assume this would need an additional version argument. The function could also be removed altogether of course, since it was moved into the newly created module.

