### PR TITLE
RUST-870 Support deserializing directly from raw BSON

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -102,6 +102,16 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/run-tests-serde.sh
 
+  "run decimal128 tests":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          .evergreen/run-tests-decimal128.sh
+
   "compile only":
     - command: shell.exec
       type: test
@@ -164,6 +174,10 @@ tasks:
     commands:
       - func: "run serde tests"
 
+  - name: "test-decimal128"
+    commands:
+      - func: "run decimal128 tests"
+
   - name: "compile-only"
     commands:
       - func: "compile only"
@@ -198,6 +212,7 @@ buildvariants:
     - name: "test"
     - name: "test-u2i"
     - name: "test-serde"
+    - name: "test-decimal128"
 
 - matrix_name: "compile only"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -180,9 +180,9 @@ axes:
   - id: "extra-rust-versions"
     values:
       - id: "min"
-        display_name: "1.43 (minimum supported version)"
+        display_name: "1.48 (minimum supported version)"
         variables:
-          RUST_VERSION: "1.43.1"
+          RUST_VERSION: "1.48.0"
       - id: "nightly"
         display_name: "nightly"
         variables:

--- a/.evergreen/run-tests-decimal128.sh
+++ b/.evergreen/run-tests-decimal128.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -o errexit
+
+. ~/.cargo/env
+RUST_BACKTRACE=1 cargo test --features decimal128

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ decimal = { version = "2.1.0", default_features = false, optional = true }
 base64 = "0.13.0"
 lazy_static = "1.4.0"
 uuid = "0.8.1"
+serde_bytes = "0.11.5"
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This crate works with Cargo and can be found on
 bson = "2.0.0-beta.2"
 ```
 
+This crate requires Rust 1.48+.
+
 ## Overview of BSON Format
 
 BSON, short for Binary JSON, is a binary-encoded serialization of JSON-like documents.

--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Kevin Yeh <kevinyeah@utexas.edu>"]
 edition = "2018"
 
 [dependencies]
-bson = { path = ".." }
+bson = { path = "..", features = ["decimal128"] }
 serde = { version = "1.0", features = ["derive"] }
+pretty_assertions = "0.6.1"
 
 [lib]
 name = "serde_tests"

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -9,7 +9,10 @@ use serde::{
     Serialize,
 };
 
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashSet},
+};
 
 use bson::{
     doc,
@@ -802,6 +805,10 @@ fn borrowed() {
         s: &'a str,
         binary: &'a [u8],
         doc: Inner<'a>,
+        #[serde(borrow)]
+        cow: Cow<'a, str>,
+        #[serde(borrow)]
+        array: Vec<&'a str>,
     }
 
     #[derive(Debug, Deserialize, PartialEq)]
@@ -819,13 +826,16 @@ fn borrowed() {
         "binary": binary.clone(),
         "doc": {
             "string": "another borrowed string",
-        }
+        },
+        "cow": "cow",
+        "array": ["borrowed string"],
     };
     let mut bson = Vec::new();
     doc.to_writer(&mut bson).unwrap();
 
     let s = "borrowed string".to_string();
     let ss = "another borrowed string".to_string();
+    let cow = "cow".to_string();
     let inner = Inner {
         string: ss.as_str(),
     };
@@ -833,6 +843,8 @@ fn borrowed() {
         s: s.as_str(),
         binary: binary.bytes.as_slice(),
         doc: inner,
+        cow: Cow::Borrowed(cow.as_str()),
+        array: vec![s.as_str()],
     };
 
     let deserialized: Foo =

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -416,8 +416,6 @@ fn parse_enum() {
 
     let v = Foo { a: E::Empty };
     let doc = doc! { "a": "Empty" };
-    // assert_eq!(serialize!(v), bdoc! { "a" => "Empty" });
-    // assert_eq!(v, deserialize!(serialize!(v)));
     run_test(&v, &doc, "parse_enum: Empty");
 
     let v = Foo { a: E::Bar(10) };

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -620,7 +620,7 @@ fn unused_fields_deny() {
         "a": 1,
         "b": 2,
     };
-    bson::from_document::<Foo>(doc.clone()).expect_err("extra filds should cause failure");
+    bson::from_document::<Foo>(doc.clone()).expect_err("extra fields should cause failure");
 
     let mut bytes = Vec::new();
     doc.to_writer(&mut bytes).unwrap();

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -750,7 +750,7 @@ fn all_types() {
         "binary_other": binary_other.clone(),
         "date": date,
         "regex": regex.clone(),
-        "ts": timestamp.clone(),
+        "ts": timestamp,
         "i": { "a": 300, "b": 12345 },
         "undefined": Bson::Undefined,
         "code": code.clone(),

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -35,7 +35,7 @@ use bson::{
 ///     - deserializing from the serialized document produces `expected_value`
 ///   - round trip through raw BSON:
 ///     - deserializing a `T` from the raw BSON version of `expected_doc` produces `expected_value`
-///     - desierializing a `Document` from the raw BSON version of `expected_doc` produces
+///     - deserializing a `Document` from the raw BSON version of `expected_doc` produces
 ///       `expected_doc`
 fn run_test<T>(expected_value: &T, expected_doc: &Document, description: &str)
 where

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -534,8 +534,8 @@ impl Bson {
     /// This function mainly used for [extended JSON format](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
     // TODO RUST-426: Investigate either removing this from the serde implementation or unifying
     // with the extended JSON implementation.
-    pub(crate) fn to_extended_document(&self) -> Document {
-        match *self {
+    pub(crate) fn into_extended_document(self) -> Document {
+        match self {
             Bson::RegularExpression(Regex {
                 ref pattern,
                 ref options,
@@ -547,23 +547,23 @@ impl Bson {
 
                 doc! {
                     "$regularExpression": {
-                        "pattern": pattern.clone(),
+                        "pattern": pattern,
                         "options": options,
                     }
                 }
             }
             Bson::JavaScriptCode(ref code) => {
                 doc! {
-                    "$code": code.clone(),
+                    "$code": code,
                 }
             }
             Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
-                ref code,
-                ref scope,
+                code,
+                scope,
             }) => {
                 doc! {
-                    "$code": code.clone(),
-                    "$scope": scope.clone(),
+                    "$code": code,
+                    "$scope": scope,
                 }
             }
             Bson::Timestamp(Timestamp { time, increment }) => {

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -32,7 +32,7 @@ use serde_json::{json, Value};
 
 pub use crate::document::Document;
 use crate::{
-    de::{read_i32, read_string, MAX_BSON_SIZE, MIN_CODE_WITH_SCOPE_SIZE},
+    de::{read_i32, read_i64, read_string, MAX_BSON_SIZE, MIN_CODE_WITH_SCOPE_SIZE},
     oid::{self, ObjectId},
     spec::{BinarySubtype, ElementType},
     Decimal128,
@@ -557,10 +557,7 @@ impl Bson {
                     "$code": code,
                 }
             }
-            Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
-                code,
-                scope,
-            }) => {
+            Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope { code, scope }) => {
                 doc! {
                     "$code": code,
                     "$scope": scope,
@@ -999,6 +996,10 @@ pub struct Timestamp {
 }
 
 impl Timestamp {
+    pub(crate) fn from_reader<R: Read>(mut reader: R) -> crate::de::Result<Self> {
+        read_i64(&mut reader).map(|val| Timestamp::from_le_i64(val))
+    }
+
     pub(crate) fn to_le_i64(self) -> i64 {
         let upper = (self.time.to_le() as u64) << 32;
         let lower = self.increment.to_le() as u64;

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -21,7 +21,10 @@
 
 //! BSON definition
 
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Debug, Display, Formatter},
+};
 
 use chrono::Datelike;
 use serde_json::{json, Value};
@@ -182,7 +185,7 @@ impl Debug for Bson {
 
 impl From<f32> for Bson {
     fn from(a: f32) -> Bson {
-        Bson::Double(a as f64)
+        Bson::Double(a.into())
     }
 }
 
@@ -297,7 +300,11 @@ impl From<i64> for Bson {
 
 impl From<u32> for Bson {
     fn from(a: u32) -> Bson {
-        Bson::Int32(a as i32)
+        if let Ok(i) = i32::try_from(a) {
+            Bson::Int32(i)
+        } else {
+            Bson::Int64(a.into())
+        }
     }
 }
 
@@ -580,7 +587,7 @@ impl Bson {
                     "$oid": v.to_string(),
                 }
             }
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 99999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 9999 => {
                 doc! {
                     "$date": v.to_rfc3339(),
                 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -21,13 +21,18 @@
 
 //! BSON definition
 
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    io::Read,
+};
 
 use chrono::Datelike;
+use serde::de::Error;
 use serde_json::{json, Value};
 
 pub use crate::document::Document;
 use crate::{
+    de::{read_i32, read_string, MAX_BSON_SIZE, MIN_CODE_WITH_SCOPE_SIZE},
     oid::{self, ObjectId},
     spec::{BinarySubtype, ElementType},
     Decimal128,
@@ -1032,6 +1037,35 @@ pub struct Regex {
 pub struct JavaScriptCodeWithScope {
     pub code: String,
     pub scope: Document,
+}
+
+impl JavaScriptCodeWithScope {
+    pub(crate) fn from_reader<R: Read>(mut reader: R) -> crate::de::Result<Self> {
+        let length = read_i32(&mut reader)?;
+        if length < MIN_CODE_WITH_SCOPE_SIZE {
+            return Err(crate::de::Error::invalid_length(
+                length as usize,
+                &format!(
+                    "code with scope length must be at least {}",
+                    MIN_CODE_WITH_SCOPE_SIZE
+                )
+                .as_str(),
+            ));
+        } else if length > MAX_BSON_SIZE {
+            return Err(Error::invalid_length(
+                length as usize,
+                &"code with scope length too large",
+            ));
+        }
+
+        let mut buf = vec![0u8; (length - 4) as usize];
+        reader.read_exact(&mut buf)?;
+
+        let mut slice = buf.as_slice();
+        let code = read_string(&mut slice, false)?;
+        let scope = Document::from_reader(&mut slice)?;
+        Ok(JavaScriptCodeWithScope { code, scope })
+    }
 }
 
 /// Represents a BSON binary value.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -427,9 +427,9 @@ where
 }
 
 /// Decode BSON bytes from the provided reader into a `T` Deserializable.
-pub fn from_slice<T>(bytes: &[u8]) -> Result<T>
+pub fn from_slice<'de, T>(bytes: &'de [u8]) -> Result<T>
 where
-    T: DeserializeOwned,
+    T: Deserialize<'de>,
 {
     let mut deserializer = raw::Deserializer::new(bytes);
     T::deserialize(&mut deserializer)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -290,9 +290,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
         }
         Some(ElementType::Int32) => read_i32(reader).map(Bson::Int32)?,
         Some(ElementType::Int64) => read_i64(reader).map(Bson::Int64)?,
-        Some(ElementType::Timestamp) => {
-            Bson::Timestamp(Timestamp::from_reader(reader)?)
-        }
+        Some(ElementType::Timestamp) => Bson::Timestamp(Timestamp::from_reader(reader)?),
         Some(ElementType::DateTime) => {
             // The int64 is UTC milliseconds since the Unix epoch.
             let time = read_i64(reader)?;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -434,7 +434,7 @@ where
 ///
 /// This is mainly useful when reading raw BSON returned from a MongoDB server, which
 /// in rare cases can contain invalidly truncated strings (https://jira.mongodb.org/browse/SERVER-24007).
-/// For most use cases, `bson::from_slice` can be used instead.
+/// For most use cases, [`crate::from_reader`] can be used instead.
 pub fn from_reader_utf8_lossy<R, T>(reader: R) -> Result<T>
 where
     T: DeserializeOwned,
@@ -458,7 +458,7 @@ where
 ///
 /// This is mainly useful when reading raw BSON returned from a MongoDB server, which
 /// in rare cases can contain invalidly truncated strings (https://jira.mongodb.org/browse/SERVER-24007).
-/// For most use cases, `bson::from_slice` can be used instead.
+/// For most use cases, [`crate::from_slice`] can be used instead.
 pub fn from_slice_utf8_lossy<'de, T>(bytes: &'de [u8]) -> Result<T>
 where
     T: Deserialize<'de>,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -134,7 +134,7 @@ pub(crate) fn read_i32<R: Read + ?Sized>(reader: &mut R) -> Result<i32> {
 }
 
 #[inline]
-fn read_i64<R: Read + ?Sized>(reader: &mut R) -> Result<i64> {
+pub(crate) fn read_i64<R: Read + ?Sized>(reader: &mut R) -> Result<i64> {
     let mut buf = [0; 8];
     reader.read_exact(&mut buf)?;
     Ok(i64::from_le_bytes(buf))
@@ -291,7 +291,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
         Some(ElementType::Int32) => read_i32(reader).map(Bson::Int32)?,
         Some(ElementType::Int64) => read_i64(reader).map(Bson::Int64)?,
         Some(ElementType::Timestamp) => {
-            read_i64(reader).map(|val| Bson::Timestamp(Timestamp::from_le_i64(val)))?
+            Bson::Timestamp(Timestamp::from_reader(reader)?)
         }
         Some(ElementType::DateTime) => {
             // The int64 is UTC milliseconds since the Unix epoch.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -23,6 +23,7 @@
 
 mod error;
 mod serde;
+mod raw;
 
 pub use self::{
     error::{Error, Result},
@@ -360,4 +361,15 @@ where
     T: DeserializeOwned,
 {
     from_bson(Bson::Document(doc))
+}
+
+
+/// Decode a BSON `Document` into a `T` Deserializable.
+pub fn from_reader<R, T>(reader: R) -> Result<T>
+where
+    T: DeserializeOwned,
+    R: Read,
+{
+    let mut deserializer = raw::Deserializer::new(reader);
+    T::deserialize(&mut deserializer)
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -332,7 +332,7 @@ impl Regex {
 
 impl Timestamp {
     pub(crate) fn from_reader<R: Read>(mut reader: R) -> Result<Self> {
-        read_i64(&mut reader).map(|val| Timestamp::from_le_i64(val))
+        read_i64(&mut reader).map(Timestamp::from_le_i64)
     }
 }
 

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -547,7 +547,7 @@ impl<'de> serde::de::MapAccess<'de> for Decimal128Access {
         }
         self.visited = true;
         seed.deserialize(FieldDeserializer {
-            field_name: "$numberDecimal",
+            field_name: "$numberDecimalBytes",
         })
         .map(Some)
     }

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -541,7 +541,7 @@ impl<'de> serde::de::MapAccess<'de> for Decimal128Access {
         }
         self.visited = true;
         seed.deserialize(FieldDeserializer {
-            field_name: "$numberDecimalBytes",
+            field_name: "$numberDecimal",
         })
         .map(Some)
     }

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -65,7 +65,7 @@ impl<'de, 'a, R: Read> serde::de::Deserializer<'de> for &'a mut Deserializer<R> 
             ElementType::Int32 => visitor.visit_i32(read_i32(&mut self.reader)?),
             ElementType::Int64 => visitor.visit_i64(read_i64(&mut self.reader)?),
             ElementType::Double => visitor.visit_f64(read_f64(&mut self.reader)?),
-            ElementType::String => visitor.visit_string(read_string(&mut self.reader, true)?),
+            ElementType::String => visitor.visit_string(read_string(&mut self.reader, false)?),
             ElementType::Boolean => visitor.visit_bool(read_bool(&mut self.reader)?),
             ElementType::Null => visitor.visit_none(),
             ElementType::ObjectId => {

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -1,0 +1,449 @@
+use std::io::Read;
+
+use serde::forward_to_deserialize_any;
+
+use crate::{oid::ObjectId, spec::ElementType};
+
+use super::{read_cstring, read_f64, read_i32, read_u8, Error};
+use super::{read_i64, read_string, Result};
+
+// hello
+
+struct CountReader<R> {
+    reader: R,
+    bytes_read: usize,
+}
+
+impl<R: Read> CountReader<R> {
+    /// Constructs a new CountReader that wraps `reader`.
+    pub(super) fn new(reader: R) -> Self {
+        CountReader {
+            reader,
+            bytes_read: 0,
+        }
+    }
+
+    /// Gets the number of bytes read so far.
+    pub(super) fn bytes_read(&self) -> usize {
+        self.bytes_read
+    }
+}
+
+impl<R: Read> Read for CountReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let bytes = self.reader.read(buf)?;
+        self.bytes_read += bytes;
+        Ok(bytes)
+    }
+}
+
+pub(crate) struct Deserializer<R> {
+    reader: CountReader<R>,
+    current_type: ElementType,
+}
+
+impl<R> Deserializer<R>
+where
+    R: Read,
+{
+    pub(crate) fn new(reader: R) -> Self {
+        Self {
+            reader: CountReader::new(reader),
+            current_type: ElementType::EmbeddedDocument,
+        }
+    }
+}
+
+impl<'de, 'a, R: Read> serde::de::Deserializer<'de> for &'a mut Deserializer<R> {
+    type Error = Error;
+
+    fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self.current_type {
+            ElementType::Int32 => visitor.visit_i32(read_i32(&mut self.reader)?),
+            ElementType::Int64 => visitor.visit_i64(read_i64(&mut self.reader)?),
+            ElementType::Double => visitor.visit_f64(read_f64(&mut self.reader)?),
+            ElementType::String => visitor.visit_string(read_string(&mut self.reader, true)?),
+            ElementType::Boolean => visitor.visit_bool(read_u8(&mut self.reader)? == 1),
+            ElementType::Null => visitor.visit_none(),
+            ElementType::ObjectId => {
+                let oid = ObjectId::from_reader(&mut self.reader)?;
+                visitor.visit_map(ObjectIdAccess::new(oid))
+            }
+            ElementType::EmbeddedDocument => {
+                let length = read_i32(&mut self.reader)?;
+                visitor.visit_map(MapAccess {
+                    root_deserializer: &mut self,
+                    length_remaining: length - 4,
+                })
+            }
+            _ => todo!("unexecpted type {:?}", self.current_type),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool char str bytes byte_buf option unit unit_struct
+            newtype_struct seq tuple tuple_struct struct map enum
+            ignored_any i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let s = read_cstring(&mut self.reader)?;
+        visitor.visit_string(s)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
+    // fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    // fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_unit_struct<V>(
+    //     self,
+    //     name: &'static str,
+    //     visitor: V,
+    // ) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_newtype_struct<V>(
+    //     self,
+    //     name: &'static str,
+    //     visitor: V,
+    // ) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_tuple_struct<V>(
+    //     self,
+    //     name: &'static str,
+    //     len: usize,
+    //     visitor: V,
+    // ) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_struct<V>(
+    //     self,
+    //     name: &'static str,
+    //     fields: &'static [&'static str],
+    //     visitor: V,
+    // ) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_enum<V>(
+    //     self,
+    //     name: &'static str,
+    //     variants: &'static [&'static str],
+    //     visitor: V,
+    // ) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+
+    // fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    // where
+    //     V: serde::de::Visitor<'de> {
+    //     todo!()
+    // }
+}
+
+struct MapAccess<'d, T: 'd> {
+    root_deserializer: &'d mut Deserializer<T>,
+    length_remaining: i32,
+}
+
+impl<'de, 'd, R: Read> serde::de::MapAccess<'de> for MapAccess<'d, R> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: serde::de::DeserializeSeed<'de>,
+    {
+        let tag = read_u8(&mut self.root_deserializer.reader)?;
+        self.length_remaining -= 1;
+        if tag == 0 {
+            if self.length_remaining != 0 {
+                panic!(
+                    "got null byte but still have length {} remaining",
+                    self.length_remaining
+                )
+            }
+            return Ok(None);
+        }
+        // TODO: handle bad tags
+        self.root_deserializer.current_type = ElementType::from(tag).unwrap();
+        let start_bytes = self.root_deserializer.reader.bytes_read();
+        let out = seed
+            .deserialize(DocumentKeyDeserializer {
+                root_deserializer: &mut *self.root_deserializer,
+            })
+            .map(Some);
+        let bytes_read = self.root_deserializer.reader.bytes_read() - start_bytes;
+        self.length_remaining -= bytes_read as i32;
+
+        if self.length_remaining <= 0 {
+            panic!("ran out of bytes!");
+        }
+        out
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        let start_bytes = self.root_deserializer.reader.bytes_read();
+        let out = seed.deserialize(&mut *self.root_deserializer);
+        let bytes_read = self.root_deserializer.reader.bytes_read() - start_bytes;
+        self.length_remaining -= bytes_read as i32;
+
+        if self.length_remaining <= 0 {
+            panic!("ran out of bytes!");
+        }
+        out
+    }
+}
+
+struct DocumentKeyDeserializer<'d, R> {
+    root_deserializer: &'d mut Deserializer<R>,
+}
+
+impl<'de, 'a, R: Read> serde::de::Deserializer<'de> for DocumentKeyDeserializer<'a, R> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let s = read_cstring(&mut self.root_deserializer.reader)?;
+        visitor.visit_string(s)
+    }
+
+    forward_to_deserialize_any! {
+        bool char str bytes byte_buf option unit unit_struct string
+        identifier newtype_struct seq tuple tuple_struct struct map enum
+        ignored_any i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
+    }
+}
+
+struct ObjectIdAccess {
+    oid: ObjectId,
+    visited: bool,
+}
+
+impl ObjectIdAccess {
+    fn new(oid: ObjectId) -> Self {
+        Self {
+            oid,
+            visited: false,
+        }
+    }
+}
+
+impl<'de> serde::de::MapAccess<'de> for ObjectIdAccess {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: serde::de::DeserializeSeed<'de>,
+    {
+        if self.visited {
+            return Ok(None);
+        }
+        self.visited = true;
+        seed.deserialize(FieldDeserializer { field_name: "$oid" })
+            .map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(ObjectIdDeserializer(self.oid))
+    }
+}
+
+struct FieldDeserializer {
+    field_name: &'static str,
+}
+
+impl<'de> serde::de::Deserializer<'de> for FieldDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.field_name)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map struct option unit newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct ObjectIdDeserializer(ObjectId);
+
+impl<'de> serde::de::Deserializer<'de> for ObjectIdDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_string(self.0.to_hex())
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map struct option unit newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Instant;
+
+    use serde::Deserialize;
+
+    use crate::{oid::ObjectId, Document};
+
+    use super::Deserializer;
+
+    #[derive(Debug, Deserialize)]
+    struct D {
+        x: i32,
+        y: i32,
+        i: I,
+        // oid: ObjectId,
+        null: Option<i32>,
+        b: bool,
+        d: f32,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct I {
+        a: i32,
+        b: i32,
+    }
+
+    #[test]
+    fn raw() {
+        let doc = doc! {
+            "ok": 1,
+            "x": 1,
+            "y": 2,
+            "i": { "a": 300, "b": 12345 },
+            // "oid": ObjectId::new(),
+            "null": crate::Bson::Null,
+            "b": true,
+            "d": 12.5,
+        };
+        let mut bson = vec![0u8; 0];
+        doc.to_writer(&mut bson).unwrap();
+        println!("byte len: {}", bson.len());
+
+        let raw_start = Instant::now();
+        for _ in 0..10_000 {
+            let mut de = Deserializer::new(bson.as_slice());
+            // let cr = CommandResponse::deserialize(&mut de).unwrap();
+            let t = Document::deserialize(&mut de).unwrap();
+        }
+        let raw_time = raw_start.elapsed();
+        println!("raw time: {}", raw_time.as_secs_f32());
+
+        let normal_start = Instant::now();
+        for _ in 0..10_000 {
+            // let mut de = Deserializer::new(bson.as_slice());
+            // // let cr = CommandResponse::deserialize(&mut de).unwrap();
+            // let t = D::deserialize(&mut de).unwrap();
+            let d = Document::from_reader(bson.as_slice()).unwrap();
+            let t: Document = crate::from_document(d).unwrap();
+        }
+        let normal_time = normal_start.elapsed();
+        println!("normal time: {}", normal_time.as_secs_f32());
+
+        let normal_start = Instant::now();
+        for _ in 0..10_000 {
+            // let mut de = Deserializer::new(bson.as_slice());
+            // // let cr = CommandResponse::deserialize(&mut de).unwrap();
+            // let t = D::deserialize(&mut de).unwrap();
+            // let d = Document::from_reader(bson.as_slice()).unwrap();
+            // let t: Document = crate::from_document(doc.clone()).unwrap();
+            let _d = Document::from_reader(bson.as_slice()).unwrap();
+        }
+        let normal_time = normal_start.elapsed();
+        println!("decode time: {}", normal_time.as_secs_f32());
+    }
+}

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -74,7 +74,11 @@ impl<'de> Deserializer<'de> {
                     length_remaining
                 )));
             }
-            _ => (),
+            std::cmp::Ordering::Less => {
+                if length_remaining < 0 {
+                    return Err(Error::custom("length of document was too short"));
+                }
+            }
         }
         Ok(())
     }

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -174,10 +174,17 @@ impl<'de, 'a, R: Read> serde::de::Deserializer<'de> for &'a mut Deserializer<R> 
                     deserializer: &mut d,
                 })
             }
-            // ElementType::Decimal128 => {}
-            // ElementType::MaxKey => {}
-            // ElementType::MinKey => {}
-            _ => todo!(),
+            ElementType::Decimal128 => {
+                todo!()
+            }
+            ElementType::MaxKey => {
+                let doc = Bson::MaxKey.into_extended_document();
+                visitor.visit_map(MapDeserializer::new(doc))
+            }
+            ElementType::MinKey => {
+                let doc = Bson::MinKey.into_extended_document();
+                visitor.visit_map(MapDeserializer::new(doc))
+            }
         }
     }
 

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     convert::{TryFrom, TryInto},
     fmt,
     vec,
@@ -23,7 +22,7 @@ use serde_bytes::ByteBuf;
 use crate::{
     bson::{Binary, Bson, DbPointer, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
-    document::{Document, DocumentVisitor, IntoIter},
+    document::{Document, IntoIter},
     oid::ObjectId,
     spec::BinarySubtype,
     Decimal128,

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -377,7 +377,7 @@ impl<'de> Visitor<'de> for BsonVisitor {
                         .map_err(Error::custom);
                 }
 
-                "$numberDecimalBytes" => {
+                "$numberDecimal" => {
                     let bytes = visitor.next_value::<ByteBuf>()?;
                     let arr = bytes.into_vec().try_into().map_err(|v: Vec<u8>| {
                         Error::custom(format!(

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -225,7 +225,6 @@ impl<'de> Visitor<'de> for BsonVisitor {
         use crate::extjson;
 
         let mut doc = Document::new();
-        // let mut next_key = None;
 
         while let Some(k) = visitor.next_key::<String>()? {
             match k.as_str() {
@@ -300,7 +299,7 @@ impl<'de> Visitor<'de> for BsonVisitor {
                                 scope,
                             }));
                         } else {
-                            todo!()
+                            return Err(Error::unknown_field(key.as_str(), &["$scope"]));
                         }
                     } else {
                         return Ok(Bson::JavaScriptCode(code));
@@ -317,10 +316,10 @@ impl<'de> Visitor<'de> for BsonVisitor {
                                 scope,
                             }));
                         } else {
-                            todo!()
+                            return Err(Error::unknown_field(key.as_str(), &["$code"]));
                         }
                     } else {
-                        todo!()
+                        return Err(Error::missing_field("$code"));
                     }
                 }
 

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -509,12 +509,12 @@ impl<'de> de::Deserializer<'de> for Deserializer {
                 bytes,
             }) => visitor.visit_byte_buf(bytes),
             binary @ Bson::Binary(..) => visitor.visit_map(MapDeserializer {
-                iter: binary.to_extended_document().into_iter(),
+                iter: binary.into_extended_document().into_iter(),
                 value: None,
                 len: 2,
             }),
             _ => {
-                let doc = value.to_extended_document();
+                let doc = value.into_extended_document();
                 let len = doc.len();
                 visitor.visit_map(MapDeserializer {
                     iter: doc.into_iter(),

--- a/src/document.rs
+++ b/src/document.rs
@@ -5,13 +5,12 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     io::{Read, Write},
     iter::{Extend, FromIterator, IntoIterator},
-    marker::PhantomData,
     mem,
 };
 
 use ahash::RandomState;
 use indexmap::IndexMap;
-use serde::de::{self, Error, MapAccess, Visitor};
+use serde::de::Error;
 
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
@@ -681,52 +680,6 @@ impl<'a> OccupiedEntry<'a> {
     /// Gets a reference to the key in the entry.
     pub fn key(&self) -> &str {
         self.inner.key()
-    }
-}
-
-pub(crate) struct DocumentVisitor {
-    marker: PhantomData<Document>,
-}
-
-impl DocumentVisitor {
-    #[allow(clippy::new_without_default)]
-    pub(crate) fn new() -> DocumentVisitor {
-        DocumentVisitor {
-            marker: PhantomData,
-        }
-    }
-}
-
-impl<'de> Visitor<'de> for DocumentVisitor {
-    type Value = Document;
-
-    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "expecting ordered document")
-    }
-
-    #[inline]
-    fn visit_unit<E>(self) -> Result<Document, E>
-    where
-        E: de::Error,
-    {
-        Ok(Document::new())
-    }
-
-    #[inline]
-    fn visit_map<V>(self, mut visitor: V) -> Result<Document, V::Error>
-    where
-        V: MapAccess<'de>,
-    {
-        let mut inner = match visitor.size_hint() {
-            Some(size) => IndexMap::with_capacity_and_hasher(size, RandomState::default()),
-            None => IndexMap::default(),
-        };
-
-        while let Some((key, value)) = visitor.next_entry()? {
-            inner.insert(key, value);
-        }
-
-        Ok(Document { inner })
     }
 }
 

--- a/src/extjson/mod.rs
+++ b/src/extjson/mod.rs
@@ -90,4 +90,4 @@
 //! ```
 
 pub mod de;
-mod models;
+pub(crate) mod models;

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -102,9 +102,9 @@ pub(crate) struct Regex {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RegexBody {
-    pattern: String,
-    options: String,
+pub(crate) struct RegexBody {
+    pub(crate) pattern: String,
+    pub(crate) options: String,
 }
 
 impl Regex {
@@ -124,15 +124,16 @@ impl Regex {
 #[serde(deny_unknown_fields)]
 pub(crate) struct Binary {
     #[serde(rename = "$binary")]
-    body: BinaryBody,
+    pub(crate) body: BinaryBody,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct BinaryBody {
-    base64: String,
+pub(crate) struct BinaryBody {
+    pub(crate) base64: String,
+
     #[serde(rename = "subType")]
-    subtype: String,
+    pub(crate) subtype: String,
 }
 
 impl Binary {
@@ -209,8 +210,8 @@ pub(crate) struct Timestamp {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TimestampBody {
-    t: u32,
-    i: u32,
+    pub(crate) t: u32,
+    pub(crate) i: u32,
 }
 
 impl Timestamp {
@@ -226,12 +227,12 @@ impl Timestamp {
 #[serde(deny_unknown_fields)]
 pub(crate) struct DateTime {
     #[serde(rename = "$date")]
-    body: DateTimeBody,
+    pub(crate) body: DateTimeBody,
 }
 
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum DateTimeBody {
+pub(crate) enum DateTimeBody {
     Canonical(Int64),
     Relaxed(String),
 }
@@ -263,7 +264,7 @@ impl DateTime {
 #[serde(deny_unknown_fields)]
 pub(crate) struct MinKey {
     #[serde(rename = "$minKey")]
-    value: u8,
+    pub(crate) value: u8,
 }
 
 impl MinKey {
@@ -283,7 +284,7 @@ impl MinKey {
 #[serde(deny_unknown_fields)]
 pub(crate) struct MaxKey {
     #[serde(rename = "$maxKey")]
-    value: u8,
+    pub(crate) value: u8,
 }
 
 impl MaxKey {
@@ -308,12 +309,12 @@ pub(crate) struct DbPointer {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct DbPointerBody {
+pub(crate) struct DbPointerBody {
     #[serde(rename = "$ref")]
-    ref_ns: String,
+    pub(crate) ref_ns: String,
 
     #[serde(rename = "$id")]
-    id: ObjectId,
+    pub(crate) id: ObjectId,
 }
 
 impl DbPointer {
@@ -350,7 +351,7 @@ impl Decimal128 {
 #[serde(deny_unknown_fields)]
 pub(crate) struct Undefined {
     #[serde(rename = "$undefined")]
-    value: bool,
+    pub(crate) value: bool,
 }
 
 impl Undefined {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,15 @@
 pub use self::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
-    de::{from_bson, from_document, from_reader, from_slice, Deserializer},
+    de::{
+        from_bson,
+        from_document,
+        from_reader,
+        from_reader_utf8_lossy,
+        from_slice,
+        from_slice_utf8_lossy,
+        Deserializer,
+    },
     decimal128::Decimal128,
     ser::{to_bson, to_document, Serializer},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 pub use self::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
-    de::{from_bson, from_document, from_reader, Deserializer},
+    de::{from_bson, from_document, from_reader, from_slice, Deserializer},
     decimal128::Decimal128,
     ser::{to_bson, to_document, Serializer},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 pub use self::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
-    de::{from_bson, from_document, Deserializer},
+    de::{from_bson, from_document, from_reader, Deserializer},
     decimal128::Decimal128,
     ser::{to_bson, to_document, Serializer},
 };

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,14 +1,6 @@
 //! ObjectId
 
-use std::{
-    convert::TryInto,
-    error,
-    fmt,
-    result,
-    str::FromStr,
-    sync::atomic::{AtomicUsize, Ordering},
-    time::SystemTime,
-};
+use std::{io::Read, convert::TryInto, error, fmt, result, str::FromStr, sync::atomic::{AtomicUsize, Ordering}, time::SystemTime};
 
 use hex::{self, FromHexError};
 use rand::{thread_rng, Rng};
@@ -212,6 +204,12 @@ impl ObjectId {
         let buf = u_int.to_be_bytes();
         let buf_u24: [u8; 3] = [buf[5], buf[6], buf[7]];
         buf_u24
+    }
+
+    pub(crate) fn from_reader<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let mut buf = [0u8; 12];
+        reader.read_exact(&mut buf)?;
+        Ok(Self::from_bytes(buf))
     }
 }
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,6 +1,15 @@
 //! ObjectId
 
-use std::{io::Read, convert::TryInto, error, fmt, result, str::FromStr, sync::atomic::{AtomicUsize, Ordering}, time::SystemTime};
+use std::{
+    convert::TryInto,
+    error,
+    fmt,
+    io::Read,
+    result,
+    str::FromStr,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::SystemTime,
+};
 
 use hex::{self, FromHexError};
 use rand::{thread_rng, Rng};

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -4,7 +4,6 @@ use std::{
     convert::TryInto,
     error,
     fmt,
-    io::Read,
     result,
     str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
@@ -213,12 +212,6 @@ impl ObjectId {
         let buf = u_int.to_be_bytes();
         let buf_u24: [u8; 3] = [buf[5], buf[6], buf[7]];
         buf_u24
-    }
-
-    pub(crate) fn from_reader<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let mut buf = [0u8; 12];
-        reader.read_exact(&mut buf)?;
-        Ok(Self::from_bytes(buf))
     }
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -29,7 +29,7 @@ pub use self::{
     serde::Serializer,
 };
 
-use std::{io::Write, mem};
+use std::{io::Write, iter::FromIterator, mem};
 
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
@@ -119,7 +119,11 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
             ref options,
         }) => {
             write_cstring(writer, pattern)?;
-            write_cstring(writer, options)
+
+            let mut chars: Vec<char> = options.chars().collect();
+            chars.sort_unstable();
+
+            write_cstring(writer, String::from_iter(chars).as_str())
         }
         Bson::JavaScriptCode(ref code) => write_string(writer, code),
         Bson::ObjectId(ref id) => writer.write_all(&id.bytes()).map_err(From::from),

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -67,7 +67,7 @@ impl Serialize for Bson {
                 ref bytes,
             }) => serializer.serialize_bytes(bytes),
             _ => {
-                let doc = self.to_extended_document();
+                let doc = self.clone().into_extended_document();
                 doc.serialize(serializer)
             }
         }

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -173,8 +173,12 @@ fn run_test(test: TestFile) {
 
             let bson = hex::decode(&decode_error.bson).expect("should decode from hex");
             Document::from_reader(bson.as_slice()).expect_err(decode_error.description.as_str());
-            crate::from_reader::<_, Document>(bson.as_slice())
-                .expect_err(decode_error.description.as_str());
+
+            // the from_reader implementation supports deserializing from lossy UTF-8
+            if !decode_error.description.contains("invalid UTF-8") {
+                crate::from_reader::<_, Document>(bson.as_slice())
+                    .expect_err(decode_error.description.as_str());
+            }
         }
 
         // TODO RUST-36: Enable decimal128 tests.

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -109,7 +109,7 @@ fn run_test(test: TestFile) {
         );
 
         // NaN == NaN is false, so we skip document comparisons that contain NaN
-        if !description.contains("NaN") {
+        if !description.to_ascii_lowercase().contains("nan") && !description.contains("decq541") {
             assert_eq!(
                 bson_to_native_cb, bson_to_native_cb_serde,
                 "{}",

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{tests::LOCK, Bson, Document};
-// use pretty_assertions::assert_eq;
+use pretty_assertions::assert_eq;
 use serde::Deserialize;
 
 use super::run_spec_test;
@@ -69,8 +69,6 @@ fn run_test(test: TestFile) {
 
         let native_to_native_cb_serde: Document =
             crate::from_document(bson_to_native_cb.clone()).expect(&description);
-
-        // assert_eq!(bson_to_native_cb_serde, bson_to_native_cb, "{}", description);
 
         let mut native_to_bson_bson_to_native_cb = Vec::new();
         bson_to_native_cb


### PR DESCRIPTION
RUST-870

This PR introduces two new functions to the public API which allow for deserializing a `T` directly from raw BSON bytes instead of going through `Document` first: `from_reader` and `from_slice`. The primary goal of these functions is to enable performance improvements in the driver, though they should be generally useful on their own. This PR also enables borrowed deserialization via `from_slice` (#231, RUST-688).

The implementation of this involved introducing a new deserializer that reads directly from raw BSON. The code for this lives in `srd/de/raw.rs`, and is modeled off of the [Implementing a Deserializer](https://serde.rs/impl-deserializer.html) example and `serde_json`'s [`Deserializer`](https://github.com/serde-rs/json/blob/master/src/de.rs#L24). I encourage reading through the example and having both handy while reviewing this PR.

This also fixes RUST-880, RUST-884, and partially RUST-882.