### PR TITLE
RUST-889 Deserialize `ObjectId` directly from bytes in raw deserializer

### DIFF
--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -271,12 +271,22 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
     }
 
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self.current_type {
+            ElementType::ObjectId => visitor.visit_borrowed_bytes(self.bytes.read_slice(12)?),
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
     fn is_human_readable(&self) -> bool {
         false
     }
 
     forward_to_deserialize_any! {
-        bool char str bytes byte_buf unit unit_struct string
+        bool char str byte_buf unit unit_struct string
         identifier newtype_struct seq tuple tuple_struct struct
         map ignored_any i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
     }


### PR DESCRIPTION
RUST-889

This PR updates the deserialization logic of `ObjectId` to skip the extended JSON format when deserializing from raw BSON. This is achieved by using the `is_human_readable` method on the deserializer. The changes were largely based on the POC written by @univerz [here](https://github.com/mongodb/bson-rust/issues/264#issuecomment-876266709) (thank you!).

After running the benchmarks provided in that thread, I'm seeing a similar reduction to ~70ns in the `struct<oid> from bytes<struct<oid>>/bson_raw` case.