### PR TITLE
RUST-943 Fix utf8-lossy parsing of code and symbols

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -235,7 +235,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
             read_string(reader, utf8_lossy).map(Bson::JavaScriptCode)?
         }
         Some(ElementType::JavaScriptCodeWithScope) => {
-            Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope::from_reader(reader)?)
+            Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope::from_reader(reader, utf8_lossy)?)
         }
         Some(ElementType::Int32) => read_i32(reader).map(Bson::Int32)?,
         Some(ElementType::Int64) => read_i64(reader).map(Bson::Int64)?,
@@ -350,7 +350,7 @@ impl ObjectId {
 }
 
 impl JavaScriptCodeWithScope {
-    pub(crate) fn from_reader<R: Read>(mut reader: R) -> Result<Self> {
+    pub(crate) fn from_reader<R: Read>(mut reader: R, utf8_lossy: bool) -> Result<Self> {
         let length = read_i32(&mut reader)?;
         if length < MIN_CODE_WITH_SCOPE_SIZE {
             return Err(Error::invalid_length(
@@ -372,7 +372,7 @@ impl JavaScriptCodeWithScope {
         reader.read_exact(&mut buf)?;
 
         let mut slice = buf.as_slice();
-        let code = read_string(&mut slice, false)?;
+        let code = read_string(&mut slice, utf8_lossy)?;
         let scope = Document::from_reader(&mut slice)?;
         Ok(JavaScriptCodeWithScope { code, scope })
     }

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -213,7 +213,8 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
             }
             ElementType::JavaScriptCodeWithScope => {
                 let utf8_lossy = self.bytes.utf8_lossy;
-                let code_w_scope = JavaScriptCodeWithScope::from_reader(&mut self.bytes, utf8_lossy)?;
+                let code_w_scope =
+                    JavaScriptCodeWithScope::from_reader(&mut self.bytes, utf8_lossy)?;
                 let doc = Bson::JavaScriptCodeWithScope(code_w_scope).into_extended_document();
                 visitor.visit_map(MapDeserializer::new(doc))
             }

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -212,7 +212,8 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 visitor.visit_map(MapDeserializer::new(doc))
             }
             ElementType::JavaScriptCodeWithScope => {
-                let code_w_scope = JavaScriptCodeWithScope::from_reader(&mut self.bytes)?;
+                let utf8_lossy = self.bytes.utf8_lossy;
+                let code_w_scope = JavaScriptCodeWithScope::from_reader(&mut self.bytes, utf8_lossy)?;
                 let doc = Bson::JavaScriptCodeWithScope(code_w_scope).into_extended_document();
                 visitor.visit_map(MapDeserializer::new(doc))
             }

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -206,7 +206,8 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 visitor.visit_map(MapDeserializer::new(doc))
             }
             ElementType::JavaScriptCode => {
-                let code = read_string(&mut self.bytes, false)?;
+                let utf8_lossy = self.bytes.utf8_lossy;
+                let code = read_string(&mut self.bytes, utf8_lossy)?;
                 let doc = Bson::JavaScriptCode(code).into_extended_document();
                 visitor.visit_map(MapDeserializer::new(doc))
             }
@@ -216,7 +217,8 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 visitor.visit_map(MapDeserializer::new(doc))
             }
             ElementType::Symbol => {
-                let symbol = read_string(&mut self.bytes, false)?;
+                let utf8_lossy = self.bytes.utf8_lossy;
+                let symbol = read_string(&mut self.bytes, utf8_lossy)?;
                 let doc = Bson::Symbol(symbol).into_extended_document();
                 visitor.visit_map(MapDeserializer::new(doc))
             }
@@ -912,7 +914,7 @@ impl<'a> BsonBuf<'a> {
         Ok(())
     }
 
-    /// Get the starting at the provided index and ending at the buffer's current index.
+    /// Get the string starting at the provided index and ending at the buffer's current index.
     fn str(&mut self, start: usize) -> Result<Cow<'a, str>> {
         let bytes = &self.bytes[start..self.index];
         let s = if self.utf8_lossy {

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -363,12 +363,8 @@ fn run_test(test: TestFile) {
         crate::from_reader::<_, Document>(bson.as_slice()).expect_err(description.as_str());
 
         if decode_error.description.contains("invalid UTF-8") {
-            let d = crate::from_reader_utf8_lossy::<_, Document>(bson.as_slice())
-                .unwrap_or_else(|_| panic!("{}: utf8_lossy should not fail", description));
-            if let Some(ref key) = test.test_key {
-                d.get_str(key)
-                    .unwrap_or_else(|_| panic!("{}: value should be a string", description));
-            }
+            crate::from_reader_utf8_lossy::<_, Document>(bson.as_slice())
+                .unwrap_or_else(|err| panic!("{}: utf8_lossy should not fail (failed with {:?})", description, err));
         }
     }
 

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -363,8 +363,12 @@ fn run_test(test: TestFile) {
         crate::from_reader::<_, Document>(bson.as_slice()).expect_err(description.as_str());
 
         if decode_error.description.contains("invalid UTF-8") {
-            crate::from_reader_utf8_lossy::<_, Document>(bson.as_slice())
-                .unwrap_or_else(|err| panic!("{}: utf8_lossy should not fail (failed with {:?})", description, err));
+            crate::from_reader_utf8_lossy::<_, Document>(bson.as_slice()).unwrap_or_else(|err| {
+                panic!(
+                    "{}: utf8_lossy should not fail (failed with {:?})",
+                    description, err
+                )
+            });
         }
     }
 

--- a/src/tests/spec/json/bson-corpus/code.json
+++ b/src/tests/spec/json/bson-corpus/code.json
@@ -20,48 +20,48 @@
         },
         {
             "description": "two-byte UTF-8 (\u00e9)",
-            "canonical_bson": "190000000261000D000000C3A9C3A9C3A9C3A9C3A9C3A90000",
-            "canonical_extjson": "{\"a\" : \"\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\"}"
+            "canonical_bson": "190000000D61000D000000C3A9C3A9C3A9C3A9C3A9C3A90000",
+            "canonical_extjson": "{\"a\" : {\"$code\" : \"\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\"}}"
         },
         {
             "description": "three-byte UTF-8 (\u2606)",
-            "canonical_bson": "190000000261000D000000E29886E29886E29886E298860000",
-            "canonical_extjson": "{\"a\" : \"\\u2606\\u2606\\u2606\\u2606\"}"
+            "canonical_bson": "190000000D61000D000000E29886E29886E29886E298860000",
+            "canonical_extjson": "{\"a\" : {\"$code\" : \"\\u2606\\u2606\\u2606\\u2606\"}}"
         },
         {
             "description": "Embedded nulls",
-            "canonical_bson": "190000000261000D0000006162006261620062616261620000",
-            "canonical_extjson": "{\"a\" : \"ab\\u0000bab\\u0000babab\"}"
+            "canonical_bson": "190000000D61000D0000006162006261620062616261620000",
+            "canonical_extjson": "{\"a\" : {\"$code\" : \"ab\\u0000bab\\u0000babab\"}}"
         }
     ],
     "decodeErrors": [
         {
             "description": "bad code string length: 0 (but no 0x00 either)",
-            "bson": "0C0000000261000000000000"
+            "bson": "0C0000000D61000000000000"
         },
         {
             "description": "bad code string length: -1",
-            "bson": "0C000000026100FFFFFFFF00"
+            "bson": "0C0000000D6100FFFFFFFF00"
         },
         {
             "description": "bad code string length: eats terminator",
-            "bson": "10000000026100050000006200620000"
+            "bson": "100000000D6100050000006200620000"
         },
         {
             "description": "bad code string length: longer than rest of document",
-            "bson": "120000000200FFFFFF00666F6F6261720000"
+            "bson": "120000000D00FFFFFF00666F6F6261720000"
         },
         {
             "description": "code string is not null-terminated",
-            "bson": "1000000002610004000000616263FF00"
+            "bson": "100000000D610004000000616263FF00"
         },
         {
             "description": "empty code string, but extra null",
-            "bson": "0E00000002610001000000000000"
+            "bson": "0E0000000D610001000000000000"
         },
         {
             "description": "invalid UTF-8",
-            "bson": "0E00000002610002000000E90000"
+            "bson": "0E0000000D610002000000E90000"
         }
     ]
 }

--- a/src/tests/spec/json/bson-corpus/symbol.json
+++ b/src/tests/spec/json/bson-corpus/symbol.json
@@ -50,31 +50,31 @@
     "decodeErrors": [
         {
             "description": "bad symbol length: 0 (but no 0x00 either)",
-            "bson": "0C0000000261000000000000"
+            "bson": "0C0000000E61000000000000"
         },
         {
             "description": "bad symbol length: -1",
-            "bson": "0C000000026100FFFFFFFF00"
+            "bson": "0C0000000E6100FFFFFFFF00"
         },
         {
             "description": "bad symbol length: eats terminator",
-            "bson": "10000000026100050000006200620000"
+            "bson": "100000000E6100050000006200620000"
         },
         {
             "description": "bad symbol length: longer than rest of document",
-            "bson": "120000000200FFFFFF00666F6F6261720000"
+            "bson": "120000000E00FFFFFF00666F6F6261720000"
         },
         {
             "description": "symbol is not null-terminated",
-            "bson": "1000000002610004000000616263FF00"
+            "bson": "100000000E610004000000616263FF00"
         },
         {
             "description": "empty symbol, but extra null",
-            "bson": "0E00000002610001000000000000"
+            "bson": "0E0000000E610001000000000000"
         },
         {
             "description": "invalid UTF-8",
-            "bson": "0E00000002610002000000E90000"
+            "bson": "0E0000000E610002000000E90000"
         }
     ]
 }


### PR DESCRIPTION
RUST-943

Previously, the spec tests for these were erroneously giving the serialized form of a string value, not a code or symbol value.  Fixing that uncovered a bug where the intended utf8-lossiness was not being correctly propagated when parsing those.