### PR TITLE
RUST-811 Improve ergonomics of `bson::DateTime`

### DIFF
--- a/.evergreen/run-tests-chrono.sh
+++ b/.evergreen/run-tests-chrono.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -o errexit
-
-. ~/.cargo/env
-RUST_BACKTRACE=1 cargo test --features chrono-0_4

--- a/.evergreen/run-tests-chrono.sh
+++ b/.evergreen/run-tests-chrono.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -o errexit
+
+. ~/.cargo/env
+RUST_BACKTRACE=1 cargo test --features chrono-0_4

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -4,3 +4,4 @@ set -o errexit
 
 . ~/.cargo/env
 RUST_BACKTRACE=1 cargo test
+RUST_BACKTRACE=1 cargo test --features chrono-0_4,uuid-0_8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ exclude = [
 [features]
 # no features by default
 default = []
+# whether to include interop with chrono 0.4 in the public API
+chrono-0_4 = []
 # attempt to encode unsigned types in signed types
 u2i = []
 # Decimal128 in BSON 1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,10 @@ exclude = [
 [features]
 # no features by default
 default = []
-# whether to include interop with chrono 0.4 in the public API
+# if enabled, include API for interfacing with chrono 0.4
 chrono-0_4 = []
+# if enabled, include API for interfacing with uuid 0.8
+uuid-0_8 = []
 # attempt to encode unsigned types in signed types
 u2i = []
 # Decimal128 in BSON 1.1

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use bson::{oid, Bson, Document};
+use bson::{oid, Bson, DateTime, Document};
 
 fn main() {
     let mut doc = Document::new();
@@ -8,7 +8,7 @@ fn main() {
 
     let arr = vec![
         Bson::String("blah".to_string()),
-        Bson::DateTime(chrono::Utc::now().into()),
+        Bson::DateTime(DateTime::now()),
         Bson::ObjectId(oid::ObjectId::from_bytes([
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
         ])),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -23,7 +23,7 @@
 
 use std::fmt::{self, Debug, Display};
 
-use chrono::{Datelike, SecondsFormat};
+use chrono::Datelike;
 use serde_json::{json, Value};
 
 pub use crate::document::Document;
@@ -378,14 +378,8 @@ impl Bson {
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
             Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 99999 => {
-                let seconds_format = if v.to_chrono().timestamp_subsec_millis() == 0 {
-                    SecondsFormat::Secs
-                } else {
-                    SecondsFormat::Millis
-                };
-
                 json!({
-                    "$date": v.to_chrono().to_rfc3339_opts(seconds_format, true),
+                    "$date": v.to_rfc3339(),
                 })
             }
             Bson::DateTime(v) => json!({
@@ -544,14 +538,8 @@ impl Bson {
                 }
             }
             Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 99999 => {
-                let seconds_format = if v.to_chrono().timestamp_subsec_millis() == 0 {
-                    SecondsFormat::Secs
-                } else {
-                    SecondsFormat::Millis
-                };
-
                 doc! {
-                    "$date": v.to_chrono().to_rfc3339_opts(seconds_format, true),
+                    "$date": v.to_rfc3339(),
                 }
             }
             Bson::DateTime(v) => doc! {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,0 +1,212 @@
+use std::{
+    fmt::{self, Display},
+    time::{Duration, SystemTime},
+};
+
+use chrono::{LocalResult, TimeZone, Utc};
+
+/// Struct representing a BSON datetime.
+/// Note: BSON datetimes have millisecond precision.
+///
+/// To enable conversions between this type and [`chrono::DateTime`], enable the `"chrono-0_4"`
+/// feature flag in your `Cargo.toml`.
+/// ```
+/// use chrono::prelude::*;
+/// # fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+/// # #[cfg(feature = "chrono-0_4")]
+/// # {
+/// let chrono_dt: chrono::DateTime<Utc> = "2014-11-28T12:00:09Z".parse()?;
+/// let bson_dt: bson::DateTime = chrono_dt.into();
+/// let bson_dt = bson::DateTime::from_chrono(chrono_dt);
+/// let back_to_chrono: chrono::DateTime<Utc> = bson_dt.into();
+/// let back_to_chrono = bson_dt.to_chrono();
+/// # }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// This type differs from [`chrono::DateTime`] in that it serializes to and deserializes from a
+/// BSON datetime rather than an ISO-8601 formatted string. This means that in non-BSON formats, it
+/// will serialize to and deserialize from that format's equivalent of the [extended JSON representation](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) of a datetime. To serialize a
+/// [`chrono::DateTime`] as a BSON datetime, you can use
+/// [`serde_helpers::chrono_datetime_as_bson_datetime`].
+///
+/// ```rust
+/// # #[cfg(feature = "chrono-0_4")]
+/// # {
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Foo {
+///     // serializes as a BSON datetime.
+///     date_time: bson::DateTime,
+///
+///     // serializes as an ISO-8601 string.
+///     chrono_datetime: chrono::DateTime<chrono::Utc>,
+///
+///     // serializes as a BSON datetime.
+///     // this requires the "chrono-0_4" feature flag
+///     #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+///     chrono_as_bson: chrono::DateTime<chrono::Utc>,
+/// }
+/// # }
+/// ```
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Copy, Clone)]
+pub struct DateTime(i64);
+
+impl crate::DateTime {
+    /// The latest possibile date that can be represented in BSON.
+    pub const MAX: crate::DateTime = DateTime(i64::MAX);
+
+    /// The earliest possibile date that can be represented in BSON.
+    pub const MIN: crate::DateTime = DateTime(i64::MIN);
+
+    /// Makes a new [`DateTime`] from the number of non-leap milliseconds since
+    /// January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
+    pub fn from_millis(date: i64) -> Self {
+        Self(date)
+    }
+
+    /// Returns a [`DateTime`] which corresponds to the current date and time.
+    pub fn now() -> DateTime {
+        Self::from_chrono(Utc::now())
+    }
+
+    #[cfg(not(feature = "chrono-0_4"))]
+    pub(crate) fn from_chrono<T: chrono::TimeZone>(dt: chrono::DateTime<T>) -> Self {
+        Self::from_millis(dt.timestamp_millis())
+    }
+
+    /// Convert the given `chrono::DateTime` into a `bson::DateTime`, truncating it to millisecond
+    /// precision.
+    #[cfg(feature = "chrono-0_4")]
+    pub fn from_chrono<T: chrono::TimeZone>(dt: chrono::DateTime<T>) -> Self {
+        Self::from_millis(dt.timestamp_millis())
+    }
+
+    fn to_chrono_private(self) -> chrono::DateTime<Utc> {
+        match Utc.timestamp_millis_opt(self.0) {
+            LocalResult::Single(dt) => dt,
+            _ => {
+                if self.0 < 0 {
+                    chrono::MIN_DATETIME
+                } else {
+                    chrono::MAX_DATETIME
+                }
+            }
+        }
+    }
+
+    #[cfg(not(feature = "chrono-0_4"))]
+    #[allow(unused)]
+    pub(crate) fn to_chrono(self) -> chrono::DateTime<Utc> {
+        self.to_chrono_private()
+    }
+
+    /// Convert this [`DateTime`] to a [`chrono::DateTime<Utc>`].
+    ///
+    /// Note: Not every BSON datetime can be represented as a [`chrono::DateTime`]. For such dates,
+    /// [`chrono::MIN_DATETIME`] or [`chrono::MAX_DATETIME`] will be returned, whichever is closer.
+    ///
+    /// ```
+    /// let bson_dt = bson::DateTime::now();
+    /// let chrono_dt = bson_dt.to_chrono();
+    /// assert_eq!(bson_dt.timestamp_millis(), chrono_dt.timestamp_millis());
+    ///
+    /// let big = bson::DateTime::from_millis(i64::MAX);
+    /// let chrono_big = big.to_chrono();
+    /// assert_eq!(chrono_big, chrono::MAX_DATETIME)
+    /// ```
+    #[cfg(feature = "chrono-0_4")]
+    pub fn to_chrono(self) -> chrono::DateTime<Utc> {
+        self.to_chrono_private()
+    }
+
+    /// Convert the given [`std::SystemTime`] to a [`DateTime`].
+    ///
+    /// If the provided time is too far in the future or too far in the past to be represented
+    /// by a BSON datetime, either [`DateTime::MAX`] or [`DateTime::MIN`] will be
+    /// returned, whichever is closer.
+    pub fn from_system_time(st: SystemTime) -> Self {
+        match st.duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(d) => {
+                if d.as_millis() <= i64::MAX as u128 {
+                    Self::from_millis(d.as_millis() as i64)
+                } else {
+                    Self::MAX
+                }
+            }
+            // handle SystemTime from before the Unix Epoch
+            Err(e) => {
+                let millis = e.duration().as_millis();
+                if millis > i64::MAX as u128 {
+                    Self::MIN
+                } else {
+                    Self::from_millis(-(millis as i64))
+                }
+            }
+        }
+    }
+
+    /// Convert this [`DateTime`] to a [`std::SystemTime`].
+    pub fn to_system_time(self) -> SystemTime {
+        if self.0 >= 0 {
+            SystemTime::UNIX_EPOCH + Duration::from_millis(self.0 as u64)
+        } else {
+            // need to convert to i128 beforce calculating absolute value since i64::MIN.abs()
+            // overflows and panics.
+            SystemTime::UNIX_EPOCH - Duration::from_millis((self.0 as i128).abs() as u64)
+        }
+    }
+
+    /// Returns the number of non-leap-milliseconds since January 1, 1970 UTC.
+    pub fn timestamp_millis(&self) -> i64 {
+        self.0
+    }
+}
+
+impl fmt::Debug for crate::DateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut tup = f.debug_tuple("DateTime");
+        match Utc.timestamp_millis_opt(self.0) {
+            LocalResult::Single(ref dt) => tup.field(dt),
+            _ => tup.field(&self.0),
+        };
+        tup.finish()
+    }
+}
+
+impl Display for crate::DateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match Utc.timestamp_millis_opt(self.0) {
+            LocalResult::Single(ref dt) => Display::fmt(dt, f),
+            _ => Display::fmt(&self.0, f),
+        }
+    }
+}
+
+impl From<SystemTime> for crate::DateTime {
+    fn from(st: SystemTime) -> Self {
+        Self::from_system_time(st)
+    }
+}
+
+impl From<crate::DateTime> for SystemTime {
+    fn from(dt: crate::DateTime) -> Self {
+        dt.to_system_time()
+    }
+}
+
+#[cfg(feature = "chrono-0_4")]
+impl From<crate::DateTime> for chrono::DateTime<Utc> {
+    fn from(bson_dt: DateTime) -> Self {
+        bson_dt.to_chrono()
+    }
+}
+
+#[cfg(feature = "chrono-0_4")]
+impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for crate::DateTime {
+    fn from(x: chrono::DateTime<T>) -> Self {
+        Self::from_chrono(x)
+    }
+}

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -57,14 +57,14 @@ pub struct DateTime(i64);
 
 impl crate::DateTime {
     /// The latest possibile date that can be represented in BSON.
-    pub const MAX: Self = Self(i64::MAX);
+    pub const MAX: Self = Self::from_millis(i64::MAX);
 
     /// The earliest possibile date that can be represented in BSON.
-    pub const MIN: Self = Self(i64::MIN);
+    pub const MIN: Self = Self::from_millis(i64::MIN);
 
     /// Makes a new [`DateTime`] from the number of non-leap milliseconds since
     /// January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
-    pub fn from_millis(date: i64) -> Self {
+    pub const fn from_millis(date: i64) -> Self {
         Self(date)
     }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -161,7 +161,7 @@ impl crate::DateTime {
     }
 
     /// Returns the number of non-leap-milliseconds since January 1, 1970 UTC.
-    pub fn timestamp_millis(&self) -> i64 {
+    pub const fn timestamp_millis(self) -> i64 {
         self.0
     }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -26,9 +26,10 @@ use chrono::{LocalResult, TimeZone, Utc};
 /// ```
 ///
 /// This type differs from [`chrono::DateTime`] in that it serializes to and deserializes from a
-/// BSON datetime rather than an ISO-8601 formatted string. This means that in non-BSON formats, it
-/// will serialize to and deserialize from that format's equivalent of the [extended JSON representation](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) of a datetime. To serialize a
-/// [`chrono::DateTime`] as a BSON datetime, you can use
+/// BSON datetime rather than an RFC 3339 formatted string. Additionally, in non-BSON formats, it
+/// will serialize to and deserialize from that format's equivalent of the
+/// [extended JSON representation](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) of a datetime.
+/// To serialize a [`chrono::DateTime`] as a BSON datetime, you can use
 /// [`serde_helpers::chrono_datetime_as_bson_datetime`].
 ///
 /// ```rust
@@ -41,7 +42,7 @@ use chrono::{LocalResult, TimeZone, Utc};
 ///     // serializes as a BSON datetime.
 ///     date_time: bson::DateTime,
 ///
-///     // serializes as an ISO-8601 string.
+///     // serializes as an RFC 3339 / ISO-8601 string.
 ///     chrono_datetime: chrono::DateTime<chrono::Utc>,
 ///
 ///     // serializes as a BSON datetime.

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -164,6 +164,11 @@ impl crate::DateTime {
     pub fn timestamp_millis(&self) -> i64 {
         self.0
     }
+
+    pub(crate) fn to_rfc3339(&self) -> String {
+        self.to_chrono()
+            .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
+    }
 }
 
 impl fmt::Debug for crate::DateTime {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -57,10 +57,10 @@ pub struct DateTime(i64);
 
 impl crate::DateTime {
     /// The latest possibile date that can be represented in BSON.
-    pub const MAX: crate::DateTime = DateTime(i64::MAX);
+    pub const MAX: Self = Self(i64::MAX);
 
     /// The earliest possibile date that can be represented in BSON.
-    pub const MIN: crate::DateTime = DateTime(i64::MIN);
+    pub const MIN: Self = Self(i64::MIN);
 
     /// Makes a new [`DateTime`] from the number of non-leap milliseconds since
     /// January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -56,10 +56,10 @@ use chrono::{LocalResult, TimeZone, Utc};
 pub struct DateTime(i64);
 
 impl crate::DateTime {
-    /// The latest possibile date that can be represented in BSON.
+    /// The latest possible date that can be represented in BSON.
     pub const MAX: Self = Self::from_millis(i64::MAX);
 
-    /// The earliest possibile date that can be represented in BSON.
+    /// The earliest possible date that can be represented in BSON.
     pub const MIN: Self = Self::from_millis(i64::MIN);
 
     /// Makes a new [`DateTime`] from the number of non-leap milliseconds since
@@ -154,7 +154,7 @@ impl crate::DateTime {
         if self.0 >= 0 {
             SystemTime::UNIX_EPOCH + Duration::from_millis(self.0 as u64)
         } else {
-            // need to convert to i128 beforce calculating absolute value since i64::MIN.abs()
+            // need to convert to i128 before calculating absolute value since i64::MIN.abs()
             // overflows and panics.
             SystemTime::UNIX_EPOCH - Duration::from_millis((self.0 as i128).abs() as u64)
         }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -165,7 +165,7 @@ impl crate::DateTime {
         self.0
     }
 
-    pub(crate) fn to_rfc3339(&self) -> String {
+    pub(crate) fn to_rfc3339(self) -> String {
         self.to_chrono()
             .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
     }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -29,16 +29,6 @@ pub enum Error {
     /// The end of the BSON input was reached too soon.
     EndOfStream,
 
-    /// An invalid datetime was encountered while decoding.
-    #[non_exhaustive]
-    InvalidDateTime {
-        /// The key at which an unexpected/unsupported datetime was encountered.
-        key: String,
-
-        /// The value of the invalid datetime.
-        datetime: i64,
-    },
-
     /// A general error encountered during deserialization.
     /// See: https://docs.serde.rs/serde/de/trait.Error.html
     #[non_exhaustive]
@@ -75,9 +65,6 @@ impl fmt::Display for Error {
             ),
             Error::EndOfStream => fmt.write_str("end of stream"),
             Error::DeserializationError { ref message } => message.fmt(fmt),
-            Error::InvalidDateTime { ref key, datetime } => {
-                write!(fmt, "invalid datetime for key \"{}\": {}", key, datetime)
-            }
         }
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -31,11 +31,6 @@ pub use self::{
 
 use std::io::Read;
 
-use chrono::{
-    offset::{LocalResult, TimeZone},
-    Utc,
-};
-
 use crate::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     oid,
@@ -325,16 +320,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
         Some(ElementType::DateTime) => {
             // The int64 is UTC milliseconds since the Unix epoch.
             let time = read_i64(reader)?;
-
-            match Utc.timestamp_millis_opt(time) {
-                LocalResult::Single(t) => Bson::DateTime(t.into()),
-                _ => {
-                    return Err(Error::InvalidDateTime {
-                        key,
-                        datetime: time,
-                    })
-                }
-            }
+            Bson::DateTime(crate::DateTime::from_millis(time))
         }
         Some(ElementType::Symbol) => read_string(reader, utf8_lossy).map(Bson::Symbol)?,
         Some(ElementType::Decimal128) => read_f128(reader).map(Bson::Decimal128)?,

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -17,7 +17,8 @@ use serde::de::{
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
 use crate::{
-    bson::{Binary, Bson, DateTime, DbPointer, JavaScriptCodeWithScope, Regex, Timestamp},
+    bson::{Binary, Bson, DbPointer, JavaScriptCodeWithScope, Regex, Timestamp},
+    datetime::DateTime,
     document::{Document, DocumentVisitor, IntoIter},
     oid::ObjectId,
     spec::BinarySubtype,

--- a/src/extjson/mod.rs
+++ b/src/extjson/mod.rs
@@ -28,13 +28,13 @@
 //!   - In relaxed mode, all BSON numbers are represented by the JSON number type, rather than the
 //!     object
 //! notation.
-//!   - In relaxed mode, the string in the datetime object notation is ISO-8601 formatted (if the
-//!     date is after 1970).
+//!   - In relaxed mode, the string in the datetime object notation is RFC 3339 (ISO-8601) formatted
+//!     (if the date is after 1970).
 //!
 //! e.g.
 //! ```rust
 //! # use bson::bson;
-//! let doc = bson!({ "x": 5, "d": chrono::Utc::now() });
+//! let doc = bson!({ "x": 5, "d": bson::DateTime::now() });
 //!
 //! println!("relaxed: {}", doc.clone().into_relaxed_extjson());
 //! // relaxed: "{"x":5,"d":{"$date":"2020-06-01T22:19:13.075Z"}}"

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -253,7 +253,7 @@ impl DateTime {
                             )
                         })?
                         .into();
-                Ok(crate::DateTime::from_chrono(datetime).into())
+                Ok(crate::DateTime::from_chrono(datetime))
             }
         }
     }

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -253,7 +253,7 @@ impl DateTime {
                             )
                         })?
                         .into();
-                Ok(datetime.into())
+                Ok(crate::DateTime::from_chrono(datetime).into())
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,17 +186,8 @@
 #![doc(html_root_url = "https://docs.rs/bson/2.0.0-beta")]
 
 pub use self::{
-    bson::{
-        Array,
-        Binary,
-        Bson,
-        DateTime,
-        DbPointer,
-        Document,
-        JavaScriptCodeWithScope,
-        Regex,
-        Timestamp,
-    },
+    bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
+    datetime::DateTime,
     de::{from_bson, from_document, Deserializer},
     decimal128::Decimal128,
     ser::{to_bson, to_document, Serializer},
@@ -205,6 +196,7 @@ pub use self::{
 #[macro_use]
 mod macros;
 mod bson;
+mod datetime;
 pub mod de;
 pub mod decimal128;
 pub mod document;

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -13,17 +13,8 @@ use serde::ser::{
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
 use crate::{
-    bson::{
-        Array,
-        Binary,
-        Bson,
-        DateTime,
-        DbPointer,
-        Document,
-        JavaScriptCodeWithScope,
-        Regex,
-        Timestamp,
-    },
+    bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
+    datetime::DateTime,
     oid::ObjectId,
     spec::BinarySubtype,
 };

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -185,7 +185,7 @@ pub mod chrono_datetime_as_bson_datetime {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
 
-    /// Deserializes a chrono::DateTime from a bson::DateTime.
+    /// Deserializes a [`chrono::DateTime`] from a [`crate::DateTime`].
     pub fn deserialize<'de, D>(deserializer: D) -> Result<chrono::DateTime<Utc>, D::Error>
     where
         D: Deserializer<'de>,
@@ -194,7 +194,7 @@ pub mod chrono_datetime_as_bson_datetime {
         Ok(datetime.to_chrono())
     }
 
-    /// Serializes a chrono::DateTime as a bson::DateTime.
+    /// Serializes a [`chrono::DateTime`] as a [`crate::DateTime`].
     pub fn serialize<S: Serializer>(
         val: &chrono::DateTime<Utc>,
         serializer: S,
@@ -241,7 +241,7 @@ pub mod rfc3339_string_as_bson_datetime {
 }
 
 /// Contains functions to serialize a [`crate::DateTime`] as an RFC 3339 (ISO 8601) formatted string
-/// and deserialize a bson::DateTime from an RFC 3339 (ISO 8601) formatted string.
+/// and deserialize a [`crate::DateTime`] from an RFC 3339 (ISO 8601) formatted string.
 ///
 /// ```rust
 /// # use serde::{Serialize, Deserialize};
@@ -270,7 +270,7 @@ pub mod bson_datetime_as_rfc3339_string {
         Ok(DateTime::from_chrono(date))
     }
 
-    /// Serializes a bson::DateTime as an RFC 3339 (ISO 8601) formatted string.
+    /// Serializes a [`crate::DateTime`] as an RFC 3339 (ISO 8601) formatted string.
     pub fn serialize<S: Serializer>(val: &DateTime, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&val.to_rfc3339())
     }

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -31,19 +31,24 @@ pub use u32_as_timestamp::{
     serialize as serialize_u32_as_timestamp,
 };
 pub use u64_as_f64::{deserialize as deserialize_u64_from_f64, serialize as serialize_u64_as_f64};
-pub use uuid_0_8_as_binary::{
-    deserialize as deserialize_uuid_0_8_from_binary,
-    serialize as serialize_uuid_0_8_as_binary,
+
+#[cfg(feature = "uuid-0_8")]
+pub use uuid_as_binary::{
+    deserialize as deserialize_uuid_from_binary,
+    serialize as serialize_uuid_as_binary,
 };
-pub use uuid_0_8_as_c_sharp_legacy_binary::{
+#[cfg(feature = "uuid-0_8")]
+pub use uuid_as_c_sharp_legacy_binary::{
     deserialize as deserialize_uuid_from_c_sharp_legacy_binary,
     serialize as serialize_uuid_as_c_sharp_legacy_binary,
 };
-pub use uuid_0_8_as_java_legacy_binary::{
+#[cfg(feature = "uuid-0_8")]
+pub use uuid_as_java_legacy_binary::{
     deserialize as deserialize_uuid_from_java_legacy_binary,
     serialize as serialize_uuid_as_java_legacy_binary,
 };
-pub use uuid_0_8_as_python_legacy_binary::{
+#[cfg(feature = "uuid-0_8")]
+pub use uuid_as_python_legacy_binary::{
     deserialize as deserialize_uuid_from_python_legacy_binary,
     serialize as serialize_uuid_as_python_legacy_binary,
 };
@@ -308,20 +313,22 @@ pub mod hex_string_as_object_id {
     }
 }
 
-/// Contains functions to serialize a [`uuid::Uuid`] as a [`bson::Binary`] and deserialize a
-/// [`uuid::Uuid`] from a [`bson::Binary`]. This only works with version 0.8 of the [`uuid`] crate.
+/// Contains functions to serialize a [`uuid::Uuid`] as a [`crate::Binary`] and deserialize a
+/// [`uuid::Uuid`] from a [`crate::Binary`]. This only works with version 0.8 of the [`uuid`] crate.
 ///
 /// ```rust
-/// # use serde::{Serialize, Deserialize};
-/// # use uuid::Uuid;
-/// # use bson::serde_helpers::uuid_0_8_as_binary;
+/// use serde::{Serialize, Deserialize};
+/// use uuid::Uuid;
+/// use bson::serde_helpers::uuid_as_binary;
+///
 /// #[derive(Serialize, Deserialize)]
 /// struct Item {
-///     #[serde(with = "uuid_0_8_as_binary")]
+///     #[serde(with = "uuid_as_binary")]
 ///     pub id: Uuid,
 /// }
 /// ```
-pub mod uuid_0_8_as_binary {
+#[cfg(feature = "uuid-0_8")]
+pub mod uuid_as_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
@@ -360,7 +367,25 @@ pub mod uuid_0_8_as_binary {
     }
 }
 
-pub mod uuid_0_8_as_java_legacy_binary {
+/// Contains functions to serialize a [`uuid::Uuid`] to a [`crate::Binary`] in the legacy
+/// Java driver UUID format and deserialize [`uuid::Uuid`] from a [`crate::Binary`] in the legacy
+/// Java driver format.
+///
+/// Note: the `"uuid-0_8"` feature must be enabled to use this helper.
+///
+/// ```rust
+/// use serde::{Serialize, Deserialize};
+/// use uuid::Uuid;
+/// use bson::serde_helpers::uuid_as_java_legacy_binary;
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Item {
+///     #[serde(with = "uuid_as_java_legacy_binary")]
+///     pub id: Uuid,
+/// }
+/// ```
+#[cfg(feature = "uuid-0_8")]
+pub mod uuid_as_java_legacy_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
@@ -398,7 +423,25 @@ pub mod uuid_0_8_as_java_legacy_binary {
     }
 }
 
-pub mod uuid_0_8_as_python_legacy_binary {
+/// Contains functions to serialize a [`uuid::Uuid`] to a [`crate::Binary`] in the legacy Python
+/// driver UUID format and deserialize [`uuid::Uuid`] from a [`crate::Binary`] in the legacy Python
+/// driver format.
+///
+/// Note: the `"uuid-0_8"` feature must be enabled to use this helper.
+///
+/// ```rust
+/// use serde::{Serialize, Deserialize};
+/// use uuid::Uuid;
+/// use bson::serde_helpers::uuid_as_python_legacy_binary;
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Item {
+///     #[serde(with = "uuid_as_python_legacy_binary")]
+///     pub id: Uuid,
+/// }
+/// ```
+#[cfg(feature = "uuid-0_8")]
+pub mod uuid_as_python_legacy_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
@@ -430,7 +473,26 @@ pub mod uuid_0_8_as_python_legacy_binary {
         }
     }
 }
-pub mod uuid_0_8_as_c_sharp_legacy_binary {
+
+/// Contains functions to serialize a [`uuid::Uuid`] to a [`crate::Binary`] in the legacy C# driver
+/// UUID format and deserialize [`uuid::Uuid`] from a [`crate::Binary`] in the legacy C# driver
+/// format.
+///
+/// Note: the `"uuid-0_8"` feature must be enabled to use this helper.
+///
+/// ```rust
+/// use serde::{Serialize, Deserialize};
+/// use uuid::Uuid;
+/// use bson::serde_helpers::uuid_as_c_sharp_legacy_binary;
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Item {
+///     #[serde(with = "uuid_as_c_sharp_legacy_binary")]
+///     pub id: Uuid,
+/// }
+/// ```
+#[cfg(feature = "uuid-0_8")]
+pub mod uuid_as_c_sharp_legacy_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -227,7 +227,7 @@ pub mod rfc3339_string_as_bson_datetime {
         D: Deserializer<'de>,
     {
         let date = DateTime::deserialize(deserializer)?;
-        Ok(date.to_chrono().to_rfc3339())
+        Ok(date.to_rfc3339())
     }
 
     /// Serializes an ISO string as a DateTime.
@@ -272,7 +272,7 @@ pub mod bson_datetime_as_rfc3339_string {
 
     /// Serializes a bson::DateTime as an RFC 3339 (ISO 8601) formatted string.
     pub fn serialize<S: Serializer>(val: &DateTime, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&val.to_chrono().to_rfc3339())
+        serializer.serialize_str(&val.to_rfc3339())
     }
 }
 

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -176,6 +176,8 @@ fn timestamp_ordering() {
 
 #[test]
 fn from_chrono_datetime() {
+    let _guard = LOCK.run_concurrently();
+
     fn assert_millisecond_precision(dt: DateTime) {
         assert_eq!(dt.to_chrono().timestamp_subsec_micros() % 1000 != 0, false);
     }
@@ -258,6 +260,8 @@ fn from_chrono_datetime() {
 
 #[test]
 fn system_time() {
+    let _guard = LOCK.run_concurrently();
+
     let st = SystemTime::now();
     let bt_into: crate::DateTime = st.into();
     let bt_from = crate::DateTime::from_system_time(st);

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -179,7 +179,7 @@ fn from_chrono_datetime() {
     let _guard = LOCK.run_concurrently();
 
     fn assert_millisecond_precision(dt: DateTime) {
-        assert_eq!(dt.to_chrono().timestamp_subsec_micros() % 1000 != 0, false);
+        assert!(dt.to_chrono().timestamp_subsec_micros() % 1000 == 0);
     }
     fn assert_subsec_millis(dt: DateTime, millis: u32) {
         assert_eq!(dt.to_chrono().timestamp_subsec_millis(), millis)

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -33,7 +33,7 @@ fn standard_format() {
         "binary": Binary { subtype: BinarySubtype::Md5, bytes: "thingies".to_owned().into_bytes() },
         "encrypted": Binary { subtype: BinarySubtype::Encrypted, bytes: "secret".to_owned().into_bytes() },
         "_id": id,
-        "date": Bson::DateTime(date.into()),
+        "date": Bson::DateTime(crate::DateTime::from_chrono(date)),
     };
 
     let expected = format!(

--- a/src/tests/modules/ordered.rs
+++ b/src/tests/modules/ordered.rs
@@ -62,7 +62,7 @@ fn test_decimal128(doc: &mut Document) {
 fn test_getters() {
     let _guard = LOCK.run_concurrently();
     let datetime = Utc::now();
-    let cloned_dt = datetime;
+    let cloned_dt = crate::DateTime::from_chrono(datetime);
     let binary = vec![0, 1, 2, 3, 4];
     let mut doc = doc! {
         "floating_point": 10.0,
@@ -136,14 +136,12 @@ fn test_getters() {
         doc.get_timestamp("timestamp")
     );
 
-    assert_eq!(Some(&Bson::DateTime(datetime.into())), doc.get("datetime"));
-    assert_eq!(Ok(&datetime.into()), doc.get_datetime("datetime"));
+    let dt = crate::DateTime::from_chrono(datetime);
+    assert_eq!(Some(&Bson::DateTime(dt)), doc.get("datetime"));
+    assert_eq!(Ok(&dt), doc.get_datetime("datetime"));
 
     #[cfg(feature = "decimal128")]
     test_decimal128(&mut doc);
-
-    assert_eq!(Some(&Bson::DateTime(datetime.into())), doc.get("datetime"));
-    assert_eq!(Ok(&datetime.into()), doc.get_datetime("datetime"));
 
     let object_id = ObjectId::new();
     doc.insert("_id".to_string(), Bson::ObjectId(object_id));

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -314,6 +314,9 @@ fn test_serialize_deserialize_object_id() {
 #[test]
 fn test_serialize_utc_date_time() {
     let _guard = LOCK.run_concurrently();
+    #[cfg(not(feature = "chrono-0_4"))]
+    let src = crate::DateTime::from_chrono(Utc.timestamp(1_286_705_410, 0));
+    #[cfg(feature = "chrono-0_4")]
     let src = Utc.timestamp(1_286_705_410, 0);
     let dst = vec![
         18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0,
@@ -365,7 +368,8 @@ fn test_deserialize_utc_date_time_overflows() {
 
     let deserialized = Document::from_reader(&mut Cursor::new(raw)).unwrap();
 
-    let expected = doc! { "A": Utc.timestamp(1_530_492_218, 999 * 1_000_000)};
+    let expected =
+        doc! { "A": crate::DateTime::from_chrono(Utc.timestamp(1_530_492_218, 999 * 1_000_000))};
     assert_eq!(deserialized, expected);
 }
 

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -243,21 +243,20 @@ fn test_de_code_with_scope() {
 fn test_ser_datetime() {
     let _guard = LOCK.run_concurrently();
     use crate::DateTime;
-    use chrono::Utc;
 
     #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
     struct Foo {
         date: DateTime,
     }
 
-    let now = crate::DateTime::from_chrono(Utc::now());
+    let now = DateTime::now();
 
     let foo = Foo { date: now };
 
     let x = to_bson(&foo).unwrap();
     assert_eq!(
         x.as_document().unwrap(),
-        &doc! { "date": (Bson::DateTime(now.into())) }
+        &doc! { "date": (Bson::DateTime(now)) }
     );
 
     let xfoo: Foo = from_bson(x).unwrap();

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -734,7 +734,7 @@ fn test_datetime_helpers() {
         pub date: DateTime,
     }
 
-    let iso = "1996-12-20T00:39:57+00:00";
+    let iso = "1996-12-20T00:39:57Z";
     let date = chrono::DateTime::<chrono::Utc>::from_str(iso).unwrap();
     let a = A {
         date: crate::DateTime::from_chrono(date),
@@ -777,7 +777,7 @@ fn test_datetime_helpers() {
         pub date: String,
     }
 
-    let date = "2020-06-09T10:58:07.095+00:00";
+    let date = "2020-06-09T10:58:07.095Z";
     let c = C {
         date: date.to_string(),
     };

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -13,7 +13,6 @@ use crate::{
         rfc3339_string_as_bson_datetime,
         timestamp_as_u32,
         u32_as_timestamp,
-        uuid_0_8_as_binary,
     },
     spec::BinarySubtype,
     tests::LOCK,
@@ -30,7 +29,6 @@ use crate::{
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use uuid::Uuid;
 
 use std::{collections::BTreeMap, convert::TryFrom, str::FromStr};
 
@@ -552,17 +550,20 @@ fn test_de_db_pointer() {
     assert_eq!(foo.db_pointer, db_pointer.clone());
 }
 
+#[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_serde_legacy_uuid() {
+    use uuid::Uuid;
+
     let _guard = LOCK.run_concurrently();
 
     #[derive(Serialize, Deserialize)]
     struct Foo {
-        #[serde(with = "serde_helpers::uuid_0_8_as_java_legacy_binary")]
+        #[serde(with = "serde_helpers::uuid_as_java_legacy_binary")]
         java_legacy: Uuid,
-        #[serde(with = "serde_helpers::uuid_0_8_as_python_legacy_binary")]
+        #[serde(with = "serde_helpers::uuid_as_python_legacy_binary")]
         python_legacy: Uuid,
-        #[serde(with = "serde_helpers::uuid_0_8_as_c_sharp_legacy_binary")]
+        #[serde(with = "serde_helpers::uuid_as_c_sharp_legacy_binary")]
         csharp_legacy: Uuid,
     }
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
@@ -804,12 +805,16 @@ fn test_oid_helpers() {
 }
 
 #[test]
+#[cfg(feature = "uuid-0_8")]
 fn test_uuid_helpers() {
+    use serde_helpers::uuid_as_binary;
+    use uuid::Uuid;
+
     let _guard = LOCK.run_concurrently();
 
     #[derive(Serialize, Deserialize)]
     struct A {
-        #[serde(with = "uuid_0_8_as_binary")]
+        #[serde(with = "uuid_as_binary")]
         uuid: Uuid,
     }
 


### PR DESCRIPTION
RUST-811 / #256 / RUST-799 / RUST-825

This PR adds a few methods to `bson::DateTime` to make the conversions between it and `chrono::DateTime` and `std::SystemTime` more obvious / easier to use, as well as to make it more functional on its own. To allow us to make these changes without the fear of polluting the API with old versions of `chrono`, any methods interacting with `chrono` were moved behind the feature flag `"chrono-0_4"`. For consistency, the same was done for `uuid`.

Summary of the new methods:
- `DateTime::now`
- `DateTime::from_millis`
- `DateTime::from_chrono` 
- `DateTime::to_chrono`
  - the `to_chrono` and `from_chrono` naming takes inspiration from tokio's [`from_std`](https://docs.rs/tokio/1.6.0/tokio/fs/struct.File.html#method.from_std)
- `DateTime::from_system_time` 
- `DateTime::to_system_time`

Notably, the following were _not_ included:
- `DateTime::as_chrono(&self) -> &chrono::DateTime`
  - This was not added because it can only be implemented if the inner value is in fact a `chrono::DateTime`. However, `chrono::DateTime` doesn't support the full range of `i64` milliseconds from the Unix epoch, which BSON does support (RUST-799). This means that there could be a situation where valid data resides in a MongoDB deployment that the Rust driver could not read (pymongo has this issue, see [PYTHON-1824](https://jira.mongodb.org/browse/PYTHON-1824)). To fix this issue, the interior value of `DateTime` was updated to be an `i64` to match BSON, meaning this helper could not be implemented.
- `impl AsRef<chrono::DateTime> for crate::DateTime`
  - same reasoning as the previous one
- `impl Deref<chrono::DateTime> for `crate::DateTime`
  - same reasoning as before
  - `crate::DateTime` is also not a smart pointer type, and the Rust API guidelines recommend that exclusively smart pointer types implement `Deref` and `DerefMut` ([C-DEREF](https://rust-lang.github.io/api-guidelines/predictability.html#c-deref))

In a related change, I noticed that our ISO-8601 string helpers weren't actually adhering to ISO-8601 (see RUST-825). This was fixed, and the helpers were renamed to be a bit more explicit about the standards they work with.