### PR TITLE
RUST-765 Ensure API meets Rust API guidelines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,20 @@
 [package]
 name = "bson"
-version = "1.2.0"
+version = "2.0.0-beta"
 authors = [
     "Y. T. Chung <zonyitoo@gmail.com>",
     "Kevin Yeh <kevinyeah@utexas.edu>",
-    "Saghm Rossi <saghmrossi@gmail.com>"
+    "Saghm Rossi <saghmrossi@gmail.com>",
+    "Patrick Freed <patrick.freed@mongodb.com>",
+    "Isabel Atkinson <isabel.atkinson@mongodb.com>",
 ]
 description = "Encoding and decoding support for BSON in Rust"
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/mongodb/bson-rust"
-documentation = "https://docs.rs/crate/bson"
+repository = "https://github.com/mongodb/bson-rust"
 edition = "2018"
+keywords = ["bson", "mongodb", "serde", "serialization", "deserialization"]
+categories = ["encoding"]
 
 # By default cargo include everything git include
 # cargo diet can help to manage what's not useful.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ uuid = "0.8.1"
 assert_matches = "1.2"
 serde_bytes = "0.11"
 pretty_assertions = "0.6.1"
+chrono = { version = "0.4", features = ["serde"] }
 
 [package.metadata.docs.rs]
 features = ["decimal128"]

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let arr = vec![
         Bson::String("blah".to_string()),
-        Bson::DateTime(chrono::Utc::now()),
+        Bson::DateTime(chrono::Utc::now().into()),
         Bson::ObjectId(oid::ObjectId::from_bytes([
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
         ])),

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -9,7 +9,7 @@ fn main() {
     let arr = vec![
         Bson::String("blah".to_string()),
         Bson::DateTime(chrono::Utc::now()),
-        Bson::ObjectId(oid::ObjectId::with_bytes([
+        Bson::ObjectId(oid::ObjectId::from_bytes([
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
         ])),
     ];

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -278,7 +278,7 @@ impl From<u64> for Bson {
 
 impl From<[u8; 12]> for Bson {
     fn from(a: [u8; 12]) -> Bson {
-        Bson::ObjectId(oid::ObjectId::with_bytes(a))
+        Bson::ObjectId(oid::ObjectId::from_bytes(a))
     }
 }
 
@@ -607,7 +607,7 @@ impl Bson {
         match keys.as_slice() {
             ["$oid"] => {
                 if let Ok(oid) = doc.get_str("$oid") {
-                    if let Ok(oid) = ObjectId::with_string(oid) {
+                    if let Ok(oid) = ObjectId::parse_str(oid) {
                         return Bson::ObjectId(oid);
                     }
                 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -21,10 +21,7 @@
 
 //! BSON definition
 
-use std::{
-    fmt::{self, Debug, Display},
-    ops::{Deref, DerefMut},
-};
+use std::fmt::{self, Debug, Display};
 
 use chrono::{Datelike, SecondsFormat, TimeZone, Utc};
 use serde_json::{json, Value};
@@ -68,7 +65,7 @@ pub enum Bson {
     /// [ObjectId](http://dochub.mongodb.org/core/objectids)
     ObjectId(oid::ObjectId),
     /// UTC datetime
-    DateTime(chrono::DateTime<Utc>),
+    DateTime(crate::DateTime),
     /// Symbol (Deprecated)
     Symbol(String),
     /// [128-bit decimal floating point](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst)
@@ -290,7 +287,7 @@ impl From<oid::ObjectId> for Bson {
 
 impl From<chrono::DateTime<Utc>> for Bson {
     fn from(a: chrono::DateTime<Utc>) -> Bson {
-        Bson::DateTime(a)
+        Bson::DateTime(DateTime(a))
     }
 }
 
@@ -373,15 +370,15 @@ impl Bson {
                 })
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.year() <= 99999 => {
-                let seconds_format = if v.timestamp_subsec_millis() == 0 {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.0.year() <= 99999 => {
+                let seconds_format = if v.0.timestamp_subsec_millis() == 0 {
                     SecondsFormat::Secs
                 } else {
                     SecondsFormat::Millis
                 };
 
                 json!({
-                    "$date": v.to_rfc3339_opts(seconds_format, true),
+                    "$date": v.0.to_rfc3339_opts(seconds_format, true),
                 })
             }
             Bson::DateTime(v) => json!({
@@ -539,15 +536,15 @@ impl Bson {
                     "$oid": v.to_string(),
                 }
             }
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.year() <= 99999 => {
-                let seconds_format = if v.timestamp_subsec_millis() == 0 {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.0.year() <= 99999 => {
+                let seconds_format = if v.0.timestamp_subsec_millis() == 0 {
                     SecondsFormat::Secs
                 } else {
                     SecondsFormat::Millis
                 };
 
                 doc! {
-                    "$date": v.to_rfc3339_opts(seconds_format, true),
+                    "$date": v.0.to_rfc3339_opts(seconds_format, true),
                 }
             }
             Bson::DateTime(v) => doc! {
@@ -738,12 +735,12 @@ impl Bson {
 
             ["$date"] => {
                 if let Ok(date) = doc.get_i64("$date") {
-                    return Bson::DateTime(DateTime::from_i64(date).into());
+                    return Bson::DateTime(DateTime::from_millis(date));
                 }
 
                 if let Ok(date) = doc.get_str("$date") {
                     if let Ok(date) = chrono::DateTime::parse_from_rfc3339(date) {
-                        return Bson::DateTime(date.into());
+                        return Bson::DateTime(date.with_timezone(&Utc).into());
                     }
                 }
             }
@@ -888,7 +885,7 @@ impl Bson {
     }
 
     /// If `Bson` is `DateTime`, return its value. Returns `None` otherwise
-    pub fn as_datetime(&self) -> Option<&chrono::DateTime<Utc>> {
+    pub fn as_datetime(&self) -> Option<&crate::DateTime> {
         match *self {
             Bson::DateTime(ref v) => Some(v),
             _ => None,
@@ -897,7 +894,7 @@ impl Bson {
 
     /// If `Bson` is `DateTime`, return a mutable reference to its value. Returns `None`
     /// otherwise
-    pub fn as_datetime_mut(&mut self) -> Option<&mut chrono::DateTime<Utc>> {
+    pub fn as_datetime_mut(&mut self) -> Option<&mut crate::DateTime> {
         match *self {
             Bson::DateTime(ref mut v) => Some(v),
             _ => None,
@@ -973,76 +970,78 @@ impl Timestamp {
     }
 }
 
-/// `DateTime` representation in struct for serde serialization
+/// Struct representing a BSON datetime.
 ///
-/// Just a helper for convenience
+/// Is is recommended to use a [`chrono::DateTime`] for date operations
+/// and to convert it to/from a [`crate::DateTime`] via the `From`/`Into` implementations.
+///
+/// ```
+/// use chrono::prelude::*;
+/// # fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+/// let chrono_dt: chrono::DateTime<Utc> = "2014-11-28T12:00:09Z".parse()?;
+/// let bson_dt: bson::DateTime = chrono_dt.into();
+/// let back_to_chrono: chrono::DateTime<Utc> = bson_dt.into();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// This type differs from [`chrono::DateTime`] in that it serializes to and deserializes from a
+/// BSON datetime rather than an ISO-8601 formatted string. This means that in non-BSON formats, it
+/// will serialize to and deserialize from that format's equivalent of the [extended JSON representation](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) of a datetime. To serialize a
+/// [`chrono::DateTime`] as a BSON datetime, you can use
+/// [`serde_helpers::chrono_0_4_datetime_as_bson_datetime`].
 ///
 /// ```rust
 /// use serde::{Serialize, Deserialize};
-/// use bson::DateTime;
 ///
 /// #[derive(Serialize, Deserialize)]
 /// struct Foo {
-///     date_time: DateTime,
+///     // serializes as a BSON datetime.
+///     date_time: bson::DateTime,
+///
+///     // serializes as an ISO-8601 string.
+///     chrono_datetime: chrono::DateTime<chrono::Utc>,
+///
+///     // serializes as a BSON datetime.
+///     #[serde(with = "bson::serde_helpers::chrono_0_4_datetime_as_bson_datetime")]
+///     chrono_as_bson: chrono::DateTime<chrono::Utc>,
 /// }
 /// ```
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Copy, Clone)]
-pub struct DateTime(pub chrono::DateTime<Utc>);
+pub struct DateTime(chrono::DateTime<Utc>);
 
-impl DateTime {
-    pub(crate) fn from_i64(date: i64) -> Self {
-        let mut num_secs = date / 1000;
-        let mut num_millis = date % 1000;
+impl crate::DateTime {
+    pub(crate) fn from_millis(date: i64) -> Self {
+        Utc.timestamp_millis(date).into()
+    }
 
-        // The chrono API only lets us create a DateTime with an i64 number of seconds
-        // and a u32 number of nanoseconds. In the case of a negative timestamp, this
-        // means that we need to turn the negative fractional part into a positive and
-        // shift the number of seconds down. For example:
-        //
-        //     date       = -4300 ms
-        //     num_secs   = date / 1000 = -4300 / 1000 = -4
-        //     num_millis = date % 1000 = -4300 % 1000 = -300
-        //
-        // Since num_millis is less than 0:
-        //     num_secs   = num_secs -1 = -4 - 1 = -5
-        //     num_millis = num_nanos + 1000 = -300 + 1000 = 700
-        //
-        // Instead of -4 seconds and -300 milliseconds, we now have -5 seconds and +700
-        // milliseconds, which expresses the same timestamp, but in a way we can create
-        // a DateTime with.
-        if num_millis < 0 {
-            num_secs -= 1;
-            num_millis += 1000;
-        };
+    /// Returns the number of non-leap-milliseconds since January 1, 1970 UTC.
+    pub fn timestamp_millis(&self) -> i64 {
+        self.0.timestamp_millis()
+    }
 
-        Utc.timestamp(num_secs, num_millis as u32 * 1_000_000)
-            .into()
+    /// If this DateTime is sub-millisecond precision. BSON only supports millisecond precision, so
+    /// this should be checked before serializing to BSON.
+    pub(crate) fn is_sub_millis_precision(&self) -> bool {
+        self.0.timestamp_subsec_micros() % 1000 != 0
     }
 }
 
-impl Deref for DateTime {
-    type Target = chrono::DateTime<Utc>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl Display for crate::DateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }
 
-impl DerefMut for DateTime {
-    fn deref_mut(&mut self) -> &mut chrono::DateTime<Utc> {
-        &mut self.0
-    }
-}
-
-impl From<DateTime> for chrono::DateTime<Utc> {
+impl From<crate::DateTime> for chrono::DateTime<Utc> {
     fn from(utc: DateTime) -> Self {
         utc.0
     }
 }
 
-impl From<chrono::DateTime<Utc>> for DateTime {
-    fn from(x: chrono::DateTime<Utc>) -> Self {
-        DateTime(x)
+impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for crate::DateTime {
+    fn from(x: chrono::DateTime<T>) -> Self {
+        DateTime(x.with_timezone(&Utc))
     }
 }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
 
     /// While decoding a `Document` from bytes, an unexpected or unsupported element type was
     /// encountered.
+    #[non_exhaustive]
     UnrecognizedDocumentElementType {
         /// The key at which an unexpected/unsupported element type was encountered.
         key: String,
@@ -26,12 +27,14 @@ pub enum Error {
     },
 
     /// There was an error with the syntactical structure of the BSON.
+    #[non_exhaustive]
     SyntaxError { message: String },
 
     /// The end of the BSON input was reached too soon.
     EndOfStream,
 
     /// An invalid datetime was encountered while decoding.
+    #[non_exhaustive]
     InvalidDateTime {
         /// The key at which an unexpected/unsupported datetime was encountered.
         key: String,
@@ -42,6 +45,7 @@ pub enum Error {
 
     /// A general error encountered during deserialization.
     /// See: https://docs.serde.rs/serde/de/trait.Error.html
+    #[non_exhaustive]
     DeserializationError {
         /// A message describing the error.
         message: String,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -263,7 +263,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
             for x in &mut objid {
                 *x = read_u8(reader)?;
             }
-            Bson::ObjectId(oid::ObjectId::with_bytes(objid))
+            Bson::ObjectId(oid::ObjectId::from_bytes(objid))
         }
         Some(ElementType::Boolean) => {
             let val = read_u8(reader)?;
@@ -345,7 +345,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
             reader.read_exact(&mut objid)?;
             Bson::DbPointer(DbPointer {
                 namespace,
-                id: oid::ObjectId::with_bytes(objid),
+                id: oid::ObjectId::from_bytes(objid),
             })
         }
         Some(ElementType::MaxKey) => Bson::MaxKey,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -327,7 +327,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
             let time = read_i64(reader)?;
 
             match Utc.timestamp_millis_opt(time) {
-                LocalResult::Single(t) => Bson::DateTime(t),
+                LocalResult::Single(t) => Bson::DateTime(t.into()),
                 _ => {
                     return Err(Error::InvalidDateTime {
                         key,

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -23,7 +23,7 @@ use crate::{
     spec::BinarySubtype,
 };
 
-pub struct BsonVisitor;
+pub(crate) struct BsonVisitor;
 
 impl<'de> Deserialize<'de> for ObjectId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -33,7 +33,7 @@ impl<'de> Deserialize<'de> for ObjectId {
         deserializer
             .deserialize_any(BsonVisitor)
             .and_then(|bson| match bson {
-                Bson::String(oid) => ObjectId::with_string(&oid).map_err(de::Error::custom),
+                Bson::String(oid) => ObjectId::parse_str(&oid).map_err(de::Error::custom),
                 Bson::ObjectId(oid) => Ok(oid),
                 _ => {
                     let err = format!(

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -18,7 +18,7 @@ use serde::de::{
 use crate::decimal128::Decimal128;
 use crate::{
     bson::{Binary, Bson, DateTime, DbPointer, JavaScriptCodeWithScope, Regex, Timestamp},
-    document::{Document, DocumentIntoIterator, DocumentVisitor},
+    document::{Document, DocumentVisitor, IntoIter},
     oid::ObjectId,
     spec::BinarySubtype,
 };
@@ -611,7 +611,7 @@ impl<'de> SeqAccess<'de> for SeqDeserializer {
 }
 
 struct MapDeserializer {
-    iter: DocumentIntoIterator,
+    iter: IntoIter,
     value: Option<Bson>,
     len: usize,
 }

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -389,9 +389,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
         let (variant, value) = match iter.next() {
             Some(v) => v,
             None => {
-                return Err(crate::de::Error::SyntaxError {
-                    message: "expected a variant name".to_owned(),
-                })
+                return Err(crate::de::Error::invalid_value(
+                    Unexpected::Other("empty document"),
+                    &"variant name",
+                ))
             }
         };
 

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -762,7 +762,7 @@ impl<'de> Deserialize<'de> for DateTime {
         D: de::Deserializer<'de>,
     {
         match Bson::deserialize(deserializer)? {
-            Bson::DateTime(dt) => Ok(DateTime(dt)),
+            Bson::DateTime(dt) => Ok(dt),
             _ => Err(D::Error::custom("expecting DateTime")),
         }
     }

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -79,42 +79,10 @@ impl Decimal128 {
     ///
     /// let num: i32 = 23;
     /// let dec128 = Decimal128::from_i32(num);
-    /// let int = dec128.into_i32();
-    /// assert_eq!(int, num);
-    /// ```
-    #[allow(clippy::wrong_self_convention)]
-    #[deprecated(since = "0.15.0", note = "Replaced by `to_i32`")]
-    pub fn into_i32(&self) -> i32 {
-        Into::into(self.inner)
-    }
-
-    /// Construct a `Decimal128` from a `i32` number.
-    ///
-    /// ```rust
-    /// use bson::decimal128::Decimal128;
-    ///
-    /// let num: i32 = 23;
-    /// let dec128 = Decimal128::from_i32(num);
     /// let int = dec128.to_i32();
     /// assert_eq!(int, num);
     /// ```
     pub fn to_i32(&self) -> i32 {
-        Into::into(self.inner)
-    }
-
-    /// Construct a `Decimal128` from a `i32` number.
-    ///
-    /// ```rust
-    /// use bson::decimal128::Decimal128;
-    ///
-    /// let num: u32 = 23;
-    /// let dec128 = Decimal128::from_u32(num);
-    /// let int = dec128.into_u32();
-    /// assert_eq!(int, num);
-    /// ```
-    #[allow(clippy::wrong_self_convention)]
-    #[deprecated(since = "0.15.0", note = "Replaced by `to_u32`")]
-    pub fn into_u32(&self) -> u32 {
         Into::into(self.inner)
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use ahash::RandomState;
-use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 use serde::de::{self, Error, MapAccess, Visitor};
 
@@ -438,7 +437,7 @@ impl Document {
     }
 
     /// Get a reference to a UTC datetime value for this key if it exists and has the correct type.
-    pub fn get_datetime(&self, key: impl AsRef<str>) -> ValueAccessResult<&DateTime<Utc>> {
+    pub fn get_datetime(&self, key: impl AsRef<str>) -> ValueAccessResult<&crate::DateTime> {
         match self.get(key) {
             Some(&Bson::DateTime(ref v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -451,7 +450,7 @@ impl Document {
     pub fn get_datetime_mut(
         &mut self,
         key: impl AsRef<str>,
-    ) -> ValueAccessResult<&mut DateTime<Utc>> {
+    ) -> ValueAccessResult<&mut crate::DateTime> {
         match self.get_mut(key) {
             Some(&mut Bson::DateTime(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),

--- a/src/document.rs
+++ b/src/document.rs
@@ -201,18 +201,18 @@ impl Document {
     }
 
     /// Returns a reference to the Bson corresponding to the key.
-    pub fn get(&self, key: &str) -> Option<&Bson> {
-        self.inner.get(key)
+    pub fn get(&self, key: impl AsRef<str>) -> Option<&Bson> {
+        self.inner.get(key.as_ref())
     }
 
     /// Gets a mutable reference to the Bson corresponding to the key
-    pub fn get_mut(&mut self, key: &str) -> Option<&mut Bson> {
-        self.inner.get_mut(key)
+    pub fn get_mut(&mut self, key: impl AsRef<str>) -> Option<&mut Bson> {
+        self.inner.get_mut(key.as_ref())
     }
 
     /// Get a floating point value for this key if it exists and has
     /// the correct type.
-    pub fn get_f64(&self, key: &str) -> ValueAccessResult<f64> {
+    pub fn get_f64(&self, key: impl AsRef<str>) -> ValueAccessResult<f64> {
         match self.get(key) {
             Some(&Bson::Double(v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -222,7 +222,7 @@ impl Document {
 
     /// Get a mutable reference to a floating point value for this key if it exists and has
     /// the correct type.
-    pub fn get_f64_mut(&mut self, key: &str) -> ValueAccessResult<&mut f64> {
+    pub fn get_f64_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut f64> {
         match self.get_mut(key) {
             Some(&mut Bson::Double(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -232,7 +232,7 @@ impl Document {
 
     /// Get a reference to a Decimal128 value for key, if it exists.
     #[cfg(feature = "decimal128")]
-    pub fn get_decimal128(&self, key: &str) -> ValueAccessResult<&Decimal128> {
+    pub fn get_decimal128(&self, key: impl AsRef<str>) -> ValueAccessResult<&Decimal128> {
         match self.get(key) {
             Some(&Bson::Decimal128(ref v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -242,7 +242,10 @@ impl Document {
 
     /// Get a mutable reference to a Decimal128 value for key, if it exists.
     #[cfg(feature = "decimal128")]
-    pub fn get_decimal128_mut(&mut self, key: &str) -> ValueAccessResult<&mut Decimal128> {
+    pub fn get_decimal128_mut(
+        &mut self,
+        key: impl AsRef<str>,
+    ) -> ValueAccessResult<&mut Decimal128> {
         match self.get_mut(key) {
             Some(&mut Bson::Decimal128(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -251,7 +254,7 @@ impl Document {
     }
 
     /// Get a string slice this key if it exists and has the correct type.
-    pub fn get_str(&self, key: &str) -> ValueAccessResult<&str> {
+    pub fn get_str(&self, key: impl AsRef<str>) -> ValueAccessResult<&str> {
         match self.get(key) {
             Some(&Bson::String(ref v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -260,7 +263,7 @@ impl Document {
     }
 
     /// Get a mutable string slice this key if it exists and has the correct type.
-    pub fn get_str_mut(&mut self, key: &str) -> ValueAccessResult<&mut str> {
+    pub fn get_str_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut str> {
         match self.get_mut(key) {
             Some(&mut Bson::String(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -270,7 +273,7 @@ impl Document {
 
     /// Get a reference to an array for this key if it exists and has
     /// the correct type.
-    pub fn get_array(&self, key: &str) -> ValueAccessResult<&Array> {
+    pub fn get_array(&self, key: impl AsRef<str>) -> ValueAccessResult<&Array> {
         match self.get(key) {
             Some(&Bson::Array(ref v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -280,7 +283,7 @@ impl Document {
 
     /// Get a mutable reference to an array for this key if it exists and has
     /// the correct type.
-    pub fn get_array_mut(&mut self, key: &str) -> ValueAccessResult<&mut Array> {
+    pub fn get_array_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut Array> {
         match self.get_mut(key) {
             Some(&mut Bson::Array(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -290,7 +293,7 @@ impl Document {
 
     /// Get a reference to a document for this key if it exists and has
     /// the correct type.
-    pub fn get_document(&self, key: &str) -> ValueAccessResult<&Document> {
+    pub fn get_document(&self, key: impl AsRef<str>) -> ValueAccessResult<&Document> {
         match self.get(key) {
             Some(&Bson::Document(ref v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -300,7 +303,7 @@ impl Document {
 
     /// Get a mutable reference to a document for this key if it exists and has
     /// the correct type.
-    pub fn get_document_mut(&mut self, key: &str) -> ValueAccessResult<&mut Document> {
+    pub fn get_document_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut Document> {
         match self.get_mut(key) {
             Some(&mut Bson::Document(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -309,7 +312,7 @@ impl Document {
     }
 
     /// Get a bool value for this key if it exists and has the correct type.
-    pub fn get_bool(&self, key: &str) -> ValueAccessResult<bool> {
+    pub fn get_bool(&self, key: impl AsRef<str>) -> ValueAccessResult<bool> {
         match self.get(key) {
             Some(&Bson::Boolean(v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -318,7 +321,7 @@ impl Document {
     }
 
     /// Get a mutable reference to a bool value for this key if it exists and has the correct type.
-    pub fn get_bool_mut(&mut self, key: &str) -> ValueAccessResult<&mut bool> {
+    pub fn get_bool_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut bool> {
         match self.get_mut(key) {
             Some(&mut Bson::Boolean(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -327,12 +330,12 @@ impl Document {
     }
 
     /// Returns wether this key has a null value
-    pub fn is_null(&self, key: &str) -> bool {
+    pub fn is_null(&self, key: impl AsRef<str>) -> bool {
         self.get(key) == Some(&Bson::Null)
     }
 
     /// Get an i32 value for this key if it exists and has the correct type.
-    pub fn get_i32(&self, key: &str) -> ValueAccessResult<i32> {
+    pub fn get_i32(&self, key: impl AsRef<str>) -> ValueAccessResult<i32> {
         match self.get(key) {
             Some(&Bson::Int32(v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -341,7 +344,7 @@ impl Document {
     }
 
     /// Get a mutable reference to an i32 value for this key if it exists and has the correct type.
-    pub fn get_i32_mut(&mut self, key: &str) -> ValueAccessResult<&mut i32> {
+    pub fn get_i32_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut i32> {
         match self.get_mut(key) {
             Some(&mut Bson::Int32(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -350,7 +353,7 @@ impl Document {
     }
 
     /// Get an i64 value for this key if it exists and has the correct type.
-    pub fn get_i64(&self, key: &str) -> ValueAccessResult<i64> {
+    pub fn get_i64(&self, key: impl AsRef<str>) -> ValueAccessResult<i64> {
         match self.get(key) {
             Some(&Bson::Int64(v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -359,7 +362,7 @@ impl Document {
     }
 
     /// Get a mutable reference to an i64 value for this key if it exists and has the correct type.
-    pub fn get_i64_mut(&mut self, key: &str) -> ValueAccessResult<&mut i64> {
+    pub fn get_i64_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut i64> {
         match self.get_mut(key) {
             Some(&mut Bson::Int64(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -368,7 +371,7 @@ impl Document {
     }
 
     /// Get a time stamp value for this key if it exists and has the correct type.
-    pub fn get_timestamp(&self, key: &str) -> ValueAccessResult<Timestamp> {
+    pub fn get_timestamp(&self, key: impl AsRef<str>) -> ValueAccessResult<Timestamp> {
         match self.get(key) {
             Some(&Bson::Timestamp(timestamp)) => Ok(timestamp),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -378,7 +381,7 @@ impl Document {
 
     /// Get a mutable reference to a time stamp value for this key if it exists and has the correct
     /// type.
-    pub fn get_timestamp_mut(&mut self, key: &str) -> ValueAccessResult<&mut Timestamp> {
+    pub fn get_timestamp_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut Timestamp> {
         match self.get_mut(key) {
             Some(&mut Bson::Timestamp(ref mut timestamp)) => Ok(timestamp),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -388,7 +391,7 @@ impl Document {
 
     /// Get a reference to a generic binary value for this key if it exists and has the correct
     /// type.
-    pub fn get_binary_generic(&self, key: &str) -> ValueAccessResult<&Vec<u8>> {
+    pub fn get_binary_generic(&self, key: impl AsRef<str>) -> ValueAccessResult<&Vec<u8>> {
         match self.get(key) {
             Some(&Bson::Binary(Binary {
                 subtype: BinarySubtype::Generic,
@@ -401,7 +404,10 @@ impl Document {
 
     /// Get a mutable reference generic binary value for this key if it exists and has the correct
     /// type.
-    pub fn get_binary_generic_mut(&mut self, key: &str) -> ValueAccessResult<&mut Vec<u8>> {
+    pub fn get_binary_generic_mut(
+        &mut self,
+        key: impl AsRef<str>,
+    ) -> ValueAccessResult<&mut Vec<u8>> {
         match self.get_mut(key) {
             Some(&mut Bson::Binary(Binary {
                 subtype: BinarySubtype::Generic,
@@ -413,7 +419,7 @@ impl Document {
     }
 
     /// Get an object id value for this key if it exists and has the correct type.
-    pub fn get_object_id(&self, key: &str) -> ValueAccessResult<ObjectId> {
+    pub fn get_object_id(&self, key: impl AsRef<str>) -> ValueAccessResult<ObjectId> {
         match self.get(key) {
             Some(&Bson::ObjectId(v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -423,7 +429,7 @@ impl Document {
 
     /// Get a mutable reference to an object id value for this key if it exists and has the correct
     /// type.
-    pub fn get_object_id_mut(&mut self, key: &str) -> ValueAccessResult<&mut ObjectId> {
+    pub fn get_object_id_mut(&mut self, key: impl AsRef<str>) -> ValueAccessResult<&mut ObjectId> {
         match self.get_mut(key) {
             Some(&mut Bson::ObjectId(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -432,7 +438,7 @@ impl Document {
     }
 
     /// Get a reference to a UTC datetime value for this key if it exists and has the correct type.
-    pub fn get_datetime(&self, key: &str) -> ValueAccessResult<&DateTime<Utc>> {
+    pub fn get_datetime(&self, key: impl AsRef<str>) -> ValueAccessResult<&DateTime<Utc>> {
         match self.get(key) {
             Some(&Bson::DateTime(ref v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -442,7 +448,10 @@ impl Document {
 
     /// Get a mutable reference to a UTC datetime value for this key if it exists and has the
     /// correct type.
-    pub fn get_datetime_mut(&mut self, key: &str) -> ValueAccessResult<&mut DateTime<Utc>> {
+    pub fn get_datetime_mut(
+        &mut self,
+        key: impl AsRef<str>,
+    ) -> ValueAccessResult<&mut DateTime<Utc>> {
         match self.get_mut(key) {
             Some(&mut Bson::DateTime(ref mut v)) => Ok(v),
             Some(_) => Err(ValueAccessError::UnexpectedType),
@@ -451,8 +460,8 @@ impl Document {
     }
 
     /// Returns true if the map contains a value for the specified key.
-    pub fn contains_key(&self, key: &str) -> bool {
-        self.inner.contains_key(key)
+    pub fn contains_key(&self, key: impl AsRef<str>) -> bool {
+        self.inner.contains_key(key.as_ref())
     }
 
     /// Gets a collection of all keys in the document.
@@ -488,8 +497,8 @@ impl Document {
 
     /// Takes the value of the entry out of the document, and returns it.
     /// Computes in **O(n)** time (average).
-    pub fn remove(&mut self, key: &str) -> Option<Bson> {
-        self.inner.shift_remove(key)
+    pub fn remove(&mut self, key: impl AsRef<str>) -> Option<Bson> {
+        self.inner.shift_remove(key.as_ref())
     }
 
     pub fn entry(&mut self, k: String) -> Entry {

--- a/src/document.rs
+++ b/src/document.rs
@@ -99,12 +99,12 @@ impl Debug for Document {
 }
 
 /// An iterator over Document entries.
-pub struct DocumentIntoIterator {
+pub struct IntoIter {
     inner: indexmap::map::IntoIter<String, Bson>,
 }
 
 /// An owning iterator over Document entries.
-pub struct DocumentIterator<'a> {
+pub struct Iter<'a> {
     inner: indexmap::map::Iter<'a, String, Bson>,
 }
 
@@ -136,10 +136,10 @@ impl<'a> Iterator for Values<'a> {
 
 impl IntoIterator for Document {
     type Item = (String, Bson);
-    type IntoIter = DocumentIntoIterator;
+    type IntoIter = IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        DocumentIntoIterator {
+        IntoIter {
             inner: self.inner.into_iter(),
         }
     }
@@ -147,10 +147,10 @@ impl IntoIterator for Document {
 
 impl<'a> IntoIterator for &'a Document {
     type Item = (&'a String, &'a Bson);
-    type IntoIter = DocumentIterator<'a>;
+    type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        DocumentIterator {
+        Iter {
             inner: self.inner.iter(),
         }
     }
@@ -166,7 +166,7 @@ impl FromIterator<(String, Bson)> for Document {
     }
 }
 
-impl<'a> Iterator for DocumentIntoIterator {
+impl<'a> Iterator for IntoIter {
     type Item = (String, Bson);
 
     fn next(&mut self) -> Option<(String, Bson)> {
@@ -174,7 +174,7 @@ impl<'a> Iterator for DocumentIntoIterator {
     }
 }
 
-impl<'a> Iterator for DocumentIterator<'a> {
+impl<'a> Iterator for Iter<'a> {
     type Item = (&'a String, &'a Bson);
 
     fn next(&mut self) -> Option<(&'a String, &'a Bson)> {
@@ -191,7 +191,7 @@ impl Document {
     }
 
     /// Gets an iterator over the entries of the map.
-    pub fn iter(&self) -> DocumentIterator {
+    pub fn iter(&self) -> Iter {
         self.into_iter()
     }
 

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -141,7 +141,7 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for Bson {
 
         if obj.contains_key("$date") {
             let extjson_datetime: models::DateTime = serde_json::from_value(obj.into())?;
-            return Ok(Bson::DateTime(extjson_datetime.parse()?.0));
+            return Ok(Bson::DateTime(extjson_datetime.parse()?));
         }
 
         if obj.contains_key("$minKey") {

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -241,7 +241,7 @@ impl DateTime {
         match self.body {
             DateTimeBody::Canonical(date) => {
                 let date = date.parse()?;
-                Ok(crate::DateTime::from_i64(date))
+                Ok(crate::DateTime::from_millis(date))
             }
             DateTimeBody::Relaxed(date) => {
                 let datetime: chrono::DateTime<Utc> =

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -81,7 +81,7 @@ pub(crate) struct ObjectId {
 
 impl ObjectId {
     pub(crate) fn parse(self) -> extjson::de::Result<oid::ObjectId> {
-        let oid = oid::ObjectId::with_string(self.oid.as_str())?;
+        let oid = oid::ObjectId::parse_str(self.oid.as_str())?;
         Ok(oid)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,6 @@
 //! that is also less error prone.
 
 #![allow(clippy::cognitive_complexity)]
-
 #![doc(html_root_url = "https://docs.rs/bson/1.2.2")]
 
 pub use self::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,8 @@
 
 #![allow(clippy::cognitive_complexity)]
 
+#![doc(html_root_url = "https://docs.rs/bson/1.2.2")]
+
 pub use self::{
     bson::{
         Array,

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
         key: Bson,
     },
 
+    /// Attempted to serialize a sub-millisecond precision datetime, which BSON does not support.
+    SubMillisecondPrecisionDateTime(crate::DateTime),
+
     /// A general error that ocurred during serialization.
     /// See: https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom
     SerializationError {
@@ -64,6 +67,12 @@ impl fmt::Display for Error {
                  An attempt to serialize the value: {} in a signed type failed due to the value's \
                  size.",
                 value
+            ),
+            Error::SubMillisecondPrecisionDateTime(dt) => write!(
+                fmt,
+                "BSON supports millisecond-precision datetimes, could not serialize datetime with \
+                 greater precision losslessly: {}",
+                dt
             ),
         }
     }

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -12,16 +12,14 @@ pub enum Error {
     IoError(Arc<io::Error>),
 
     /// A key could not be serialized to a BSON string.
-    InvalidMapKeyType {
-        /// The value that could not be used as a key.
-        key: Bson,
-    },
+    InvalidDocumentKey(Bson),
 
     /// Attempted to serialize a sub-millisecond precision datetime, which BSON does not support.
     SubMillisecondPrecisionDateTime(crate::DateTime),
 
     /// A general error that ocurred during serialization.
     /// See: https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom
+    #[non_exhaustive]
     SerializationError {
         /// A message describing the error.
         message: String,
@@ -50,7 +48,7 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::IoError(ref inner) => inner.fmt(fmt),
-            Error::InvalidMapKeyType { ref key } => write!(fmt, "Invalid map key type: {}", key),
+            Error::InvalidDocumentKey(ref key) => write!(fmt, "Invalid map key type: {}", key),
             Error::SerializationError { ref message } => message.fmt(fmt),
             #[cfg(not(feature = "u2i"))]
             Error::UnsupportedUnsignedInteger(value) => write!(

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -9,7 +9,7 @@ use crate::bson::Bson;
 #[non_exhaustive]
 pub enum Error {
     /// A [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html) encountered while serializing.
-    IoError(Arc<io::Error>),
+    Io(Arc<io::Error>),
 
     /// A key could not be serialized to a BSON string.
     InvalidDocumentKey(Bson),
@@ -40,14 +40,14 @@ pub enum Error {
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
-        Error::IoError(Arc::new(err))
+        Error::Io(Arc::new(err))
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::IoError(ref inner) => inner.fmt(fmt),
+            Error::Io(ref inner) => inner.fmt(fmt),
             Error::InvalidDocumentKey(ref key) => write!(fmt, "Invalid map key type: {}", key),
             Error::SerializationError { ref message } => message.fmt(fmt),
             #[cfg(not(feature = "u2i"))]
@@ -79,7 +79,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            Error::IoError(ref inner) => Some(inner.as_ref()),
+            Error::Io(ref inner) => Some(inner.as_ref()),
             _ => None,
         }
     }

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -571,7 +571,7 @@ impl Serialize for DateTime {
         S: ser::Serializer,
     {
         // Cloning a `DateTime` is extremely cheap
-        let value = Bson::DateTime(self.0);
+        let value = Bson::DateTime(*self);
         value.serialize(serializer)
     }
 }

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -84,6 +84,7 @@ impl Serialize for Bson {
 }
 
 /// Serde Serializer
+#[non_exhaustive]
 pub struct Serializer;
 
 impl Serializer {
@@ -440,7 +441,7 @@ impl SerializeMap for MapSerializer {
     fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> crate::ser::Result<()> {
         self.next_key = match to_bson(&key)? {
             Bson::String(s) => Some(s),
-            other => return Err(Error::InvalidMapKeyType { key: other }),
+            other => return Err(Error::InvalidDocumentKey(other)),
         };
         Ok(())
     }

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -279,7 +279,7 @@ pub mod hex_string_as_object_id {
 
     /// Serializes a hex string as an ObjectId.
     pub fn serialize<S: Serializer>(val: &str, serializer: S) -> Result<S::Ok, S::Error> {
-        match ObjectId::with_string(val) {
+        match ObjectId::parse_str(val) {
             Ok(oid) => oid.serialize(serializer),
             Err(_) => Err(ser::Error::custom(format!(
                 "cannot convert {} to ObjectId",

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -8,9 +8,9 @@ pub use bson_datetime_as_iso_string::{
     deserialize as deserialize_bson_datetime_from_iso_string,
     serialize as serialize_bson_datetime_as_iso_string,
 };
-pub use chrono_datetime_as_bson_datetime::{
-    deserialize as deserialize_chrono_datetime_from_bson_datetime,
-    serialize as serialize_chrono_datetime_as_bson_datetime,
+pub use chrono_0_4_datetime_as_bson_datetime::{
+    deserialize as deserialize_chrono_0_4_datetime_from_bson_datetime,
+    serialize as serialize_chrono_0_4_datetime_as_bson_datetime,
 };
 pub use hex_string_as_object_id::{
     deserialize as deserialize_hex_string_from_object_id,
@@ -30,9 +30,9 @@ pub use u32_as_timestamp::{
     serialize as serialize_u32_as_timestamp,
 };
 pub use u64_as_f64::{deserialize as deserialize_u64_from_f64, serialize as serialize_u64_as_f64};
-pub use uuid_as_binary::{
-    deserialize as deserialize_uuid_from_binary,
-    serialize as serialize_uuid_as_binary,
+pub use uuid_0_8_as_binary::{
+    deserialize as deserialize_uuid_0_8_from_binary,
+    serialize as serialize_uuid_0_8_as_binary,
 };
 
 /// Attempts to serialize a u32 as an i32. Errors if an exact conversion is not possible.
@@ -150,14 +150,14 @@ pub mod u64_as_f64 {
 ///
 /// ```rust
 /// # use serde::{Serialize, Deserialize};
-/// # use bson::serde_helpers::chrono_datetime_as_bson_datetime;
+/// # use bson::serde_helpers::chrono_0_4_datetime_as_bson_datetime;
 /// #[derive(Serialize, Deserialize)]
 /// struct Event {
-///     #[serde(with = "chrono_datetime_as_bson_datetime")]
+///     #[serde(with = "chrono_0_4_datetime_as_bson_datetime")]
 ///     pub date: chrono::DateTime<chrono::Utc>,
 /// }
 /// ```
-pub mod chrono_datetime_as_bson_datetime {
+pub mod chrono_0_4_datetime_as_bson_datetime {
     use crate::DateTime;
     use chrono::Utc;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -210,10 +210,10 @@ pub mod iso_string_as_bson_datetime {
 
     /// Serializes an ISO string as a DateTime.
     pub fn serialize<S: Serializer>(val: &str, serializer: S) -> Result<S::Ok, S::Error> {
-        let date = chrono::DateTime::from_str(val).map_err(|_| {
+        let date = chrono::DateTime::<chrono::Utc>::from_str(val).map_err(|_| {
             ser::Error::custom(format!("cannot convert {} to chrono::DateTime", val))
         })?;
-        Bson::DateTime(date).serialize(serializer)
+        Bson::DateTime(date.into()).serialize(serializer)
     }
 }
 
@@ -240,7 +240,7 @@ pub mod bson_datetime_as_iso_string {
         D: Deserializer<'de>,
     {
         let iso = String::deserialize(deserializer)?;
-        let date = chrono::DateTime::from_str(&iso).map_err(|_| {
+        let date = chrono::DateTime::<chrono::Utc>::from_str(&iso).map_err(|_| {
             de::Error::custom(format!("cannot convert {} to chrono::DateTime", iso))
         })?;
         Ok(DateTime::from(date))
@@ -289,20 +289,20 @@ pub mod hex_string_as_object_id {
     }
 }
 
-/// Contains functions to serialize a Uuid as a bson::Binary and deserialize a Uuid from a
-/// bson::Binary.
+/// Contains functions to serialize a [`uuid::Uuid`] as a [`bson::Binary`] and deserialize a
+/// [`uuid::Uuid`] from a [`bson::Binary`]. This only works with version 0.8 of the [`uuid`] crate.
 ///
 /// ```rust
 /// # use serde::{Serialize, Deserialize};
 /// # use uuid::Uuid;
-/// # use bson::serde_helpers::uuid_as_binary;
+/// # use bson::serde_helpers::uuid_0_8_as_binary;
 /// #[derive(Serialize, Deserialize)]
 /// struct Item {
-///     #[serde(with = "uuid_as_binary")]
+///     #[serde(with = "uuid_0_8_as_binary")]
 ///     pub id: Uuid,
 /// }
 /// ```
-pub mod uuid_as_binary {
+pub mod uuid_0_8_as_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -20,7 +20,7 @@ fn to_json() {
     let mut doc = Document::new();
     doc.insert(
         "_id",
-        Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl")),
+        Bson::ObjectId(ObjectId::from_bytes(*b"abcdefghijkl")),
     );
     doc.insert("first", Bson::Int32(1));
     doc.insert("second", Bson::String("foo".to_owned()));
@@ -115,7 +115,7 @@ fn from_impls() {
     let oid = ObjectId::new();
     assert_eq!(
         Bson::from(b"abcdefghijkl"),
-        Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl"))
+        Bson::ObjectId(ObjectId::from_bytes(*b"abcdefghijkl"))
     );
     assert_eq!(Bson::from(oid), Bson::ObjectId(oid));
     assert_eq!(

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -33,7 +33,7 @@ fn standard_format() {
         "binary": Binary { subtype: BinarySubtype::Md5, bytes: "thingies".to_owned().into_bytes() },
         "encrypted": Binary { subtype: BinarySubtype::Encrypted, bytes: "secret".to_owned().into_bytes() },
         "_id": id,
-        "date": Bson::DateTime(date),
+        "date": Bson::DateTime(date.into()),
     };
 
     let expected = format!(

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -10,7 +10,7 @@ fn standard_format() {
     let mut bytes = [0; 12];
     bytes[..12].clone_from_slice(&string_bytes[..12]);
 
-    let id = ObjectId::with_bytes(bytes);
+    let id = ObjectId::from_bytes(bytes);
     let date = Utc::now();
 
     let doc = doc! {

--- a/src/tests/modules/oid.rs
+++ b/src/tests/modules/oid.rs
@@ -4,7 +4,7 @@ use crate::{oid::ObjectId, tests::LOCK};
 fn string_oid() {
     let _guard = LOCK.run_concurrently();
     let s = "123456789012123456789012";
-    let oid_res = ObjectId::with_string(s);
+    let oid_res = ObjectId::parse_str(s);
     assert!(oid_res.is_ok());
     let actual_s = hex::encode(oid_res.unwrap().bytes());
     assert_eq!(s.to_owned(), actual_s);
@@ -14,7 +14,7 @@ fn string_oid() {
 fn byte_string_oid() {
     let _guard = LOCK.run_concurrently();
     let s = "541b1a00e8a23afa832b218e";
-    let oid_res = ObjectId::with_string(s);
+    let oid_res = ObjectId::parse_str(s);
     assert!(oid_res.is_ok());
     let oid = oid_res.unwrap();
     let bytes: [u8; 12] = [

--- a/src/tests/modules/ordered.rs
+++ b/src/tests/modules/ordered.rs
@@ -136,14 +136,14 @@ fn test_getters() {
         doc.get_timestamp("timestamp")
     );
 
-    assert_eq!(Some(&Bson::DateTime(datetime)), doc.get("datetime"));
-    assert_eq!(Ok(&datetime), doc.get_datetime("datetime"));
+    assert_eq!(Some(&Bson::DateTime(datetime.into())), doc.get("datetime"));
+    assert_eq!(Ok(&datetime.into()), doc.get_datetime("datetime"));
 
     #[cfg(feature = "decimal128")]
     test_decimal128(&mut doc);
 
-    assert_eq!(Some(&Bson::DateTime(datetime)), doc.get("datetime"));
-    assert_eq!(Ok(&datetime), doc.get_datetime("datetime"));
+    assert_eq!(Some(&Bson::DateTime(datetime.into())), doc.get("datetime"));
+    assert_eq!(Ok(&datetime.into()), doc.get_datetime("datetime"));
 
     let object_id = ObjectId::new();
     doc.insert("_id".to_string(), Bson::ObjectId(object_id));

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -295,7 +295,7 @@ fn test_serialize_binary_generic() {
 #[test]
 fn test_serialize_deserialize_object_id() {
     let _guard = LOCK.run_concurrently();
-    let src = ObjectId::with_string("507f1f77bcf86cd799439011").unwrap();
+    let src = ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap();
     let dst = vec![
         22, 0, 0, 0, 7, 107, 101, 121, 0, 80, 127, 31, 119, 188, 248, 108, 215, 153, 67, 144, 17, 0,
     ];

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -569,7 +569,7 @@ fn test_de_oid_string() {
     }
 
     let foo: Foo = serde_json::from_str("{ \"oid\": \"507f1f77bcf86cd799439011\" }").unwrap();
-    let oid = ObjectId::with_string("507f1f77bcf86cd799439011").unwrap();
+    let oid = ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap();
     assert_eq!(foo.oid, oid);
 }
 

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -9,12 +9,12 @@ use crate::{
     serde_helpers,
     serde_helpers::{
         bson_datetime_as_iso_string,
-        chrono_datetime_as_bson_datetime,
+        chrono_0_4_datetime_as_bson_datetime,
         hex_string_as_object_id,
         iso_string_as_bson_datetime,
         timestamp_as_u32,
         u32_as_timestamp,
-        uuid_as_binary,
+        uuid_0_8_as_binary,
     },
     spec::BinarySubtype,
     tests::LOCK,
@@ -266,7 +266,7 @@ fn test_ser_datetime() {
     let x = to_bson(&foo).unwrap();
     assert_eq!(
         x.as_document().unwrap(),
-        &doc! { "date": (Bson::DateTime(now)) }
+        &doc! { "date": (Bson::DateTime(now.into())) }
     );
 
     let xfoo: Foo = from_bson(x).unwrap();
@@ -693,7 +693,7 @@ fn test_datetime_helpers() {
     }
 
     let iso = "1996-12-20 00:39:57 UTC";
-    let date = chrono::DateTime::from_str(iso).unwrap();
+    let date = chrono::DateTime::<chrono::Utc>::from_str(iso).unwrap();
     let a = A { date: date.into() };
     let doc = to_document(&a).unwrap();
     assert_eq!(doc.get_str("date").unwrap(), iso);
@@ -702,7 +702,7 @@ fn test_datetime_helpers() {
 
     #[derive(Deserialize, Serialize)]
     struct B {
-        #[serde(with = "chrono_datetime_as_bson_datetime")]
+        #[serde(with = "chrono_0_4_datetime_as_bson_datetime")]
         pub date: chrono::DateTime<chrono::Utc>,
     }
 
@@ -720,7 +720,7 @@ fn test_datetime_helpers() {
         chrono::DateTime::from_str("2020-06-09 10:58:07.095 UTC").unwrap();
     assert_eq!(b.date, expected);
     let doc = to_document(&b).unwrap();
-    assert_eq!(doc.get_datetime("date").unwrap(), &expected);
+    assert_eq!(doc.get_datetime("date").unwrap(), &expected.into());
     let b: B = from_document(doc).unwrap();
     assert_eq!(b.date, expected);
 
@@ -766,7 +766,7 @@ fn test_uuid_helpers() {
 
     #[derive(Serialize, Deserialize)]
     struct A {
-        #[serde(with = "uuid_as_binary")]
+        #[serde(with = "uuid_0_8_as_binary")]
         uuid: Uuid,
     }
 


### PR DESCRIPTION
RUST-765 / RUST-789 / RUST-788 / RUST-739

This PR makes a number of breaking changes to the API to ensure it meets the [Rust API Guidelines checklist](https://rust-lang.github.io/api-guidelines/checklist.html).

Notable changes:
- Restructured or eliminated public dependencies on unstable crates to be compatible with future major releases of those crates
  - `chrono`:
    -  `Bson::DateTime(chrono::DateTime<Utc>)` => `Bson::DateTime(crate::DateTime)`
    - removed `pub` from the wrapped `chrono::DateTime` in `bson::DateTime`
    - `serde_helpers::chrono_datetime_as_bson_datetime` => `serde_helpers::chrono_0_4_datetime_as_bson_datetime`
    - `ObjectId::timestamp` now returns a `crate::DateTime`
  - `uuid`:
    - `serde_helpers::uuid_as_binary` => `serde_helpers::uuid_0_8_as_binary`
  - `hex`: rewrote `oid::Error` to exclude it
- All `Document` getters now accept `impl AsRef<str>` instead of `&str`
- Updated `ObjectId`'s constructors to match the names of [`uuid::Uuid`](https://docs.rs/uuid/0.8.2/uuid/struct.Uuid.html#method.from_bytes)
- Attempting to serialize a `DateTime` with sub-millisecond precision to BSON data will result in an error
- Renamed error variants to be less redundant and more consistent
  - `de::Error`:
    - `Error:Io(...)` => `Error::Io(...)`
    - `Error::FromUtf8Error(...)` => `Error::InvalidUtf8String(...)`
    - `Error::SyntaxError` _removed_, replaced by `Error::DeserializationError`
  - `ser::Error`:
    - `Error::IoError(...)` => `Error::Io(...)`