### PR TITLE
RUST-882 Remove lossy `From<u64>` impl for `Bson`

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -308,12 +308,6 @@ impl From<u32> for Bson {
     }
 }
 
-impl From<u64> for Bson {
-    fn from(a: u64) -> Bson {
-        Bson::Int64(a as i64)
-    }
-}
-
 impl From<[u8; 12]> for Bson {
     fn from(a: [u8; 12]) -> Bson {
         Bson::ObjectId(oid::ObjectId::from_bytes(a))

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -196,7 +196,6 @@ impl TryFrom<serde_json::Value> for Bson {
                         Bson::Int64(i)
                     }
                 })
-                .or_else(|| x.as_u64().map(Bson::from))
                 .or_else(|| x.as_f64().map(Bson::from))
                 .ok_or_else(|| {
                     Error::invalid_value(

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -114,7 +114,6 @@ fn from_impls() {
     assert_eq!(Bson::from(-48i32), Bson::Int32(-48));
     assert_eq!(Bson::from(-96i64), Bson::Int64(-96));
     assert_eq!(Bson::from(152u32), Bson::Int32(152));
-    assert_eq!(Bson::from(4096u64), Bson::Int64(4096));
 
     let oid = ObjectId::new();
     assert_eq!(


### PR DESCRIPTION
RUST-882

This PR removes the `From<u64>` impl for `Bson` that could be lossy in the event that the `u64 > i64::MAX`. I opted to not replace it with a `TryFrom` implementation as I would have to specify an error, and I wasn't sure if we wanted to create yet another error type just for this case. An alternative could be to use `<i64 as TryFrom<u64>>::Error`, but I wasn't sure if that would be weird. Let me know what you guys think.

The lossiness in `From<u32>` was fixed in #276.