### PR TITLE
RUST-838 Improve bson::DateTime now() performance

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -70,7 +70,7 @@ impl crate::DateTime {
 
     /// Returns a [`DateTime`] which corresponds to the current date and time.
     pub fn now() -> DateTime {
-        Self::from_chrono(Utc::now())
+        Self::from_system_time(SystemTime::now())
     }
 
     #[cfg(not(feature = "chrono-0_4"))]

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -163,7 +163,7 @@ impl ObjectId {
     }
 
     /// Returns the raw byte representation of an ObjectId.
-    pub fn bytes(&self) -> [u8; 12] {
+    pub const fn bytes(&self) -> [u8; 12] {
         self.id
     }
 

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     /// A key could not be serialized to a BSON string.
     InvalidDocumentKey(Bson),
 
-    /// A general error that ocurred during serialization.
+    /// A general error that occurred during serialization.
     /// See: https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom
     #[non_exhaustive]
     SerializationError {


### PR DESCRIPTION
link to jira: [RUST-838](https://jira.mongodb.org/browse/RUST-838)

## DateTime::now()

https://github.com/mongodb/bson-rust/blob/2e6bb8f4763889728cfe4339d63b817a5c99af5d/src/datetime.rs#L72-L74

because chrono::Utc::now() call SystemTime::now() and NaiveDateTime::from_timestamp

bson::DateTime::now() use SystemTime::now() can prevent **extra performance overhead** on `NaiveDateTime::from_timestamp`

```
  pub fn now() -> DateTime<Utc> {
      let now =
          SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
      let naive = NaiveDateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos() as u32);
      DateTime::from_utc(naive, Utc)
  }
```

chrono source: https://github.com/chronotope/chrono/blob/3467172c31188006147585f6ed3727629d642fed/src/offset/utc.rs#L47-L51

## confuse on feature = "chrono-0_4"

since bson use chrono::DateTime::parse_from_rfc3339 in serde, so chrono must a required feature

libraray usally use feature to tell user this is a optional dependecy

I guess `feature = "chrono-0_4"` means bson's chrono is a optional dependency

But these code is just confuse me:

https://github.com/mongodb/bson-rust/blob/2e6bb8f4763889728cfe4339d63b817a5c99af5d/src/datetime.rs#L76-L86

So I think feature = "chrono-0_4" is useless because chrono is a required dependency