### PR TITLE
RUST-282 Add pretty-printed `Debug` implementation to `Document`

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -21,7 +21,7 @@
 
 //! BSON definition
 
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug, Display, Formatter};
 
 use chrono::Datelike;
 use serde_json::{json, Value};
@@ -34,7 +34,7 @@ use crate::{
 };
 
 /// Possible BSON value types.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum Bson {
     /// 64-bit binary floating point
     Double(f64),
@@ -142,6 +142,40 @@ impl Display for Bson {
                 ref namespace,
                 ref id,
             }) => write!(fmt, "DBPointer({}, {})", namespace, id),
+        }
+    }
+}
+
+impl Debug for Bson {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        match *self {
+            Bson::Double(f) => fmt.debug_tuple("Double").field(&f).finish(),
+            Bson::String(ref s) => fmt.debug_tuple("String").field(s).finish(),
+            Bson::Array(ref vec) => {
+                write!(fmt, "Array(")?;
+                Debug::fmt(vec, fmt)?;
+                write!(fmt, ")")
+            }
+            Bson::Document(ref doc) => Debug::fmt(doc, fmt),
+            Bson::Boolean(b) => fmt.debug_tuple("Boolean").field(&b).finish(),
+            Bson::Null => write!(fmt, "Null"),
+            Bson::RegularExpression(ref regex) => Debug::fmt(regex, fmt),
+            Bson::JavaScriptCode(ref code) => {
+                fmt.debug_tuple("JavaScriptCode").field(code).finish()
+            }
+            Bson::JavaScriptCodeWithScope(ref code) => Debug::fmt(code, fmt),
+            Bson::Int32(i) => fmt.debug_tuple("Int32").field(&i).finish(),
+            Bson::Int64(i) => fmt.debug_tuple("Int64").field(&i).finish(),
+            Bson::Timestamp(ref t) => Debug::fmt(t, fmt),
+            Bson::Binary(ref b) => Debug::fmt(b, fmt),
+            Bson::ObjectId(ref id) => Debug::fmt(id, fmt),
+            Bson::DateTime(ref date_time) => Debug::fmt(date_time, fmt),
+            Bson::Symbol(ref sym) => fmt.debug_tuple("Symbol").field(sym).finish(),
+            Bson::Decimal128(ref d) => Debug::fmt(d, fmt),
+            Bson::Undefined => write!(fmt, "Undefined"),
+            Bson::MinKey => write!(fmt, "MinKey"),
+            Bson::MaxKey => write!(fmt, "MaxKey"),
+            Bson::DbPointer(ref pointer) => Debug::fmt(pointer, fmt),
         }
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -93,7 +93,11 @@ impl Display for Document {
 
 impl Debug for Document {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Document({:?})", self.inner)
+        if f.alternate() {
+            write!(f, "Document({:#?})", self.inner)
+        } else {
+            write!(f, "Document({:?})", self.inner)
+        }
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -92,12 +92,10 @@ impl Display for Document {
 }
 
 impl Debug for Document {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "Document({:#?})", self.inner)
-        } else {
-            write!(f, "Document({:?})", self.inner)
-        }
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "Document(")?;
+        Debug::fmt(&self.inner, fmt)?;
+        write!(fmt, ")")
     }
 }
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -223,7 +223,7 @@ impl fmt::Display for ObjectId {
 
 impl fmt::Debug for ObjectId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("ObjectId({})", self.to_hex()))
+        f.debug_tuple("ObjectId").field(&self.to_hex()).finish()
     }
 }
 
@@ -301,7 +301,14 @@ mod test {
     fn test_debug() {
         let id = super::ObjectId::parse_str("53e37d08776f724e42000000").unwrap();
 
-        assert_eq!(format!("{:?}", id), "ObjectId(53e37d08776f724e42000000)")
+        assert_eq!(
+            format!("{:?}", id),
+            "ObjectId(\"53e37d08776f724e42000000\")"
+        );
+        assert_eq!(
+            format!("{:#?}", id),
+            "ObjectId(\n    \"53e37d08776f724e42000000\",\n)"
+        );
     }
 
     #[test]

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -316,7 +316,7 @@ fn debug_print() {
         b: String,
     }
 
-    let doc = doc! {"a": 1, "b": "data"};
+    let doc = doc! { "a": 1, "b": "data" };
     let data = indexmap! {"a" => Bson::from(1), "b" => Bson::from("data")};
 
     assert_eq!(format!("{:?}", doc), format!("Document({:?})", data));

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -319,11 +319,13 @@ fn debug_print() {
         ]),
         "doc": doc! { "a": 1, "b": "data"},
     };
-    let normal_print = "Document({\"oid\": ObjectId(000000000000000000000000), \"arr\": \
+    let normal_print = "Document({\"oid\": ObjectId(\"000000000000000000000000\"), \"arr\": \
                         Array([Null, Timestamp { time: 1, increment: 1 }]), \"doc\": \
                         Document({\"a\": Int32(1), \"b\": String(\"data\")})})";
     let pretty_print = "Document({
-    \"oid\": ObjectId(000000000000000000000000),
+    \"oid\": ObjectId(
+        \"000000000000000000000000\",
+    ),
     \"arr\": Array([
         Null,
         Timestamp {

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -16,6 +16,7 @@ use crate::{
     Regex,
     Timestamp,
 };
+use indexmap::indexmap;
 use serde_json::{json, Value};
 
 #[test]
@@ -305,4 +306,19 @@ fn system_time() {
         crate::DateTime::from_system_time(SystemTime::UNIX_EPOCH).timestamp_millis(),
         0
     );
+}
+
+#[test]
+fn debug_print() {
+    #[derive(Debug)]
+    struct Example {
+        a: i32,
+        b: String,
+    }
+
+    let doc = doc! {"a": 1, "b": "data"};
+    let data = indexmap! {"a" => Bson::from(1), "b" => Bson::from("data")};
+
+    assert_eq!(format!("{:?}", doc), format!("Document({:?})", data));
+    assert_eq!(format!("{:#?}", doc), format!("Document({:#?})", data));
 }

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -16,7 +16,6 @@ use crate::{
     Regex,
     Timestamp,
 };
-use indexmap::indexmap;
 use serde_json::{json, Value};
 
 #[test]
@@ -310,15 +309,38 @@ fn system_time() {
 
 #[test]
 fn debug_print() {
-    #[derive(Debug)]
-    struct Example {
-        a: i32,
-        b: String,
-    }
+    let oid = ObjectId::parse_str("000000000000000000000000").unwrap();
 
-    let doc = doc! { "a": 1, "b": "data" };
-    let data = indexmap! {"a" => Bson::from(1), "b" => Bson::from("data")};
+    let doc = doc! {
+        "oid": oid,
+        "arr": Bson::Array(vec! [
+            Bson::Null,
+            Bson::Timestamp(Timestamp { time: 1, increment: 1 }),
+        ]),
+        "doc": doc! { "a": 1, "b": "data"},
+    };
+    let normal_print = "Document({\"oid\": ObjectId(000000000000000000000000), \"arr\": \
+                        Array([Null, Timestamp { time: 1, increment: 1 }]), \"doc\": \
+                        Document({\"a\": Int32(1), \"b\": String(\"data\")})})";
+    let pretty_print = "Document({
+    \"oid\": ObjectId(000000000000000000000000),
+    \"arr\": Array([
+        Null,
+        Timestamp {
+            time: 1,
+            increment: 1,
+        },
+    ]),
+    \"doc\": Document({
+        \"a\": Int32(
+            1,
+        ),
+        \"b\": String(
+            \"data\",
+        ),
+    }),
+})";
 
-    assert_eq!(format!("{:?}", doc), format!("Document({:?})", data));
-    assert_eq!(format!("{:#?}", doc), format!("Document({:#?})", data));
+    assert_eq!(format!("{:?}", doc), normal_print);
+    assert_eq!(format!("{:#?}", doc), pretty_print);
 }


### PR DESCRIPTION
It looks like the only relevant struct which doesn't derive `Debug` is `Document`, so I added support for pretty-print there.

I also added a test to the end of [bson.rs](https://github.com/mongodb/bson-rust/compare/master...NBSquare:RUST-282?expand=1#diff-d3ab75438f3cd06c982a058c8ee3fb9cc79c21af4d8424f6d7c44b3ca5ab5272R312) test.