### PR TITLE
RUST-736 Update documentation for 2.0 release

### DIFF
--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -o errexit
+
+. ~/.cargo/env
+cargo +nightly rustdoc -p bson --all-features -- --cfg docsrs -D warnings

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -112,6 +112,16 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/check-clippy.sh
 
+  "check rustdoc":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          .evergreen/check-rustdoc.sh
+
   "init test-results":
     - command: shell.exec
       params:
@@ -147,6 +157,10 @@ tasks:
   - name: "check-clippy"
     commands:
       - func: "check clippy"
+
+  - name: "check-rustdoc"
+    commands:
+      - func: "check rustdoc"
 
 axes:
   - id: "extra-rust-versions"
@@ -185,3 +199,4 @@ buildvariants:
   tasks:
     - name: "check-clippy"
     - name: "check-rustfmt"
+    - name: "check-rustdoc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ assert_matches = "1.2"
 serde_bytes = "0.11"
 pretty_assertions = "0.6.1"
 chrono = { version = "0.4", features = ["serde"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ assert_matches = "1.2"
 serde_bytes = "0.11"
 pretty_assertions = "0.6.1"
 chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "0.8.1", features = ["serde", "v4"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 
 | Feature      | Description                                                                                    | Extra dependencies | Default |
 |:-------------|:-----------------------------------------------------------------------------------------------|:-------------------|:--------|
-| `u2i`        | Attempt to serialize unsigned integer types found in `Serialize` structs to signed BSON types. | n/a                | yes     |
 | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API.         | n/a                | no      |
 | `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API.             | `uuid` 0.8         | no      |
 

--- a/README.md
+++ b/README.md
@@ -250,12 +250,12 @@ let query = doc! {
 The BSON format does not contain a dedicated UUID type, though it does have a "binary" type which
 has UUID subtypes. Accordingly, this crate provides a
 [`Binary`](https://docs.rs/bson/latest/bson/struct.Binary.html) struct which models this binary type
-and serializes to and deserializes from it. The popular [`uuid`](https://docs.rs/uuid) crate does provide a UUID type
-(`Uuid`), though its `Serialize` and `Deserialize` implementations operate on strings, so when using
-it with BSON, the BSON binary type will not be used. To facilitate the conversion between `Uuid`
-values and BSON binary values, the `uuid-0_8` feature flag can be enabled. This flag exposes a
-number of convenient conversions from `Uuid`, including the
-[`uuid_as_bson_binary`](https://docs.rs/bson/2.0.0-beta.3/bson/serde_helpers/uuid_as_binary/index.html)
+and serializes to and deserializes from it. The popular [`uuid`](https://docs.rs/uuid) crate does
+provide a UUID type (`Uuid`), though its `Serialize` and `Deserialize` implementations operate on
+strings, so when using it with BSON, the BSON binary type will not be used. To facilitate the
+conversion between `Uuid` values and BSON binary values, the `uuid-0_8` feature flag can be
+enabled. This flag exposes a number of convenient conversions from `Uuid`, including the
+[`uuid_as_binary`](https://docs.rs/bson/2.0.0-beta.3/bson/serde_helpers/uuid_as_binary/index.html)
 serde helper, which can be used to (de)serialize `Uuid`s to/from BSON binaries with the UUID
 subtype, and the `From<Uuid>` implementation for `Bson`, which allows `Uuid` values to be used in
 the `doc!` and `bson!` macros.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -7,3 +7,4 @@ use_try_shorthand = true
 wrap_comments = true
 imports_layout = "HorizontalVertical"
 imports_granularity = "Crate"
+ignore = ["src/lib.rs"]

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -321,9 +321,18 @@ impl From<oid::ObjectId> for Bson {
 }
 
 #[cfg(feature = "chrono-0_4")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
 impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for Bson {
     fn from(a: chrono::DateTime<T>) -> Bson {
         Bson::DateTime(crate::DateTime::from(a))
+    }
+}
+
+#[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
+impl From<uuid::Uuid> for Bson {
+    fn from(uuid: uuid::Uuid) -> Self {
+        Bson::Binary(uuid.into())
     }
 }
 
@@ -1041,6 +1050,17 @@ impl Binary {
             })
         } else {
             None
+        }
+    }
+}
+
+#[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
+impl From<uuid::Uuid> for Binary {
+    fn from(uuid: uuid::Uuid) -> Self {
+        Binary {
+            subtype: BinarySubtype::Uuid,
+            bytes: uuid.as_bytes().to_vec(),
         }
     }
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -81,6 +81,7 @@ impl crate::DateTime {
     /// Convert the given `chrono::DateTime` into a `bson::DateTime`, truncating it to millisecond
     /// precision.
     #[cfg(feature = "chrono-0_4")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
     pub fn from_chrono<T: chrono::TimeZone>(dt: chrono::DateTime<T>) -> Self {
         Self::from_millis(dt.timestamp_millis())
     }
@@ -119,6 +120,7 @@ impl crate::DateTime {
     /// assert_eq!(chrono_big, chrono::MAX_DATETIME)
     /// ```
     #[cfg(feature = "chrono-0_4")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
     pub fn to_chrono(self) -> chrono::DateTime<Utc> {
         self.to_chrono_private()
     }
@@ -204,6 +206,7 @@ impl From<crate::DateTime> for SystemTime {
 }
 
 #[cfg(feature = "chrono-0_4")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
 impl From<crate::DateTime> for chrono::DateTime<Utc> {
     fn from(bson_dt: DateTime) -> Self {
         bson_dt.to_chrono()
@@ -211,6 +214,7 @@ impl From<crate::DateTime> for chrono::DateTime<Utc> {
 }
 
 #[cfg(feature = "chrono-0_4")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
 impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for crate::DateTime {
     fn from(x: chrono::DateTime<T>) -> Self {
         Self::from_chrono(x)

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -30,7 +30,7 @@ use chrono::{LocalResult, TimeZone, Utc};
 /// will serialize to and deserialize from that format's equivalent of the
 /// [extended JSON representation](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) of a datetime.
 /// To serialize a [`chrono::DateTime`] as a BSON datetime, you can use
-/// [`serde_helpers::chrono_datetime_as_bson_datetime`].
+/// [`crate::serde_helpers::chrono_datetime_as_bson_datetime`].
 ///
 /// ```rust
 /// # #[cfg(feature = "chrono-0_4")]
@@ -125,7 +125,7 @@ impl crate::DateTime {
         self.to_chrono_private()
     }
 
-    /// Convert the given [`std::SystemTime`] to a [`DateTime`].
+    /// Convert the given [`std::time::SystemTime`] to a [`DateTime`].
     ///
     /// If the provided time is too far in the future or too far in the past to be represented
     /// by a BSON datetime, either [`DateTime::MAX`] or [`DateTime::MIN`] will be
@@ -151,7 +151,7 @@ impl crate::DateTime {
         }
     }
 
-    /// Convert this [`DateTime`] to a [`std::SystemTime`].
+    /// Convert this [`DateTime`] to a [`std::time::SystemTime`].
     pub fn to_system_time(self) -> SystemTime {
         if self.0 >= 0 {
             SystemTime::UNIX_EPOCH + Duration::from_millis(self.0 as u64)

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     EndOfStream,
 
     /// A general error encountered during deserialization.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html
+    /// See: <https://docs.serde.rs/serde/de/trait.Error.html>
     #[non_exhaustive]
     DeserializationError {
         /// A message describing the error.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -423,7 +423,7 @@ where
 /// sequences with the Unicode replacement character.
 ///
 /// This is mainly useful when reading raw BSON returned from a MongoDB server, which
-/// in rare cases can contain invalidly truncated strings (https://jira.mongodb.org/browse/SERVER-24007).
+/// in rare cases can contain invalidly truncated strings (<https://jira.mongodb.org/browse/SERVER-24007>).
 /// For most use cases, [`crate::from_reader`] can be used instead.
 pub fn from_reader_utf8_lossy<R, T>(reader: R) -> Result<T>
 where
@@ -447,7 +447,7 @@ where
 /// sequences with the Unicode replacement character.
 ///
 /// This is mainly useful when reading raw BSON returned from a MongoDB server, which
-/// in rare cases can contain invalidly truncated strings (https://jira.mongodb.org/browse/SERVER-24007).
+/// in rare cases can contain invalidly truncated strings (<https://jira.mongodb.org/browse/SERVER-24007>).
 /// For most use cases, [`crate::from_slice`] can be used instead.
 pub fn from_slice_utf8_lossy<'de, T>(bytes: &'de [u8]) -> Result<T>
 where

--- a/src/document.rs
+++ b/src/document.rs
@@ -607,7 +607,7 @@ impl Document {
     /// stream.
     ///
     /// This is mainly useful when reading raw BSON returned from a MongoDB server, which
-    /// in rare cases can contain invalidly truncated strings (https://jira.mongodb.org/browse/SERVER-24007).
+    /// in rare cases can contain invalidly truncated strings (<https://jira.mongodb.org/browse/SERVER-24007>).
     /// For most use cases, `Document::from_reader` can be used instead.
     pub fn from_reader_utf8_lossy<R: Read>(mut reader: R) -> crate::de::Result<Document> {
         Self::decode(&mut reader, true)

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -35,7 +35,7 @@ pub enum Error {
     InvalidObjectId(oid::Error),
 
     /// A general error encountered during deserialization.
-    /// See: https://docs.serde.rs/serde/de/trait.Error.html
+    /// See: <https://docs.serde.rs/serde/de/trait.Error.html>
     DeserializationError { message: String },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,15 +59,10 @@
 //!
 //! #### Feature Flags
 //!
-//! | Feature      | Description
-//! | Extra dependencies | Default | |:-------------|:
-//! -----------------------------------------------------------------------------------------------|:
-//! -------------------|:--------| | `u2i`        | Attempt to serialize unsigned integer types
-//! found in `Serialize` structs to signed BSON types. | n/a                | yes     |
-//! | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the
-//! public API.         | n/a                | no      | | `uuid-0_8`   | Enable support for v0.8 of
-//! the [`uuid`](docs.rs/uuid/0.8) crate in the public API.             | `uuid` 0.8         | no
-//! |
+//! | Feature      | Description                                                                                    | Extra dependencies | Default |
+//! |:-------------|:-----------------------------------------------------------------------------------------------|:-------------------|:--------|
+//! | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API.         | n/a                | no      |
+//! | `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API.             | `uuid` 0.8         | no      |
 //!
 //! ## BSON values
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,34 @@
 //!
 //! For more information about BSON itself, see [bsonspec.org](http://bsonspec.org).
 //!
+//! ## Installation
+//! ### Requirements
+//! - Rust 1.48+
+//!
+//! ### Importing
+//! This crate is available on [crates.io](https://crates.io/crates/bson). To use it in your application,
+//! simply add it to your project's `Cargo.toml`.
+//!
+//! ```toml
+//! [dependencies]
+//! bson = "2.0.0-beta.3"
+//! ```
+//!
+//! Note that if you are using `bson` through the `mongodb` crate, you do not need to specify it in
+//! your `Cargo.toml`, since the `mongodb` crate already re-exports it.
+//!
+//! #### Feature Flags
+//!
+//! | Feature      | Description
+//! | Extra dependencies | Default | |:-------------|:
+//! -----------------------------------------------------------------------------------------------|:
+//! -------------------|:--------| | `u2i`        | Attempt to serialize unsigned integer types
+//! found in `Serialize` structs to signed BSON types. | n/a                | yes     |
+//! | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the
+//! public API.         | n/a                | no      | | `uuid-0_8`   | Enable support for v0.8 of
+//! the [`uuid`](docs.rs/uuid/0.8) crate in the public API.             | `uuid` 0.8         | no
+//! |
+//!
 //! ## BSON values
 //!
 //! Many different types can be represented as a BSON value, including 32-bit and 64-bit signed
@@ -182,6 +210,88 @@
 //! translates the data to/from its serialized form. This can lead to more clear and concise code
 //! that is also less error prone.
 //!
+//! ## Working with datetimes
+//!
+//! The BSON format includes a datetime type, which is modeled in this crate by the
+//! [`bson::DateTime`] struct, and the
+//! `Serialize` and `Deserialize` implementations for this struct produce and parse BSON datetimes
+//! when serializing to or deserializing from BSON. The popular crate [`chrono`](docs.rs/chrono)
+//! also provides a `DateTime` type, but its `Serialize` and `Deserialize` implementations operate
+//! on strings instead, so when using it with BSON, the BSON datetime type is not used. To work
+//! around this, the `chrono-0_4` feature flag can be enabled. This flag exposes a number of
+//! convenient conversions between `bson::DateTime` and `chrono::DateTime`, including the
+//! [`serde_helpers::chrono_datetime_as_bson_datetime`]
+//! serde helper, which can be used to (de)serialize `chrono::DateTime`s to/from BSON datetimes, and
+//! the `From<chrono::DateTime>` implementation for [`Bson`], which allows `chrono::DateTime` values
+//! to be used in the `doc!` and `bson!` macros.
+//!
+//! e.g.
+//! ``` rust
+//! # #[cfg(feature = "chrono-0_4")]
+//! # {
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Foo {
+//!     // serializes as a BSON datetime.
+//!     date_time: bson::DateTime,
+//!
+//!     // serializes as an RFC 3339 / ISO-8601 string.
+//!     chrono_datetime: chrono::DateTime<chrono::Utc>,
+//!
+//!     // serializes as a BSON datetime.
+//!     // this requires the "chrono-0_4" feature flag
+//!     #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+//!     chrono_as_bson: chrono::DateTime<chrono::Utc>,
+//! }
+//!
+//! // this automatic conversion also requires the "chrono-0_4" feature flag
+//! let query = doc! {
+//!     "created_at": chrono::Utc::now(),
+//! };
+//! # }
+//! ```
+//!
+//! ## Working with UUIDs
+//!
+//! The BSON format does not contain a dedicated UUID type, though it does have a "binary" type
+//! which has UUID subtypes. Accordingly, this crate provides a
+//! [`Binary`] struct which models this binary type and
+//! serializes to and deserializes from it. The popular `uuid` crate does provide a UUID type
+//! (`Uuid`), though its `Serialize` and `Deserialize` implementations operate on strings, so when
+//! using it with BSON, the BSON binary type will not be used. To facilitate the conversion between
+//! `Uuid` values and BSON binary values, the `uuid-0_8` feature flag can be enabled. This flag
+//! exposes a number of convenient conversions from `Uuid`, including the
+//! [`serde_helpers::uuid_as_bson_binary`]
+//! serde helper, which can be used to (de)serialize `Uuid`s to/from BSON binaries with the UUID
+//! subtype, and the `From<Uuid>` implementation for `Bson`, which allows `Uuid` values to be used
+//! in the `doc!` and `bson!` macros.
+//!
+//! e.g.
+//!
+//! ``` rust
+//! # #[cfg(feature = "chrono-0_4")]
+//! # {
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Foo {
+//!     // serializes as a String.
+//!     uuid: Uuid,
+//!
+//!     // serializes as a BSON binary with subtype 4.
+//!     // this requires the "uuid-0_8" feature flag
+//!     #[serde(with = "bson::serde_helpers::uuid_as_binary")]
+//!     uuid_as_bson: uuid::Uuid,
+//! }
+//!
+//! // this automatic conversion also requires the "uuid-0_8" feature flag
+//! let query = doc! {
+//!     "uuid": uuid::Uuid::new_v4(),
+//! };
+//! # }
+//! ```
+//!
 //! ## Minimum supported Rust version (MSRV)
 //!
 //! The MSRV for this crate is currently 1.48.0. This will be rarely be increased, and if it ever is,
@@ -189,7 +299,9 @@
 
 #![allow(clippy::cognitive_complexity)]
 #![doc(html_root_url = "https://docs.rs/bson/2.0.0-beta.3")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[doc(inline)]
 pub use self::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@
 //! ## Working with datetimes
 //!
 //! The BSON format includes a datetime type, which is modeled in this crate by the
-//! [`bson::DateTime`] struct, and the
+//! [`DateTime`] struct, and the
 //! `Serialize` and `Deserialize` implementations for this struct produce and parse BSON datetimes
 //! when serializing to or deserializing from BSON. The popular crate [`chrono`](docs.rs/chrono)
 //! also provides a `DateTime` type, but its `Serialize` and `Deserialize` implementations operate
@@ -262,7 +262,7 @@
 //! using it with BSON, the BSON binary type will not be used. To facilitate the conversion between
 //! `Uuid` values and BSON binary values, the `uuid-0_8` feature flag can be enabled. This flag
 //! exposes a number of convenient conversions from `Uuid`, including the
-//! [`serde_helpers::uuid_as_bson_binary`]
+//! [`serde_helpers::uuid_as_binary`]
 //! serde helper, which can be used to (de)serialize `Uuid`s to/from BSON binaries with the UUID
 //! subtype, and the `From<Uuid>` implementation for `Bson`, which allows `Uuid` values to be used
 //! in the `doc!` and `bson!` macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,8 @@
 //! [`bson!`](macro.bson.html) macro:
 //!
 //! ```rust
-//! # use bson::{bson, Bson};
+//! use bson::{bson, Bson};
+//!
 //! let string = Bson::String("hello world".to_string());
 //! let int = Bson::Int32(5);
 //! let array = Bson::Array(vec![Bson::Int32(5), Bson::Boolean(false)]);
@@ -105,7 +106,8 @@
 //!
 //! e.g.:
 //! ```rust
-//! # use bson::{bson, Bson};
+//! use bson::{bson, Bson};
+//!
 //! let value = Bson::Int32(5);
 //! let int = value.as_i32(); // Some(5)
 //! let bool = value.as_bool(); // None
@@ -126,8 +128,9 @@
 //! [`Document`](document/struct.Document.html)s can be created directly either from a byte
 //! reader containing BSON data or via the `doc!` macro:
 //! ```rust
-//! # use bson::{doc, Document};
-//! # use std::io::Read;
+//! use bson::{doc, Document};
+//! use std::io::Read;
+//!
 //! let mut bytes = hex::decode("0C0000001069000100000000").unwrap();
 //! let doc = Document::from_reader(&mut bytes.as_slice()).unwrap(); // { "i": 1 }
 //!
@@ -146,7 +149,8 @@
 //! access:
 //!
 //! ```rust
-//! # use bson::doc;
+//! use bson::doc;
+//!
 //! let doc = doc! {
 //!    "string": "string",
 //!    "bool": true,
@@ -173,8 +177,9 @@
 //!
 //! e.g.:
 //! ```rust
-//! # use serde::{Deserialize, Serialize};
-//! # use bson::{bson, Bson};
+//! use serde::{Deserialize, Serialize};
+//! use bson::{bson, Bson};
+//!
 //! #[derive(Serialize, Deserialize)]
 //! struct Person {
 //!     name: String,
@@ -230,6 +235,7 @@
 //! # #[cfg(feature = "chrono-0_4")]
 //! # {
 //! use serde::{Serialize, Deserialize};
+//! use bson::doc;
 //!
 //! #[derive(Serialize, Deserialize)]
 //! struct Foo {
@@ -273,11 +279,12 @@
 //! # #[cfg(feature = "chrono-0_4")]
 //! # {
 //! use serde::{Serialize, Deserialize};
+//! use bson::doc;
 //!
 //! #[derive(Serialize, Deserialize)]
 //! struct Foo {
 //!     // serializes as a String.
-//!     uuid: Uuid,
+//!     uuid: uuid::Uuid,
 //!
 //!     // serializes as a BSON binary with subtype 4.
 //!     // this requires the "uuid-0_8" feature flag

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     InvalidDocumentKey(Bson),
 
     /// A general error that occurred during serialization.
-    /// See: https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom
+    /// See: <https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom>
     #[non_exhaustive]
     SerializationError {
         /// A message describing the error.

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -6,50 +6,62 @@ use serde::{ser, Serialize, Serializer};
 
 use crate::oid::ObjectId;
 
+#[doc(inline)]
 pub use bson_datetime_as_rfc3339_string::{
     deserialize as deserialize_bson_datetime_from_rfc3339_string,
     serialize as serialize_bson_datetime_as_rfc3339_string,
 };
 #[cfg(feature = "chrono-0_4")]
+#[doc(inline)]
 pub use chrono_datetime_as_bson_datetime::{
     deserialize as deserialize_chrono_datetime_from_bson_datetime,
     serialize as serialize_chrono_datetime_as_bson_datetime,
 };
+#[doc(inline)]
 pub use hex_string_as_object_id::{
     deserialize as deserialize_hex_string_from_object_id,
     serialize as serialize_hex_string_as_object_id,
 };
+#[doc(inline)]
 pub use rfc3339_string_as_bson_datetime::{
     deserialize as deserialize_rfc3339_string_from_bson_datetime,
     serialize as serialize_rfc3339_string_as_bson_datetime,
 };
+#[doc(inline)]
 pub use timestamp_as_u32::{
     deserialize as deserialize_timestamp_from_u32,
     serialize as serialize_timestamp_as_u32,
 };
+#[doc(inline)]
 pub use u32_as_f64::{deserialize as deserialize_u32_from_f64, serialize as serialize_u32_as_f64};
+#[doc(inline)]
 pub use u32_as_timestamp::{
     deserialize as deserialize_u32_from_timestamp,
     serialize as serialize_u32_as_timestamp,
 };
+#[doc(inline)]
 pub use u64_as_f64::{deserialize as deserialize_u64_from_f64, serialize as serialize_u64_as_f64};
 
 #[cfg(feature = "uuid-0_8")]
+#[doc(inline)]
 pub use uuid_as_binary::{
     deserialize as deserialize_uuid_from_binary,
     serialize as serialize_uuid_as_binary,
 };
 #[cfg(feature = "uuid-0_8")]
+#[doc(inline)]
 pub use uuid_as_c_sharp_legacy_binary::{
     deserialize as deserialize_uuid_from_c_sharp_legacy_binary,
     serialize as serialize_uuid_as_c_sharp_legacy_binary,
 };
 #[cfg(feature = "uuid-0_8")]
+#[doc(inline)]
 pub use uuid_as_java_legacy_binary::{
     deserialize as deserialize_uuid_from_java_legacy_binary,
     serialize as serialize_uuid_as_java_legacy_binary,
 };
 #[cfg(feature = "uuid-0_8")]
+#[doc(inline)]
 pub use uuid_as_python_legacy_binary::{
     deserialize as deserialize_uuid_from_python_legacy_binary,
     serialize as serialize_uuid_as_python_legacy_binary,
@@ -189,6 +201,7 @@ pub mod u64_as_f64 {
 /// # }
 /// ```
 #[cfg(feature = "chrono-0_4")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
 pub mod chrono_datetime_as_bson_datetime {
     use crate::DateTime;
     use chrono::Utc;
@@ -196,6 +209,7 @@ pub mod chrono_datetime_as_bson_datetime {
     use std::result::Result;
 
     /// Deserializes a [`chrono::DateTime`] from a [`crate::DateTime`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
     pub fn deserialize<'de, D>(deserializer: D) -> Result<chrono::DateTime<Utc>, D::Error>
     where
         D: Deserializer<'de>,
@@ -205,6 +219,7 @@ pub mod chrono_datetime_as_bson_datetime {
     }
 
     /// Serializes a [`chrono::DateTime`] as a [`crate::DateTime`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
     pub fn serialize<S: Serializer>(
         val: &chrono::DateTime<Utc>,
         serializer: S,
@@ -338,6 +353,7 @@ pub mod hex_string_as_object_id {
 /// }
 /// ```
 #[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -345,15 +361,14 @@ pub mod uuid_as_binary {
     use uuid::Uuid;
 
     /// Serializes a Uuid as a Binary.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn serialize<S: Serializer>(val: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
-        let binary = Binary {
-            subtype: BinarySubtype::Uuid,
-            bytes: val.as_bytes().to_vec(),
-        };
+        let binary: Binary = (*val).into();
         binary.serialize(serializer)
     }
 
     /// Deserializes a Uuid from a Binary.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Uuid, D::Error>
     where
         D: Deserializer<'de>,
@@ -395,6 +410,7 @@ pub mod uuid_as_binary {
 /// }
 /// ```
 #[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_java_legacy_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -402,6 +418,7 @@ pub mod uuid_as_java_legacy_binary {
     use uuid::Uuid;
 
     /// Serializes a Uuid as a Binary in a Java Legacy UUID format.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn serialize<S: Serializer>(val: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
         let mut bytes = val.as_bytes().to_vec();
         bytes[0..8].reverse();
@@ -414,6 +431,7 @@ pub mod uuid_as_java_legacy_binary {
     }
 
     /// Deserializes a Uuid from a Binary in a Java Legacy UUID format.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Uuid, D::Error>
     where
         D: Deserializer<'de>,
@@ -451,6 +469,7 @@ pub mod uuid_as_java_legacy_binary {
 /// }
 /// ```
 #[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_python_legacy_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -458,6 +477,7 @@ pub mod uuid_as_python_legacy_binary {
     use uuid::Uuid;
 
     /// Serializes a Uuid as a Binary in a Python Legacy UUID format.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn serialize<S: Serializer>(val: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
         let binary = Binary {
             subtype: BinarySubtype::UuidOld,
@@ -467,6 +487,7 @@ pub mod uuid_as_python_legacy_binary {
     }
 
     /// Deserializes a Uuid from a Binary in a Python Legacy UUID format.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Uuid, D::Error>
     where
         D: Deserializer<'de>,
@@ -502,6 +523,7 @@ pub mod uuid_as_python_legacy_binary {
 /// }
 /// ```
 #[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_c_sharp_legacy_binary {
     use crate::{spec::BinarySubtype, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -509,6 +531,7 @@ pub mod uuid_as_c_sharp_legacy_binary {
     use uuid::Uuid;
 
     /// Serializes a Uuid as a Binary in a C# Legacy UUID format.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn serialize<S: Serializer>(val: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
         let mut bytes = val.as_bytes().to_vec();
         bytes[0..4].reverse();
@@ -522,6 +545,7 @@ pub mod uuid_as_c_sharp_legacy_binary {
     }
 
     /// Deserializes a Uuid from a Binary in a C# Legacy UUID format.
+    #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Uuid, D::Error>
     where
         D: Deserializer<'de>,


### PR DESCRIPTION
RUST-736

This PR updates the documentation to account for the 2.0 API, namely the `chrono` and `uuid` changes. As part of that, it also completes RUST-997.

Some other housekeeping changes were made too:
- the "re-exports" section was changed to look like the functions were defined at the top level via `#[doc(inline)]`
- functionality that was gated behind feature flags are now documented
- documentation linting was added to Evergreen

You can see all the new changes in action by running:
```
cargo +nightly rustdoc -p bson --all-features --open -- --cfg docsrs
```
and comparing it to our [latest documentation](https://docs.rs/bson/2.0.0-beta.3/bson/) on docs.rs.