### PR TITLE
RUST-968 Remove `u2i` feature flag

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -82,16 +82,6 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/run-tests.sh
 
-  "run tests no default features":
-    - command: shell.exec
-      type: test
-      params:
-        shell: bash
-        working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          .evergreen/run-tests-no-default-features.sh
-
   "compile only":
     - command: shell.exec
       type: test
@@ -146,10 +136,6 @@ tasks:
     commands:
       - func: "run tests"
 
-  - name: "test-no-default-features"
-    commands:
-      - func: "run tests no default features"
-
   - name: "compile-only"
     commands:
       - func: "compile only"
@@ -182,7 +168,6 @@ buildvariants:
     - ubuntu1804-test
   tasks:
     - name: "test"
-    - name: "test-no-default-features"
 
 - matrix_name: "compile only"
   matrix_spec:

--- a/.evergreen/run-tests-no-default-features.sh
+++ b/.evergreen/run-tests-no-default-features.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -o errexit
-
-. ~/.cargo/env
-RUST_BACKTRACE=1 cargo test --no-default-features
-
-cd serde-tests
-RUST_BACKTRACE=1 cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,11 @@ exclude = [
 ]
 
 [features]
-default = ["u2i"]
+default = []
 # if enabled, include API for interfacing with chrono 0.4
 chrono-0_4 = []
 # if enabled, include API for interfacing with uuid 0.8
 uuid-0_8 = []
-# attempt to encode unsigned types in signed types in serde serializers
-u2i = []
 
 [lib]
 name = "bson"

--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Kevin Yeh <kevinyeah@utexas.edu>"]
 edition = "2018"
 
 [features]
-default = ["u2i"]
-u2i = ["bson/u2i"]
+default = []
 
 [dependencies]
 bson = { path = "..", default-features = false }

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -868,7 +868,6 @@ fn borrowed() {
     assert_eq!(deserialized, v);
 }
 
-#[cfg(feature = "u2i")]
 #[test]
 fn u2i() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -908,42 +907,6 @@ fn u2i() {
     let v = TooBig {
         u_64: i64::MAX as u64 + 1,
     };
-    bson::to_document(&v).unwrap_err();
-    bson::to_vec(&v).unwrap_err();
-}
-
-#[cfg(not(feature = "u2i"))]
-#[test]
-fn unsigned() {
-    #[derive(Serialize, Debug)]
-    struct U8 {
-        v: u8,
-    }
-    let v = U8 { v: 1 };
-    bson::to_document(&v).unwrap_err();
-    bson::to_vec(&v).unwrap_err();
-
-    #[derive(Serialize, Debug)]
-    struct U16 {
-        v: u16,
-    }
-    let v = U16 { v: 1 };
-    bson::to_document(&v).unwrap_err();
-    bson::to_vec(&v).unwrap_err();
-
-    #[derive(Serialize, Debug)]
-    struct U32 {
-        v: u32,
-    }
-    let v = U32 { v: 1 };
-    bson::to_document(&v).unwrap_err();
-    bson::to_vec(&v).unwrap_err();
-
-    #[derive(Serialize, Debug)]
-    struct U64 {
-        v: u64,
-    }
-    let v = U64 { v: 1 };
     bson::to_document(&v).unwrap_err();
     bson::to_vec(&v).unwrap_err();
 }

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -22,15 +22,6 @@ pub enum Error {
         message: String,
     },
 
-    #[cfg(not(feature = "u2i"))]
-    /// Returned when serialization of an unsigned integer was attempted. BSON only supports
-    /// 32-bit and 64-bit signed integers.
-    ///
-    /// To serialize unsigned integers to BSON, use an appropriate helper from
-    /// [`crate::serde_helpers`] or enable the "u2i" feature flag.
-    UnsupportedUnsignedInteger(u64),
-
-    #[cfg(feature = "u2i")]
     /// An unsigned integer type could not fit into a signed integer type.
     UnsignedIntegerExceededRange(u64),
 }
@@ -47,15 +38,6 @@ impl fmt::Display for Error {
             Error::Io(ref inner) => inner.fmt(fmt),
             Error::InvalidDocumentKey(ref key) => write!(fmt, "Invalid map key type: {}", key),
             Error::SerializationError { ref message } => message.fmt(fmt),
-            #[cfg(not(feature = "u2i"))]
-            Error::UnsupportedUnsignedInteger(value) => write!(
-                fmt,
-                "BSON does not support unsigned integers, cannot serialize value: {}. To \
-                 serialize unsigned integers to BSON, use an appropriate serde helper or enable \
-                 the u2i feature.",
-                value
-            ),
-            #[cfg(feature = "u2i")]
             Error::UnsignedIntegerExceededRange(value) => write!(
                 fmt,
                 "BSON does not support unsigned integers.

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -117,51 +117,27 @@ impl<'a> serde::Serializer for &'a mut Serializer {
 
     #[inline]
     fn serialize_u8(self, v: u8) -> Result<Self::Ok> {
-        #[cfg(feature = "u2i")]
-        {
-            self.serialize_i32(v.into())
-        }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(v.into()))
+        self.serialize_i32(v.into())
     }
 
     #[inline]
     fn serialize_u16(self, v: u16) -> Result<Self::Ok> {
-        #[cfg(feature = "u2i")]
-        {
-            self.serialize_i32(v.into())
-        }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(v.into()))
+        self.serialize_i32(v.into())
     }
 
     #[inline]
     fn serialize_u32(self, v: u32) -> Result<Self::Ok> {
-        #[cfg(feature = "u2i")]
-        {
-            self.serialize_i64(v.into())
-        }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(v.into()))
+        self.serialize_i64(v.into())
     }
 
     #[inline]
     fn serialize_u64(self, v: u64) -> Result<Self::Ok> {
-        #[cfg(feature = "u2i")]
-        {
-            use std::convert::TryFrom;
+        use std::convert::TryFrom;
 
-            match i64::try_from(v) {
-                Ok(ivalue) => self.serialize_i64(ivalue),
-                Err(_) => Err(Error::UnsignedIntegerExceededRange(v)),
-            }
+        match i64::try_from(v) {
+            Ok(ivalue) => self.serialize_i64(ivalue),
+            Err(_) => Err(Error::UnsignedIntegerExceededRange(v)),
         }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(v))
     }
 
     #[inline]

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -140,13 +140,7 @@ impl ser::Serializer for Serializer {
 
     #[inline]
     fn serialize_u8(self, value: u8) -> crate::ser::Result<Bson> {
-        #[cfg(feature = "u2i")]
-        {
-            Ok(Bson::Int32(value as i32))
-        }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(value as u64))
+        Ok(Bson::Int32(value as i32))
     }
 
     #[inline]
@@ -156,13 +150,7 @@ impl ser::Serializer for Serializer {
 
     #[inline]
     fn serialize_u16(self, value: u16) -> crate::ser::Result<Bson> {
-        #[cfg(feature = "u2i")]
-        {
-            Ok(Bson::Int32(value as i32))
-        }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(value as u64))
+        Ok(Bson::Int32(value as i32))
     }
 
     #[inline]
@@ -172,13 +160,7 @@ impl ser::Serializer for Serializer {
 
     #[inline]
     fn serialize_u32(self, value: u32) -> crate::ser::Result<Bson> {
-        #[cfg(feature = "u2i")]
-        {
-            Ok(Bson::Int64(value as i64))
-        }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(value as u64))
+        Ok(Bson::Int64(value as i64))
     }
 
     #[inline]
@@ -188,18 +170,12 @@ impl ser::Serializer for Serializer {
 
     #[inline]
     fn serialize_u64(self, value: u64) -> crate::ser::Result<Bson> {
-        #[cfg(feature = "u2i")]
-        {
-            use std::convert::TryFrom;
+        use std::convert::TryFrom;
 
-            match i64::try_from(value) {
-                Ok(ivalue) => Ok(Bson::Int64(ivalue)),
-                Err(_) => Err(Error::UnsignedIntegerExceededRange(value)),
-            }
+        match i64::try_from(value) {
+            Ok(ivalue) => Ok(Bson::Int64(ivalue)),
+            Err(_) => Err(Error::UnsignedIntegerExceededRange(value)),
         }
-
-        #[cfg(not(feature = "u2i"))]
-        Err(Error::UnsupportedUnsignedInteger(value))
     }
 
     #[inline]

--- a/src/tests/modules/ser.rs
+++ b/src/tests/modules/ser.rs
@@ -67,15 +67,6 @@ fn int32() {
 }
 
 #[test]
-#[cfg(not(feature = "u2i"))]
-fn uint8() {
-    let _guard = LOCK.run_concurrently();
-    let obj_min: ser::Result<Bson> = to_bson(&u8::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
-}
-
-#[test]
-#[cfg(feature = "u2i")]
 fn uint8_u2i() {
     let _guard = LOCK.run_concurrently();
     let obj: Bson = to_bson(&u8::MIN).unwrap();
@@ -88,15 +79,6 @@ fn uint8_u2i() {
 }
 
 #[test]
-#[cfg(not(feature = "u2i"))]
-fn uint16() {
-    let _guard = LOCK.run_concurrently();
-    let obj_min: ser::Result<Bson> = to_bson(&u16::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
-}
-
-#[test]
-#[cfg(feature = "u2i")]
 fn uint16_u2i() {
     let _guard = LOCK.run_concurrently();
     let obj: Bson = to_bson(&u16::MIN).unwrap();
@@ -109,15 +91,6 @@ fn uint16_u2i() {
 }
 
 #[test]
-#[cfg(not(feature = "u2i"))]
-fn uint32() {
-    let _guard = LOCK.run_concurrently();
-    let obj_min: ser::Result<Bson> = to_bson(&u32::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
-}
-
-#[test]
-#[cfg(feature = "u2i")]
 fn uint32_u2i() {
     let _guard = LOCK.run_concurrently();
     let obj_min: Bson = to_bson(&u32::MIN).unwrap();
@@ -130,15 +103,6 @@ fn uint32_u2i() {
 }
 
 #[test]
-#[cfg(not(feature = "u2i"))]
-fn uint64() {
-    let _guard = LOCK.run_concurrently();
-    let obj_min: ser::Result<Bson> = to_bson(&u64::MIN);
-    assert_matches!(obj_min, Err(ser::Error::UnsupportedUnsignedInteger(_)));
-}
-
-#[test]
-#[cfg(feature = "u2i")]
 fn uint64_u2i() {
     let _guard = LOCK.run_concurrently();
     let obj_min: Bson = to_bson(&u64::MIN).unwrap();


### PR DESCRIPTION
RUST-968

After some discussion in https://github.com/mongodb/mongo-rust-driver/pull/438, we decided that it was probably best to just remove the `u2i` feature flag altogether, given that it would be difficult and rare for a user to want to manually disable it now that it's the default.