### PR TITLE
RUST-815 Truncate to millisecond precision in `bson::DateTime`'s `From<chrono::DateTime>`

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1019,12 +1019,6 @@ impl crate::DateTime {
     pub fn timestamp_millis(&self) -> i64 {
         self.0.timestamp_millis()
     }
-
-    /// If this DateTime is sub-millisecond precision. BSON only supports millisecond precision, so
-    /// this should be checked before serializing to BSON.
-    pub(crate) fn is_sub_millis_precision(&self) -> bool {
-        self.0.timestamp_subsec_micros() % 1000 != 0
-    }
 }
 
 impl Display for crate::DateTime {

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -23,7 +23,7 @@
 
 use std::fmt::{self, Debug, Display};
 
-use chrono::{Datelike, SecondsFormat, TimeZone, Utc};
+use chrono::{Datelike, NaiveDateTime, SecondsFormat, TimeZone, Utc};
 use serde_json::{json, Value};
 
 pub use crate::document::Document;
@@ -287,7 +287,7 @@ impl From<oid::ObjectId> for Bson {
 
 impl From<chrono::DateTime<Utc>> for Bson {
     fn from(a: chrono::DateTime<Utc>) -> Bson {
-        Bson::DateTime(DateTime(a))
+        Bson::DateTime(DateTime::from(a))
     }
 }
 
@@ -1041,7 +1041,12 @@ impl From<crate::DateTime> for chrono::DateTime<Utc> {
 
 impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for crate::DateTime {
     fn from(x: chrono::DateTime<T>) -> Self {
-        DateTime(x.with_timezone(&Utc))
+        let dt = x.with_timezone(&Utc);
+
+        DateTime(chrono::DateTime::<Utc>::from_utc(
+            NaiveDateTime::from_timestamp(dt.timestamp(), dt.timestamp_subsec_millis() * 1_000_000),
+            Utc,
+        ))
     }
 }
 

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -14,9 +14,6 @@ pub enum Error {
     /// A key could not be serialized to a BSON string.
     InvalidDocumentKey(Bson),
 
-    /// Attempted to serialize a sub-millisecond precision datetime, which BSON does not support.
-    SubMillisecondPrecisionDateTime(crate::DateTime),
-
     /// A general error that ocurred during serialization.
     /// See: https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom
     #[non_exhaustive]
@@ -65,12 +62,6 @@ impl fmt::Display for Error {
                  An attempt to serialize the value: {} in a signed type failed due to the value's \
                  size.",
                 value
-            ),
-            Error::SubMillisecondPrecisionDateTime(dt) => write!(
-                fmt,
-                "BSON supports millisecond-precision datetimes, could not serialize datetime with \
-                 greater precision losslessly: {}",
-                dt
             ),
         }
     }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -153,12 +153,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
 
             writer.write_all(bytes).map_err(From::from)
         }
-        Bson::DateTime(ref v) => {
-            if v.is_sub_millis_precision() {
-                return Err(Error::SubMillisecondPrecisionDateTime(*v));
-            }
-            write_i64(writer, v.timestamp_millis())
-        }
+        Bson::DateTime(ref v) => write_i64(writer, v.timestamp_millis()),
         Bson::Null => Ok(()),
         Bson::Symbol(ref v) => write_string(writer, &v),
         #[cfg(not(feature = "decimal128"))]

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -1,8 +1,17 @@
 use std::convert::TryFrom;
 
 use crate::{
-    doc, oid::ObjectId, spec::BinarySubtype, tests::LOCK, Binary, Bson, DateTime, Document,
-    JavaScriptCodeWithScope, Regex, Timestamp,
+    doc,
+    oid::ObjectId,
+    spec::BinarySubtype,
+    tests::LOCK,
+    Binary,
+    Bson,
+    DateTime,
+    Document,
+    JavaScriptCodeWithScope,
+    Regex,
+    Timestamp,
 };
 use serde_json::{json, Value};
 

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -1,16 +1,8 @@
 use std::convert::TryFrom;
 
 use crate::{
-    doc,
-    oid::ObjectId,
-    spec::BinarySubtype,
-    tests::LOCK,
-    Binary,
-    Bson,
-    Document,
-    JavaScriptCodeWithScope,
-    Regex,
-    Timestamp,
+    doc, oid::ObjectId, spec::BinarySubtype, tests::LOCK, Binary, Bson, DateTime, Document,
+    JavaScriptCodeWithScope, Regex, Timestamp,
 };
 use serde_json::{json, Value};
 
@@ -168,4 +160,28 @@ fn timestamp_ordering() {
     assert!(ts1 < ts2);
     assert!(ts1 < ts3);
     assert!(ts2 < ts3);
+}
+
+#[test]
+fn from_chrono_datetime() {
+    let dt = DateTime::from(chrono::Utc::now());
+    assert_eq!(dt.is_sub_millis_precision(), false);
+
+    let bson = Bson::from(chrono::Utc::now());
+    assert_eq!(bson.as_datetime().unwrap().is_sub_millis_precision(), false);
+
+    for s in &[
+        "2014-11-28T12:00:09Z",
+        "2014-11-28T12:00:09.123Z",
+        "2014-11-28T12:00:09.123456Z",
+        "2014-11-28T12:00:09.123456789Z",
+    ] {
+        let chrono_dt: chrono::DateTime<chrono::Utc> = s.parse().unwrap();
+
+        let dt = DateTime::from(chrono_dt);
+        assert_eq!(dt.is_sub_millis_precision(), false);
+
+        let bson = Bson::from(chrono::Utc::now());
+        assert_eq!(bson.as_datetime().unwrap().is_sub_millis_precision(), false);
+    }
 }

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -45,7 +45,7 @@ fn standard_format() {
         base64::encode("thingies"),
         base64::encode("secret"),
         hex::encode(id_string),
-        date
+        date.format("%Y-%m-%d %H:%M:%S%.3f %Z")
     );
 
     assert_eq!(expected, format!("{}", doc));


### PR DESCRIPTION
Hi, there

The auto remove microseconds and nanoseconds feature was removed from This [commit](https://github.com/mongodb/bson-rust/commit/8a92a568ba9de1192e8fb4217ae541c98b335cad#diff-d6adfba5b9892574146927e3f707649f3b601313211502ff5ae3c796f83dcee4L160). I think should add it in the `From<chrono::DateTime<Utc>>` trait, please review it. thank you.