### PR TITLE
RUST-908 Validate that C strings do not contain null bytes

### DIFF
--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -41,7 +41,7 @@ impl fmt::Display for Error {
             Error::Io(ref inner) => inner.fmt(fmt),
             Error::InvalidDocumentKey(ref key) => write!(fmt, "Invalid map key type: {}", key),
             Error::InvalidCString(ref string) => {
-                write!(fmt, "cstrings cannot contain null bytes: {}", string)
+                write!(fmt, "cstrings cannot contain null bytes: {:?}", string)
             }
             Error::SerializationError { ref message } => message.fmt(fmt),
             Error::UnsignedIntegerExceededRange(value) => write!(

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     /// A key could not be serialized to a BSON string.
     InvalidDocumentKey(Bson),
 
+    /// An invalid string was specified.
+    InvalidCString(String),
+
     /// A general error that occurred during serialization.
     /// See: <https://docs.rs/serde/1.0.110/serde/ser/trait.Error.html#tymethod.custom>
     #[non_exhaustive]
@@ -37,6 +40,9 @@ impl fmt::Display for Error {
         match *self {
             Error::Io(ref inner) => inner.fmt(fmt),
             Error::InvalidDocumentKey(ref key) => write!(fmt, "Invalid map key type: {}", key),
+            Error::InvalidCString(ref string) => {
+                write!(fmt, "cstrings cannot contain null bytes: {}", string)
+            }
             Error::SerializationError { ref message } => message.fmt(fmt),
             Error::UnsignedIntegerExceededRange(value) => write!(
                 fmt,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -47,6 +47,9 @@ fn write_string<W: Write + ?Sized>(writer: &mut W, s: &str) -> Result<()> {
 }
 
 fn write_cstring<W: Write + ?Sized>(writer: &mut W, s: &str) -> Result<()> {
+    if s.contains('\0') {
+        return Err(Error::InvalidCString(s.into()));
+    }
     writer.write_all(s.as_bytes())?;
     writer.write_all(b"\0")?;
     Ok(())

--- a/src/ser/raw/value_serializer.rs
+++ b/src/ser/raw/value_serializer.rs
@@ -246,6 +246,7 @@ impl<'a, 'b> serde::Serializer for &'b mut ValueSerializer<'a> {
                 write_string(&mut self.root_serializer.bytes, v)?;
             }
             SerializationStep::RegExPattern | SerializationStep::RegExOptions => {
+                dbg!("regex");
                 write_cstring(&mut self.root_serializer.bytes, v)?;
             }
             SerializationStep::Code => {

--- a/src/ser/raw/value_serializer.rs
+++ b/src/ser/raw/value_serializer.rs
@@ -246,7 +246,6 @@ impl<'a, 'b> serde::Serializer for &'b mut ValueSerializer<'a> {
                 write_string(&mut self.root_serializer.bytes, v)?;
             }
             SerializationStep::RegExPattern | SerializationStep::RegExOptions => {
-                dbg!("regex");
                 write_cstring(&mut self.root_serializer.bytes, v)?;
             }
             SerializationStep::Code => {

--- a/src/tests/modules/ser.rs
+++ b/src/tests/modules/ser.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, u16, u32, u64, u8};
 
 use assert_matches::assert_matches;
 
-use crate::{Bson, Document, Regex, from_bson, oid::ObjectId, ser, tests::LOCK, to_bson, to_vec};
+use crate::{from_bson, oid::ObjectId, ser, tests::LOCK, to_bson, to_vec, Bson, Document, Regex};
 
 #[test]
 #[allow(clippy::float_cmp)]
@@ -160,7 +160,13 @@ fn cstring_null_bytes_error() {
 
     fn verify_doc(doc: Document) {
         let mut vec = Vec::new();
-        assert!(matches!(doc.to_writer(&mut vec).unwrap_err(), ser::Error::InvalidCString(_)));
-        assert!(matches!(to_vec(&doc).unwrap_err(), ser::Error::InvalidCString(_)));
+        assert!(matches!(
+            doc.to_writer(&mut vec).unwrap_err(),
+            ser::Error::InvalidCString(_)
+        ));
+        assert!(matches!(
+            to_vec(&doc).unwrap_err(),
+            ser::Error::InvalidCString(_)
+        ));
     }
 }

--- a/src/tests/modules/ser.rs
+++ b/src/tests/modules/ser.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, u16, u32, u64, u8};
 
 use assert_matches::assert_matches;
 
-use crate::{from_bson, oid::ObjectId, ser, tests::LOCK, to_bson, Bson};
+use crate::{Bson, Document, Regex, from_bson, oid::ObjectId, ser, tests::LOCK, to_bson, to_vec};
 
 #[test]
 #[allow(clippy::float_cmp)]
@@ -140,4 +140,27 @@ fn oid() {
 
     let deser: Bson = to_bson(&s).unwrap();
     assert_eq!(deser, obj);
+}
+
+#[test]
+fn cstring_null_bytes_error() {
+    let _guard = LOCK.run_concurrently();
+
+    let doc = doc! { "\0": "a" };
+    verify_doc(doc);
+
+    let doc = doc! { "a": { "\0": "b" } };
+    verify_doc(doc);
+
+    let regex = doc! { "regex": Regex { pattern: "\0".into(), options: "a".into() } };
+    verify_doc(regex);
+
+    let regex = doc! { "regex": Regex { pattern: "a".into(), options: "\0".into() } };
+    verify_doc(regex);
+
+    fn verify_doc(doc: Document) {
+        let mut vec = Vec::new();
+        assert!(matches!(doc.to_writer(&mut vec).unwrap_err(), ser::Error::InvalidCString(_)));
+        assert!(matches!(to_vec(&doc).unwrap_err(), ser::Error::InvalidCString(_)));
+    }
 }

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{Bson, Document, tests::LOCK};
+use crate::{tests::LOCK, Bson, Document};
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{tests::LOCK, Bson, Document};
+use crate::{Bson, Document, tests::LOCK};
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 
@@ -391,7 +391,10 @@ fn run_test(test: TestFile) {
         let json: serde_json::Value =
             serde_json::from_str(parse_error.string.as_str()).expect(&parse_error.description);
 
-        Bson::try_from(json).expect_err(&parse_error.description);
+        if let Ok(bson) = Bson::try_from(json.clone()) {
+            // if converting to bson succeeds, assert that translating that bson to bytes fails
+            assert!(crate::to_vec(&bson).is_err());
+        }
     }
 }
 

--- a/src/tests/spec/json/bson-corpus/binary.json
+++ b/src/tests/spec/json/bson-corpus/binary.json
@@ -51,6 +51,11 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
         },
         {
+            "description": "subtype 0x07",
+            "canonical_bson": "1D000000057800100000000773FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"07\"}}}"
+        },
+        {
             "description": "subtype 0x80",
             "canonical_bson": "0F0000000578000200000080FFFF00",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"

--- a/src/tests/spec/json/bson-corpus/dbref.json
+++ b/src/tests/spec/json/bson-corpus/dbref.json
@@ -1,5 +1,5 @@
 {
-    "description": "DBRef",
+    "description": "Document type (DBRef sub-documents)",
     "bson_type": "0x03",
     "valid": [
         {
@@ -26,6 +26,26 @@
             "description": "Document with key names similar to those of a DBRef",
             "canonical_bson": "3e0000000224726566000c0000006e6f742d612d646272656600072469640058921b3e6e32ab156a22b59e022462616e616e6100050000007065656c0000",
             "canonical_extjson": "{\"$ref\": \"not-a-dbref\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"$banana\": \"peel\"}"
+        },
+        {
+            "description": "DBRef with additional dollar-prefixed and dotted fields",
+            "canonical_bson": "48000000036462726566003c0000000224726566000b000000636f6c6c656374696f6e00072469640058921b3e6e32ab156a22b59e10612e62000100000010246300010000000000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"a.b\": {\"$numberInt\": \"1\"}, \"$c\": {\"$numberInt\": \"1\"}}}"
+        },
+        {
+            "description": "Sub-document resembles DBRef but $id is missing",
+            "canonical_bson": "26000000036462726566001a0000000224726566000b000000636f6c6c656374696f6e000000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": \"collection\"}}"
+        },
+        {
+            "description": "Sub-document resembles DBRef but $ref is not a string",
+            "canonical_bson": "2c000000036462726566002000000010247265660001000000072469640058921b3e6e32ab156a22b59e0000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": {\"$numberInt\": \"1\"}, \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}}}"
+        },
+        {
+            "description": "Sub-document resembles DBRef but $db is not a string",
+            "canonical_bson": "4000000003646272656600340000000224726566000b000000636f6c6c656374696f6e00072469640058921b3e6e32ab156a22b59e1024646200010000000000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"$db\": {\"$numberInt\": \"1\"}}}"
         }
     ]
 }

--- a/src/tests/spec/json/bson-corpus/document.json
+++ b/src/tests/spec/json/bson-corpus/document.json
@@ -51,6 +51,10 @@
         {
             "description": "Invalid subdocument: bad string length in field",
             "bson": "1C00000003666F6F001200000002626172000500000062617A000000"
+        },
+        {
+            "description": "Null byte in sub-document key",
+            "bson": "150000000378000D00000010610000010000000000"
         }
     ]
 }

--- a/src/tests/spec/json/bson-corpus/regex.json
+++ b/src/tests/spec/json/bson-corpus/regex.json
@@ -54,11 +54,11 @@
     ],
     "decodeErrors": [
         {
-            "description": "embedded null in pattern",
+            "description": "Null byte in pattern string",
             "bson": "0F0000000B610061006300696D0000"
         },
         {
-            "description": "embedded null in flags",
+            "description": "Null byte in flags string",
             "bson": "100000000B61006162630069006D0000"
         }
     ]

--- a/src/tests/spec/json/bson-corpus/top.json
+++ b/src/tests/spec/json/bson-corpus/top.json
@@ -79,6 +79,10 @@
         {
             "description": "Document truncated mid-key",
             "bson": "1200000002666F"
+        },
+        {
+            "description": "Null byte in document key",
+            "bson": "0D000000107800000100000000"
         }
     ],
     "parseErrors": [
@@ -241,7 +245,22 @@
         {
             "description": "Bad DBpointer (extra field)",
             "string": "{\"a\": {\"$dbPointer\": {\"a\": {\"$numberInt\": \"1\"}, \"$id\": {\"$oid\": \"56e1fc72e0c917e9c4714161\"}, \"c\": {\"$numberInt\": \"2\"}, \"$ref\": \"b\"}}}"
+        },
+        {
+            "description" : "Null byte in document key",
+            "string" : "{\"a\\u0000\": 1 }"
+        },
+        {
+            "description" : "Null byte in sub-document key",
+            "string" : "{\"a\" : {\"b\\u0000\": 1 }}"
+        },
+        {
+            "description": "Null byte in $regularExpression pattern",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\\u0000\", \"options\" : \"i\"}}}"
+        },
+        {
+            "description": "Null byte in $regularExpression options",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\", \"options\" : \"i\\u0000\"}}}"
         }
-
     ]
 }


### PR DESCRIPTION
Validates that any cstrings in BSON (as defined by the [BSON spec](https://bsonspec.org/spec.html)) do not contain null bytes. Rather than enforce this for all of our Rust BSON types (e.g. `Document`, `Regex`) which would be difficult/impossible in some cases, I opted to enforce it when the BSON is encoded into bytes. The entry points for this in our API are `Document::to_reader` and `to_vec`.