### PR TITLE
RUST-787 impl Display for various Bson types

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -984,6 +984,13 @@ pub struct Timestamp {
     pub increment: u32,
 }
 
+impl Display for Timestamp {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let x: Bson = self.into();
+        write!(fmt, "{}", x)
+    }
+}
+
 impl Timestamp {
     pub(crate) fn to_le_i64(self) -> i64 {
         let upper = (self.time.to_le() as u64) << 32;
@@ -1018,11 +1025,25 @@ pub struct Regex {
     pub options: String,
 }
 
+impl Display for Regex {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let x: Bson = self.into();
+        write!(fmt, "{}", x)
+    }
+}
+
 /// Represents a BSON code with scope value.
 #[derive(Debug, Clone, PartialEq)]
 pub struct JavaScriptCodeWithScope {
     pub code: String,
     pub scope: Document,
+}
+
+impl Display for JavaScriptCodeWithScope {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let x: Bson = self.into();
+        write!(fmt, "{}", x)
+    }
 }
 
 /// Represents a BSON binary value.
@@ -1033,6 +1054,13 @@ pub struct Binary {
 
     /// The binary bytes.
     pub bytes: Vec<u8>,
+}
+
+impl Display for Binary {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let x: Bson = self.into();
+        write!(fmt, "{}", x)
+    }
 }
 
 impl Binary {

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -61,6 +61,43 @@ fn bson_default() {
 }
 
 #[test]
+fn test_display_timestamp_type() {
+    let x = Timestamp {
+        time: 100,
+        increment: 200,
+    };
+    assert_eq!(format!("{}", x), "Timestamp(100, 200)");
+}
+
+#[test]
+fn test_display_regex_type() {
+    let x = Regex {
+        pattern: String::from("pattern"),
+        options: String::from("options"),
+    };
+    assert_eq!(format!("{}", x), "/pattern/options");
+}
+
+#[test]
+fn test_display_jscodewithcontext_type() {
+    let x = JavaScriptCodeWithScope {
+        code: String::from("code"),
+        scope: doc! {"x": 2},
+    };
+    assert_eq!(format!("{}", x), "code");
+}
+
+#[test]
+fn test_display_binary_type() {
+    let bytes = base64::decode("aGVsbG8gd29ybGQ=").unwrap();
+    let x = Binary {
+        subtype: BinarySubtype::Generic,
+        bytes,
+    };
+    assert_eq!(format!("{}", x), "Binary(0x0, aGVsbG8gd29ybGQ=)");
+}
+
+#[test]
 fn document_default() {
     let _guard = LOCK.run_concurrently();
     let doc1 = Document::default();


### PR DESCRIPTION
Implements display for Bson types.  Wraps Bson enum display.