### PR TITLE
RUST-738 Implement Clone on error types

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -26,7 +26,7 @@ use crate::{
 
 /// Error to indicate that either a value was empty or it contained an unexpected
 /// type, for use with the direct getters.
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 #[non_exhaustive]
 pub enum ValueAccessError {
     /// Cannot find the expected field with the specified key

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -27,7 +27,7 @@ use serde::de::{Error as _, Unexpected};
 
 use crate::{extjson::models, oid, Bson, Document};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 /// Error cases that can occur during deserialization from [extended JSON](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
 pub enum Error {

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -31,7 +31,7 @@ lazy_static! {
 }
 
 /// Errors that can occur during OID construction and generation.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// An invalid argument was passed in.

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -28,8 +28,8 @@ pub enum Error {
     /// Returned when serialization of an unsigned integer was attempted. BSON only supports
     /// 32-bit and 64-bit signed integers.
     ///
-    /// To allow serialization of unsigned integers as signed integers, enable the "u2i" feature
-    /// flag.
+    /// To serialize unsigned integers to BSON, use an appropriate helper from
+    /// [`crate::serde_helpers`] or enable the "u2i" feature flag.
     UnsupportedUnsignedInteger(u64),
 
     #[cfg(feature = "u2i")]
@@ -53,8 +53,8 @@ impl fmt::Display for Error {
             Error::UnsupportedUnsignedInteger(value) => write!(
                 fmt,
                 "BSON does not support unsigned integers, cannot serialize value: {}. To \
-                 serialize unsigned integers as signed integers, use an appropriate serde helper \
-                 or enable the u2i feature.",
+                 serialize unsigned integers to BSON, use an appropriate serde helper or enable \
+                 the u2i feature.",
                 value
             ),
             #[cfg(feature = "u2i")]

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -117,14 +117,14 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_u8(self, _value: u8) -> crate::ser::Result<Bson> {
+    fn serialize_u8(self, value: u8) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
-            Ok(Bson::Int32(_value as i32))
+            Ok(Bson::Int32(value as i32))
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedInteger(value as u64))
     }
 
     #[inline]
@@ -133,14 +133,14 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_u16(self, _value: u16) -> crate::ser::Result<Bson> {
+    fn serialize_u16(self, value: u16) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
-            Ok(Bson::Int32(_value as i32))
+            Ok(Bson::Int32(value as i32))
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedInteger(value as u64))
     }
 
     #[inline]
@@ -149,14 +149,14 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_u32(self, _value: u32) -> crate::ser::Result<Bson> {
+    fn serialize_u32(self, value: u32) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
-            Ok(Bson::Int64(_value as i64))
+            Ok(Bson::Int64(value as i64))
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedInteger(value as u64))
     }
 
     #[inline]
@@ -165,19 +165,19 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_u64(self, _value: u64) -> crate::ser::Result<Bson> {
+    fn serialize_u64(self, value: u64) -> crate::ser::Result<Bson> {
         #[cfg(feature = "u2i")]
         {
             use std::convert::TryFrom;
 
-            match i64::try_from(_value) {
+            match i64::try_from(value) {
                 Ok(ivalue) => Ok(Bson::Int64(ivalue)),
-                Err(_) => Err(Error::UnsignedTypesValueExceedsRange(_value)),
+                Err(_) => Err(Error::UnsignedIntegerExceededRange(_value)),
             }
         }
 
         #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedType)
+        Err(Error::UnsupportedUnsignedInteger(value))
     }
 
     #[inline]

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -172,7 +172,7 @@ impl ser::Serializer for Serializer {
 
             match i64::try_from(value) {
                 Ok(ivalue) => Ok(Bson::Int64(ivalue)),
-                Err(_) => Err(Error::UnsignedIntegerExceededRange(_value)),
+                Err(_) => Err(Error::UnsignedIntegerExceededRange(value)),
             }
         }
 

--- a/src/tests/modules/ser.rs
+++ b/src/tests/modules/ser.rs
@@ -86,7 +86,7 @@ fn dec128() {
 fn uint8() {
     let _guard = LOCK.run_concurrently();
     let obj_min: ser::Result<Bson> = to_bson(&u8::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedType));
+    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn uint8_u2i() {
 fn uint16() {
     let _guard = LOCK.run_concurrently();
     let obj_min: ser::Result<Bson> = to_bson(&u16::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedType));
+    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn uint16_u2i() {
 fn uint32() {
     let _guard = LOCK.run_concurrently();
     let obj_min: ser::Result<Bson> = to_bson(&u32::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedType));
+    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn uint32_u2i() {
 fn uint64() {
     let _guard = LOCK.run_concurrently();
     let obj_min: ser::Result<Bson> = to_bson(&u64::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedType));
+    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
 }
 
 #[test]
@@ -163,7 +163,7 @@ fn uint64_u2i() {
     let obj_max: ser::Result<Bson> = to_bson(&u64::MAX);
     assert_matches!(
         obj_max,
-        Err(ser::Error::UnsignedTypesValueExceedsRange(u64::MAX))
+        Err(ser::Error::UnsignedIntegerExceededRange(u64::MAX))
     );
 }
 


### PR DESCRIPTION
RUST-738

This PR implements `Clone` on the various error types in the crate. It also updates a few of the error cases to include more information and removes redundant ones.

Once this PR merges, I'll open a companion one on the driver to remove the `Arc` wrappers around the BSON cases.