### PR TITLE
RUST-806 Allow conversion of `Option`s to `Bson` types

### DIFF
--- a/serde-tests/rustfmt.toml
+++ b/serde-tests/rustfmt.toml
@@ -5,5 +5,5 @@ format_strings = true
 normalize_comments = true
 use_try_shorthand = true
 wrap_comments = true
-merge_imports = true
 imports_layout = "HorizontalVertical"
+imports_granularity = "Crate"

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -304,6 +304,18 @@ impl From<DbPointer> for Bson {
     }
 }
 
+impl<T> From<Option<T>> for Bson
+where
+    T: Into<Bson>,
+{
+    fn from(a: Option<T>) -> Bson {
+        match a {
+            None => Bson::Null,
+            Some(t) => t.into(),
+        }
+    }
+}
+
 /// This will create the [relaxed Extended JSON v2](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) representation of the provided [`Bson`](../enum.Bson.html).
 impl From<Bson> for Value {
     fn from(bson: Bson) -> Self {

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -143,6 +143,17 @@ fn from_impls() {
         Bson::Document(doc! {"a": "b"})
     );
 
+    // Optionals
+    assert_eq!(Bson::from(Some(4)), Bson::Int32(4));
+    assert_eq!(
+        Bson::from(Some(String::from("data"))),
+        Bson::String(String::from("data"))
+    );
+    assert_eq!(Bson::from(None::<i32>), Bson::Null);
+    assert_eq!(Bson::from(None::<String>), Bson::Null);
+    assert_eq!(doc! {"x": Some(4)}, doc! {"x": 4});
+    assert_eq!(doc! {"x": None::<i32>}, doc! {"x": Bson::Null});
+
     let db_pointer = Bson::try_from(json!({
         "$dbPointer": {
             "$ref": "db.coll",


### PR DESCRIPTION
Implemented `From<Option<T>>` for Bson where `T: Into<Bson>`

Second commit is to suppress an issue on Evergreen's end.