### PR TITLE
RUST-942 Generate 5 random bytes instead of 3 for ObjectIds

### DIFF
--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -902,7 +902,7 @@ fn u2i() {
         "u_32": 1234_i64,
         "u_32_max": u32::MAX as i64,
         "u_64": 12345_i64,
-        "i_64_max": i64::MAX as u64,
+        "i_64_max": i64::MAX,
     };
 
     run_test(&v, &expected, "u2i - valid");

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -172,8 +172,8 @@ impl ObjectId {
         hex::encode(self.id)
     }
 
-    // Generates a new timestamp representing the current seconds since epoch.
-    // Represented in Big Endian.
+    /// Generates a new timestamp representing the current seconds since epoch.
+    /// Represented in Big Endian.
     fn gen_timestamp() -> [u8; 4] {
         let timestamp: u32 = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -184,22 +184,17 @@ impl ObjectId {
         timestamp.to_be_bytes()
     }
 
-    // Generate a random 5-byte array.
+    /// Generate a random 5-byte array.
     fn gen_process_id() -> [u8; 5] {
         lazy_static! {
-            static ref BUF: [u8; 5] = {
-                let rng = thread_rng().gen_range(0, MAX_U24) as u32;
-                let mut buf: [u8; 5] = [0; 5];
-                buf[0..4].copy_from_slice(&rng.to_be_bytes());
-                buf
-            };
+            static ref BUF: [u8; 5] = thread_rng().gen();
         }
 
         *BUF
     }
 
-    // Gets an incremental 3-byte count.
-    // Represented in Big Endian.
+    /// Gets an incremental 3-byte count.
+    /// Represented in Big Endian.
     fn gen_count() -> [u8; 3] {
         let u_counter = OID_COUNTER.fetch_add(1, Ordering::SeqCst);
 


### PR DESCRIPTION
RUST-942

This also fixes the test failure inadvertently introduced in #279 