### PR TITLE
RUST-880 Fix crash when deserializing/serializing `Document` that contains decimal128

### DIFF
--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 bson = { path = ".." }
 serde = { version = "1.0", features = ["derive"] }
+hex = "0.4"
 
 [lib]
 name = "serde_tests"

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -122,7 +122,7 @@ impl Display for Bson {
             }) => write!(fmt, "/{}/{}", pattern, options),
             Bson::JavaScriptCode(ref code)
             | Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope { ref code, .. }) => {
-                fmt.write_str(&code)
+                fmt.write_str(code)
             }
             Bson::Int32(i) => write!(fmt, "{}", i),
             Bson::Int64(i) => write!(fmt, "{}", i),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -574,6 +574,15 @@ impl Bson {
                     "$numberDecimal": (v.to_string())
                 }
             }
+            #[cfg(not(feature = "decimal128"))]
+            Bson::Decimal128(ref v) => {
+                doc! {
+                    "$numberDecimalBytes": Bson::Binary(Binary {
+                        bytes: v.bytes.to_vec(),
+                        subtype: BinarySubtype::Generic,
+                    }).to_extended_document()
+                }
+            }
             Bson::Undefined => {
                 doc! {
                     "$undefined": true,
@@ -662,6 +671,16 @@ impl Bson {
                 if let Ok(d) = doc.get_str("$numberDecimal") {
                     if let Ok(d) = d.parse() {
                         return Bson::Decimal128(d);
+                    }
+                }
+            }
+
+            #[cfg(not(feature = "decimal128"))]
+            ["$numberDecimalBytes"] => {
+                if let Ok(d) = doc.get_binary_generic("$numberDecimalBytes") {
+                    let boxed_slice = d.clone().into_boxed_slice();
+                    if let Ok(ba) = Box::<[u8; 128 / 8]>::try_from(boxed_slice) {
+                        return Bson::Decimal128(Decimal128 { bytes: *ba });
                     }
                 }
             }

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -325,7 +325,7 @@ impl<'de> de::Deserializer<'de> for Deserializer {
             Bson::Binary(Binary {
                 subtype: BinarySubtype::Generic,
                 ref bytes,
-            }) => visitor.visit_bytes(&bytes),
+            }) => visitor.visit_bytes(bytes),
             binary @ Bson::Binary(..) => visitor.visit_map(MapDeserializer {
                 iter: binary.to_extended_document().into_iter(),
                 value: None,

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -200,7 +200,7 @@ impl TryFrom<serde_json::Value> for Bson {
                 .or_else(|| x.as_f64().map(Bson::from))
                 .ok_or_else(|| {
                     Error::invalid_value(
-                        Unexpected::Other(&format!("{}", x).as_str()),
+                        Unexpected::Other(format!("{}", x).as_str()),
                         &"a number that could fit in i32, i64, or f64",
                     )
                 }),

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -110,8 +110,8 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
 
     match *val {
         Bson::Double(v) => write_f64(writer, v),
-        Bson::String(ref v) => write_string(writer, &v),
-        Bson::Array(ref v) => serialize_array(writer, &v),
+        Bson::String(ref v) => write_string(writer, v),
+        Bson::Array(ref v) => serialize_array(writer, v),
         Bson::Document(ref v) => v.to_writer(writer),
         Bson::Boolean(v) => writer
             .write_all(&[if v { 0x01 } else { 0x00 }])
@@ -123,7 +123,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
             write_cstring(writer, pattern)?;
             write_cstring(writer, options)
         }
-        Bson::JavaScriptCode(ref code) => write_string(writer, &code),
+        Bson::JavaScriptCode(ref code) => write_string(writer, code),
         Bson::ObjectId(ref id) => writer.write_all(&id.bytes()).map_err(From::from),
         Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
             ref code,
@@ -160,7 +160,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
             (v.timestamp() * 1000) + (v.nanosecond() / 1_000_000) as i64,
         ),
         Bson::Null => Ok(()),
-        Bson::Symbol(ref v) => write_string(writer, &v),
+        Bson::Symbol(ref v) => write_string(writer, v),
         #[cfg(not(feature = "decimal128"))]
         Bson::Decimal128(ref v) => {
             writer.write_all(&v.bytes)?;

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -697,7 +697,7 @@ fn test_datetime_helpers() {
                 }
         }
     }"#;
-    let json: Value = serde_json::from_str(&date).unwrap();
+    let json: Value = serde_json::from_str(date).unwrap();
     let b: B = serde_json::from_value(json).unwrap();
     let expected: chrono::DateTime<chrono::Utc> =
         chrono::DateTime::from_str("2020-06-09 10:58:07.095 UTC").unwrap();


### PR DESCRIPTION
RUST-880

This PR fixes a crash that occurs when deserializing from or serializing to a `Document` that contains a decimal128 when the `decimal128` feature flag is not enabled.

This PR also fixes the clippy failures that started since the latest Rust release.