### PR TITLE
RUST-891 draft: make chrono as a optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 # no features by default
 default = []
 # if enabled, include API for interfacing with chrono 0.4
-chrono-0_4 = []
+chrono-0_4 = ["chrono"]
 # if enabled, include API for interfacing with uuid 0.8
 uuid-0_8 = []
 # attempt to encode unsigned types in signed types
@@ -47,7 +47,7 @@ name = "bson"
 
 [dependencies]
 ahash = "0.7.2"
-chrono = "0.4.15"
+chrono = { version="0.4.15", optional=true }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -23,7 +23,6 @@
 
 use std::fmt::{self, Debug, Display, Formatter};
 
-use chrono::Datelike;
 use serde_json::{json, Value};
 
 pub use crate::document::Document;
@@ -423,7 +422,7 @@ impl Bson {
                 })
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 99999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.year() <= 99999 => {
                 json!({
                     "$date": v.to_rfc3339(),
                 })
@@ -583,7 +582,7 @@ impl Bson {
                     "$oid": v.to_string(),
                 }
             }
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 99999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.year() <= 99999 => {
                 doc! {
                     "$date": v.to_rfc3339(),
                 }
@@ -780,8 +779,8 @@ impl Bson {
                 }
 
                 if let Ok(date) = doc.get_str("$date") {
-                    if let Ok(date) = chrono::DateTime::parse_from_rfc3339(date) {
-                        return Bson::DateTime(crate::DateTime::from_chrono(date));
+                    if let Ok(date) = crate::DateTime::parse_rfc3339(date) {
+                        return Bson::DateTime(date);
                     }
                 }
             }

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -1,6 +1,5 @@
 //! A module defining serde models for the extended JSON representations of the various BSON types.
 
-use chrono::Utc;
 use serde::{
     de::{Error, Unexpected},
     Deserialize,
@@ -244,16 +243,13 @@ impl DateTime {
                 Ok(crate::DateTime::from_millis(date))
             }
             DateTimeBody::Relaxed(date) => {
-                let datetime: chrono::DateTime<Utc> =
-                    chrono::DateTime::parse_from_rfc3339(date.as_str())
-                        .map_err(|_| {
-                            extjson::de::Error::invalid_value(
-                                Unexpected::Str(date.as_str()),
-                                &"rfc3339 formatted utc datetime",
-                            )
-                        })?
-                        .into();
-                Ok(crate::DateTime::from_chrono(datetime))
+                let datetime = crate::DateTime::parse_rfc3339(&date).map_err(|_| {
+                    extjson::de::Error::invalid_value(
+                        Unexpected::Str(date.as_str()),
+                        &"rfc3339 formatted utc datetime",
+                    )
+                })?;
+                Ok(datetime)
             }
         }
     }

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -242,11 +242,10 @@ pub mod rfc3339_string_as_bson_datetime {
 
     /// Serializes an ISO string as a DateTime.
     pub fn serialize<S: Serializer>(val: &str, serializer: S) -> Result<S::Ok, S::Error> {
-        let date =
-            chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(val).map_err(|_| {
-                ser::Error::custom(format!("cannot convert {} to chrono::DateTime", val))
-            })?;
-        Bson::DateTime(crate::DateTime::from_chrono(date)).serialize(serializer)
+        let datetime = DateTime::parse_rfc3339(val).map_err(|_| {
+            ser::Error::custom(format!("cannot convert {} to chrono::DateTime", val))
+        })?;
+        Bson::DateTime(datetime).serialize(serializer)
     }
 }
 
@@ -273,11 +272,10 @@ pub mod bson_datetime_as_rfc3339_string {
         D: Deserializer<'de>,
     {
         let iso = String::deserialize(deserializer)?;
-        let date =
-            chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(&iso).map_err(|_| {
-                de::Error::custom(format!("cannot parse RFC 3339 datetime from \"{}\"", iso))
-            })?;
-        Ok(DateTime::from_chrono(date))
+        let datetime = DateTime::parse_rfc3339(&iso).map_err(|_| {
+            de::Error::custom(format!("cannot parse RFC 3339 datetime from \"{}\"", iso))
+        })?;
+        Ok(datetime)
     }
 
     /// Serializes a [`crate::DateTime`] as an RFC 3339 (ISO 8601) formatted string.


### PR DESCRIPTION
bson's datetime is a i64 timestamp in millisecond like javascript, it is quite different to chrono's Datetime

since bson-rust has chrono-0_4 feature to turn on/off chrono

but If bson-rust disable chrono-0_4 feature, still a amout of functions require chrono crate

---

This PR is my attempt to impl some functions without chrono, I think chrono-0_4 need more discussions.

Please don't merge it, it just a drat and still working in progress.

some test cases didn't pass!

```
Diff < left / right > :
 Object({
     "a": Object({
         "$date": String(
<            "1970-01-01T00:00:00+0000",
>            "1970-01-01T00:00:00Z",
         ),
     }),
 })

failures:
    tests::modules::macros::standard_format
    tests::serde::test_datetime_helpers
    tests::serde::test_ser_datetime
    tests::spec::corpus::run

test result: FAILED. 97 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```