### PR TITLE
RUST-868 Add `serialize_object_id_as_hex_string` helper

### DIFF
--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -2,7 +2,9 @@
 
 use std::{convert::TryFrom, result::Result};
 
-use serde::{ser, Serializer};
+use serde::{ser, Serialize, Serializer};
+
+use crate::oid::ObjectId;
 
 pub use bson_datetime_as_rfc3339_string::{
     deserialize as deserialize_bson_datetime_from_rfc3339_string,
@@ -80,6 +82,14 @@ pub fn serialize_u64_as_i64<S: Serializer>(val: &u64, serializer: S) -> Result<S
         Ok(val) => serializer.serialize_i64(val),
         Err(_) => Err(ser::Error::custom(format!("cannot convert {} to i64", val))),
     }
+}
+
+/// Serializes an ObjectId as a hex string.
+pub fn serialize_object_id_as_hex_string<S: Serializer>(
+    val: &ObjectId,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    val.to_string().serialize(serializer)
 }
 
 /// Contains functions to serialize a u32 as an f64 (BSON double) and deserialize a

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -84,7 +84,7 @@ pub fn serialize_u64_as_i64<S: Serializer>(val: &u64, serializer: S) -> Result<S
     }
 }
 
-/// Serializes an ObjectId as a hex string.
+/// Serializes an [`ObjectId`] as a hex string.
 pub fn serialize_object_id_as_hex_string<S: Serializer>(
     val: &ObjectId,
     serializer: S,

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -89,7 +89,7 @@ pub fn serialize_object_id_as_hex_string<S: Serializer>(
     val: &ObjectId,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    val.to_string().serialize(serializer)
+    val.to_hex().serialize(serializer)
 }
 
 /// Contains functions to serialize a u32 as an f64 (BSON double) and deserialize a

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -913,5 +913,5 @@ fn oid_as_hex_string() {
     let oid = ObjectId::new();
     let foo = Foo { oid };
     let doc = to_document(&foo).unwrap();
-    assert_eq!(doc.get_str("oid").unwrap(), oid.to_string());
+    assert_eq!(doc.get_str("oid").unwrap(), oid.to_hex());
 }

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -11,6 +11,7 @@ use crate::{
         bson_datetime_as_rfc3339_string,
         hex_string_as_object_id,
         rfc3339_string_as_bson_datetime,
+        serialize_object_id_as_hex_string,
         timestamp_as_u32,
         u32_as_timestamp,
     },
@@ -897,4 +898,20 @@ fn large_dates() {
         d.as_document().unwrap().get_datetime("d").unwrap(),
         &DateTime::MIN
     );
+}
+
+#[test]
+fn oid_as_hex_string() {
+    let _guard = LOCK.run_concurrently();
+
+    #[derive(Serialize)]
+    struct Foo {
+        #[serde(serialize_with = "serialize_object_id_as_hex_string")]
+        oid: ObjectId,
+    }
+
+    let oid = ObjectId::new();
+    let foo = Foo { oid };
+    let doc = to_document(&foo).unwrap();
+    assert_eq!(doc.get_str("oid").unwrap(), oid.to_string());
 }


### PR DESCRIPTION
Adds a `serialize_object_id_as_hex_string` serde helper. Note that a deserialize helper is not needed as the implementation of `Deserialize` for `ObjectId` already does this.