### PR TITLE
RUST-876 Quote keys in `Document`'s `Display` format

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -84,7 +84,7 @@ impl Display for Document {
                 fmt.write_str(", ")?;
             }
 
-            write!(fmt, "{}: {}", k, v)?;
+            write!(fmt, "\"{}\": {}", k, v)?;
         }
 
         write!(fmt, "{}}}", if !first { " " } else { "" })

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -37,11 +37,12 @@ fn standard_format() {
     };
 
     let expected = format!(
-        "{{ float: 2.4, string: \"hello\", array: [\"testing\", 1, true, [1, 2]], doc: {{ fish: \
-         \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, \
-         with_wrapped_parens: -20, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, \
-         timestamp: Timestamp(0, 229999444), binary: Binary(0x5, {}), encrypted: Binary(0x6, {}), \
-         _id: ObjectId(\"{}\"), date: DateTime(\"{}\") }}",
+        "{{ \"float\": 2.4, \"string\": \"hello\", \"array\": [\"testing\", 1, true, [1, 2]], \
+         \"doc\": {{ \"fish\": \"in\", \"a\": \"barrel\", \"!\": 1 }}, \"bool\": true, \"null\": \
+         null, \"regexp\": /s[ao]d/i, \"with_wrapped_parens\": -20, \"code\": function(x) {{ \
+         return x._id; }}, \"i32\": 12, \"i64\": -55, \"timestamp\": Timestamp(0, 229999444), \
+         \"binary\": Binary(0x5, {}), \"encrypted\": Binary(0x6, {}), \"_id\": ObjectId(\"{}\"), \
+         \"date\": DateTime(\"{}\") }}",
         base64::encode("thingies"),
         base64::encode("secret"),
         hex::encode(id_string),
@@ -59,7 +60,7 @@ fn non_trailing_comma() {
         "b": { "ok": "then" }
     };
 
-    let expected = "{ a: \"foo\", b: { ok: \"then\" } }".to_string();
+    let expected = "{ \"a\": \"foo\", \"b\": { \"ok\": \"then\" } }".to_string();
     assert_eq!(expected, format!("{}", doc));
 }
 


### PR DESCRIPTION
RUST-876

This PR updates the format produced by `Document`'s `Display` implementation to surround the keys in quotes, as is done in `serde_json` and the shell.

e.g.
```rust
let doc = doc! {
    "some": some,
    "none": none,
    "doc": { "a": 1, "b": true, "c": 3 }
};
println!("{}", doc);
```
now yields:
```json
{ "some": 5, "none": null, "doc": { "a": 1, "b": true, "c": 3 } }
```