### PR TITLE
RUST-968 Enable `u2i` feature by default

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -82,7 +82,7 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/run-tests.sh
 
-  "run u2i tests":
+  "run tests no default features":
     - command: shell.exec
       type: test
       params:
@@ -90,7 +90,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          .evergreen/run-tests-u2i.sh
+          .evergreen/run-tests-no-default-features.sh
 
   "compile only":
     - command: shell.exec
@@ -146,9 +146,9 @@ tasks:
     commands:
       - func: "run tests"
 
-  - name: "test-u2i"
+  - name: "test-no-default-features"
     commands:
-      - func: "run u2i tests"
+      - func: "run tests no default features"
 
   - name: "compile-only"
     commands:
@@ -182,7 +182,7 @@ buildvariants:
     - ubuntu1804-test
   tasks:
     - name: "test"
-    - name: "test-u2i"
+    - name: "test-no-default-features"
 
 - matrix_name: "compile only"
   matrix_spec:

--- a/.evergreen/run-tests-no-default-features.sh
+++ b/.evergreen/run-tests-no-default-features.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -o errexit
+
+. ~/.cargo/env
+RUST_BACKTRACE=1 cargo test --no-default-features
+
+cd serde-tests
+RUST_BACKTRACE=1 cargo test --no-default-features

--- a/.evergreen/run-tests-u2i.sh
+++ b/.evergreen/run-tests-u2i.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -o errexit
-
-. ~/.cargo/env
-RUST_BACKTRACE=1 cargo test --features u2i
-
-cd serde-tests
-RUST_BACKTRACE=1 cargo test --features u2i

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,12 @@ exclude = [
 ]
 
 [features]
-# no features by default
-default = []
+default = ["u2i"]
 # if enabled, include API for interfacing with chrono 0.4
 chrono-0_4 = []
 # if enabled, include API for interfacing with uuid 0.8
 uuid-0_8 = []
-# attempt to encode unsigned types in signed types
+# attempt to encode unsigned types in signed types in serde serializers
 u2i = []
 
 [lib]

--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -5,10 +5,11 @@ authors = ["Kevin Yeh <kevinyeah@utexas.edu>"]
 edition = "2018"
 
 [features]
+default = ["u2i"]
 u2i = ["bson/u2i"]
 
 [dependencies]
-bson = { path = ".." }
+bson = { path = "..", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 pretty_assertions = "0.6.1"
 hex = "0.4.2"


### PR DESCRIPTION
RUST-968

This PR enables the `u2i` feature flag by default to match the behavior of the C#, Go, and Swift BSON implementations. 

The flag can still be disabled via `default-features = false` in case users are relying on the former default behavior, though I'm wondering if it's worth keeping this option around. I can't really think of a reason a user would explicitly want to disable this.