### PR TITLE
RUST-819 Add methods for converting between Binary and Uuid

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1084,7 +1084,8 @@ pub enum UuidRepresentation {
     CSharpLegacy,
     /// The legacy representation of UUIDs in BSON used by the Java driver (binary subtype 0x03)
     JavaLegacy,
-    /// The legacy representation of UUIDs in BSON used by the Python driver, which is the same format as STANDARD, but has binary subtype 0x03
+    /// The legacy representation of UUIDs in BSON used by the Python driver, which is the same
+    /// format as STANDARD, but has binary subtype 0x03
     PythonLegacy,
 }
 
@@ -1126,26 +1127,34 @@ impl Binary {
             }
         }
     }
-    /// Deserializes a BSON binary type into a UUID, takes the representation with which the Binary was serialized.
+    /// Deserializes a BSON binary type into a UUID, takes the representation with which the Binary
+    /// was serialized.
     pub fn to_uuid_with_representation(
         &self,
         rep: UuidRepresentation,
     ) -> Result<uuid::Uuid, crate::de::Error> {
         // If representation is non-standard, then its subtype must be UuidOld
         if rep != UuidRepresentation::Standard && self.subtype != BinarySubtype::UuidOld {
-            return Err(Error::custom(
-                format!("expected binary subtype 3 when converting to UUID with a non-standard representation, instead got {:#04x}", u8::from(self.subtype)),
-            ));
+            return Err(Error::custom(format!(
+                "expected binary subtype 3 when converting to UUID with a non-standard \
+                 representation, instead got {:#04x}",
+                u8::from(self.subtype)
+            )));
         }
         // If representation is standard, then its subtype must be Uuid
         if rep == UuidRepresentation::Standard && self.subtype != BinarySubtype::Uuid {
-            return Err(Error::custom(
-                format!("expected binary subtype 4 when converting to UUID with the standard representation, instead got {:#04x}", u8::from(self.subtype))
-            ));
+            return Err(Error::custom(format!(
+                "expected binary subtype 4 when converting to UUID with the standard \
+                 representation, instead got {:#04x}",
+                u8::from(self.subtype)
+            )));
         }
         // Must be 16 bytes long
         if self.bytes.len() != 16 {
-            return Err(Error::custom(format!("expected UUID to contain 16 bytes, instead got {}", self.bytes.len())));
+            return Err(Error::custom(format!(
+                "expected UUID to contain 16 bytes, instead got {}",
+                self.bytes.len()
+            )));
         }
         let mut buf = [0u8; 16];
         buf.copy_from_slice(&self.bytes);

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1056,6 +1056,7 @@ impl Binary {
 
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
+#[derive(PartialEq)]
 pub enum UuidRepresentation {
     Standard,
     CSharpLegacy,
@@ -1100,45 +1101,33 @@ impl Binary {
     }
 
     pub fn to_uuid_with_representation(&self, rep: UuidRepresentation) -> Result<uuid::Uuid, &str> {
+        if self.subtype != BinarySubtype::UuidOld && UuidRepresentation::Standard != rep {
+            return Err("expecting BinarySubtype::UuidOld");
+        }
+        if self.bytes.len() != 16 {
+            return Err("expecting 16 bytes");
+        }
         match rep {
             UuidRepresentation::Standard => self.to_uuid(),
             UuidRepresentation::CSharpLegacy => {
-                if self.subtype != BinarySubtype::UuidOld {
-                    Err("expecting BinarySubtype::UuidOld")
-                } else if self.bytes.len() != 16 {
-                    Err("expecting 16 bytes")
-                } else {
-                    let mut buf = [0u8; 16];
-                    buf.copy_from_slice(&self.bytes);
-                    buf[0..4].reverse();
-                    buf[4..6].reverse();
-                    buf[6..8].reverse();
-                    Ok(uuid::Uuid::from_bytes(buf))
-                }
+                let mut buf = [0u8; 16];
+                buf.copy_from_slice(&self.bytes);
+                buf[0..4].reverse();
+                buf[4..6].reverse();
+                buf[6..8].reverse();
+                Ok(uuid::Uuid::from_bytes(buf))
             }
             UuidRepresentation::PythonLegacy => {
-                if self.subtype != BinarySubtype::UuidOld {
-                    Err("expecting BinarySubtype::UuidOld")
-                } else if self.bytes.len() != 16 {
-                    Err("expecting 16 bytes")
-                } else {
-                    let mut buf = [0u8; 16];
-                    buf.copy_from_slice(&self.bytes);
-                    Ok(uuid::Uuid::from_bytes(buf))
-                }
+                let mut buf = [0u8; 16];
+                buf.copy_from_slice(&self.bytes);
+                Ok(uuid::Uuid::from_bytes(buf))
             }
             UuidRepresentation::JavaLegacy => {
-                if self.subtype != BinarySubtype::UuidOld {
-                    Err("expecting BinarySubtype::UuidOld")
-                } else if self.bytes.len() != 16 {
-                    Err("expecting 16 bytes")
-                } else {
-                    let mut buf = [0u8; 16];
-                    buf.copy_from_slice(&self.bytes);
-                    buf[0..8].reverse();
-                    buf[8..16].reverse();
-                    Ok(uuid::Uuid::from_bytes(buf))
-                }
+                let mut buf = [0u8; 16];
+                buf.copy_from_slice(&self.bytes);
+                buf[0..8].reverse();
+                buf[8..16].reverse();
+                Ok(uuid::Uuid::from_bytes(buf))
             }
         }
     }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1061,6 +1061,9 @@ impl Binary {
 /// deserializing a Binary object to a Uuid.
 /// This enum is necessary because the different drivers used to have different ways of encoding
 /// UUID, with the BSON subtype: 0x03 UUID old.
+/// If a UUID has been serialized with a particular representation, it MUST
+/// be deserialized with the same representation.
+///
 /// Example:
 /// ```
 /// use crate::{bson::UuidRepresentation, bson::Binary};
@@ -1076,9 +1079,13 @@ impl Binary {
 #[non_exhaustive]
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum UuidRepresentation {
+    /// The canonical representation of UUID BSON binary subtype 4
     Standard,
+    /// The legacy representation of UUID used by the C# driver BSON binary subtype 3
     CSharpLegacy,
+    /// The legacy representation of UUID used by the Java driver BSON binary subtype 3
     JavaLegacy,
+    /// The legacy representation of UUID used by the Python driver, which is the same format as STANDARD, but has the UUID old BSON subtype (\x03) BSON binary subtype 3
     PythonLegacy,
 }
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1057,6 +1057,8 @@ impl Binary {
     }
 }
 
+#[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 /// Enum of the possible representations to use when converting between Uuid and Binary.
 /// This enum is necessary because the different drivers used to have different ways of encoding
 /// UUID, with the BSON subtype: 0x03 UUID old.
@@ -1092,11 +1094,11 @@ pub enum UuidRepresentation {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 impl Binary {
-    /// Serializes a uuid into BSON binary type
+    /// Serializes a UUID into BSON binary type
     pub fn from_uuid(uuid: uuid::Uuid) -> Self {
         Binary::from(uuid)
     }
-    /// Serializes a uuid into BSON binary type and takes the desired representation as a parameter.
+    /// Serializes a UUID into BSON binary type and takes the desired representation as a parameter.
     /// Binary::from_uuid_with_representation(uuid, UuidRepresentation::Standard) is equivalent
     /// to Binary::from_uuid.
     pub fn from_uuid_with_representation(uuid: uuid::Uuid, rep: UuidRepresentation) -> Self {

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1075,6 +1075,8 @@ impl Binary {
 /// assert!(new_uuid.is_ok());
 /// assert_eq!(new_uuid.unwrap(), uuid);
 /// ```
+#[cfg(feature = "uuid-0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 #[non_exhaustive]
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum UuidRepresentation {
@@ -1097,8 +1099,11 @@ impl Binary {
         Binary::from(uuid)
     }
     /// Serializes a UUID into BSON binary type and takes the desired representation as a parameter.
-    /// Binary::from_uuid_with_representation(uuid, UuidRepresentation::Standard) is equivalent
-    /// to Binary::from_uuid.
+    /// ``Binary::from_uuid_with_representation(uuid, UuidRepresentation::Standard)`` is equivalent
+    /// to ``Binary::from_uuid(uuid)``.
+    ///
+    /// See the documentation for [`UuidRepresentation`] for more information on the possible
+    /// representations.
     pub fn from_uuid_with_representation(uuid: uuid::Uuid, rep: UuidRepresentation) -> Self {
         match rep {
             UuidRepresentation::Standard => Binary::from_uuid(uuid),
@@ -1129,6 +1134,9 @@ impl Binary {
     }
     /// Deserializes a BSON binary type into a UUID, takes the representation with which the Binary
     /// was serialized.
+    ///
+    /// See the documentation for [`UuidRepresentation`] for more information on the possible
+    /// representations.
     pub fn to_uuid_with_representation(
         &self,
         rep: UuidRepresentation,

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1057,9 +1057,9 @@ impl Binary {
     }
 }
 
-/// Enum of the possible representations to use when converting between Uuid and Binary.
+/// Enum of the possible representations to use when converting between [Uuid](https://docs.rs/uuid/0.8.2/uuid/) and [`Binary`].
 /// This enum is necessary because the different drivers used to have different ways of encoding
-/// UUID, with the BSON subtype: 0x03 UUID old.
+/// UUIDs, with the BSON subtype: 0x03 (UUID old).
 /// If a UUID has been serialized with a particular representation, it MUST
 /// be deserialized with the same representation.
 ///
@@ -1094,13 +1094,13 @@ pub enum UuidRepresentation {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 impl Binary {
-    /// Serializes a UUID into BSON binary type
+    /// Serializes a [Uuid](https://docs.rs/uuid/0.8.2/uuid/) into BSON [`Binary`] type
     pub fn from_uuid(uuid: uuid::Uuid) -> Self {
         Binary::from(uuid)
     }
     /// Serializes a UUID into BSON binary type and takes the desired representation as a parameter.
-    /// ``Binary::from_uuid_with_representation(uuid, UuidRepresentation::Standard)`` is equivalent
-    /// to ``Binary::from_uuid(uuid)``.
+    /// `Binary::from_uuid_with_representation(uuid, UuidRepresentation::Standard)` is equivalent
+    /// to `Binary::from_uuid(uuid)`.
     ///
     /// See the documentation for [`UuidRepresentation`] for more information on the possible
     /// representations.
@@ -1132,7 +1132,7 @@ impl Binary {
             }
         }
     }
-    /// Deserializes a BSON binary type into a UUID, takes the representation with which the Binary
+    /// Deserializes a BSON [`Binary`] type into a [Uuid](https://docs.rs/uuid/0.8.2/uuid/), takes the representation with which the [`Binary`]
     /// was serialized.
     ///
     /// See the documentation for [`UuidRepresentation`] for more information on the possible
@@ -1182,7 +1182,7 @@ impl Binary {
             }
         }
     }
-    /// Deserializes a BSON binary type into a UUID using the standard representation.
+    /// Deserializes a BSON [`Binary`] type into a [Uuid](https://docs.rs/uuid/0.8.2/uuid/) using the standard representation.
     pub fn to_uuid(&self) -> Result<uuid::Uuid, crate::de::Error> {
         self.to_uuid_with_representation(UuidRepresentation::Standard)
     }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1057,8 +1057,6 @@ impl Binary {
     }
 }
 
-#[cfg(feature = "uuid-0_8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 /// Enum of the possible representations to use when converting between Uuid and Binary.
 /// This enum is necessary because the different drivers used to have different ways of encoding
 /// UUID, with the BSON subtype: 0x03 UUID old.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@
 
 #[doc(inline)]
 pub use self::{
-    bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
+    bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp, UuidRepresentation},
     datetime::DateTime,
     de::{
         from_bson,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@
 
 #[doc(inline)]
 pub use self::{
-    bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp, UuidRepresentation},
+    bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
     de::{
         from_bson,
@@ -319,6 +319,9 @@ pub use self::{
     decimal128::Decimal128,
     ser::{to_bson, to_document, to_vec, Serializer},
 };
+
+#[cfg(feature = "uuid-0_8")]
+pub use self::bson::UuidRepresentation;
 
 #[macro_use]
 mod macros;

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -417,7 +417,9 @@ pub mod uuid_as_java_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        binary.to_uuid_with_representation(UuidRepresentation::JavaLegacy).map_err(de::Error::custom)
+        binary
+            .to_uuid_with_representation(UuidRepresentation::JavaLegacy)
+            .map_err(de::Error::custom)
     }
 }
 
@@ -460,7 +462,9 @@ pub mod uuid_as_python_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        binary.to_uuid_with_representation(UuidRepresentation::PythonLegacy).map_err(de::Error::custom)
+        binary
+            .to_uuid_with_representation(UuidRepresentation::PythonLegacy)
+            .map_err(de::Error::custom)
     }
 }
 
@@ -503,7 +507,9 @@ pub mod uuid_as_c_sharp_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        binary.to_uuid_with_representation(UuidRepresentation::CSharpLegacy).map_err(de::Error::custom)
+        binary
+            .to_uuid_with_representation(UuidRepresentation::CSharpLegacy)
+            .map_err(de::Error::custom)
     }
 }
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -355,7 +355,7 @@ pub mod hex_string_as_object_id {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_binary {
-    use crate::Binary;
+    use crate::{de::Error, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -374,9 +374,12 @@ pub mod uuid_as_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        match binary.to_uuid() {
-            Ok(x) => Ok(x),
-            Err(msg) => Err(de::Error::custom(msg)),
+        let res = binary.to_uuid();
+        if let Err(Error::DeserializationError { message: msg }) = res {
+            Err(de::Error::custom(msg))
+        } else {
+            // Guaranteed to not error because to_uuid_with_representation
+            Ok(res.unwrap())
         }
     }
 }
@@ -401,7 +404,7 @@ pub mod uuid_as_binary {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_java_legacy_binary {
-    use crate::{bson::UuidRepresentation, Binary};
+    use crate::{bson::UuidRepresentation, de::Error, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -409,7 +412,7 @@ pub mod uuid_as_java_legacy_binary {
     /// Serializes a Uuid as a Binary in a Java Legacy UUID format.
     #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn serialize<S: Serializer>(val: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
-        let binary = Binary::from_uuid_with_representation(val, UuidRepresentation::JavaLegacy);
+        let binary = Binary::from_uuid_with_representation(*val, UuidRepresentation::JavaLegacy);
         binary.serialize(serializer)
     }
 
@@ -420,9 +423,12 @@ pub mod uuid_as_java_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        match binary.to_uuid_with_representation(UuidRepresentation::JavaLegacy) {
-            Ok(x) => Ok(x),
-            Err(msg) => Err(de::Error::custom(msg)),
+        let res = binary.to_uuid_with_representation(UuidRepresentation::JavaLegacy);
+        if let Err(Error::DeserializationError { message: msg }) = res {
+            Err(de::Error::custom(msg))
+        } else {
+            // Guaranteed to not error because to_uuid_with_representation
+            Ok(res.unwrap())
         }
     }
 }
@@ -447,7 +453,7 @@ pub mod uuid_as_java_legacy_binary {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_python_legacy_binary {
-    use crate::{bson::UuidRepresentation, Binary};
+    use crate::{bson::UuidRepresentation, de::Error, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -455,7 +461,7 @@ pub mod uuid_as_python_legacy_binary {
     /// Serializes a Uuid as a Binary in a Python Legacy UUID format.
     #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn serialize<S: Serializer>(val: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
-        let binary = Binary::from_uuid_with_representation(val, UuidRepresentation::PythonLegacy);
+        let binary = Binary::from_uuid_with_representation(*val, UuidRepresentation::PythonLegacy);
         binary.serialize(serializer)
     }
 
@@ -466,9 +472,12 @@ pub mod uuid_as_python_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        match binary.to_uuid_with_representation(UuidRepresentation::PythonLegacy) {
-            Ok(x) => Ok(x),
-            Err(msg) => Err(de::Error::custom(msg)),
+        let res = binary.to_uuid_with_representation(UuidRepresentation::PythonLegacy);
+        if let Err(Error::DeserializationError { message: msg }) = res {
+            Err(de::Error::custom(msg))
+        } else {
+            // Guaranteed to not error because to_uuid_with_representation
+            Ok(res.unwrap())
         }
     }
 }
@@ -493,7 +502,7 @@ pub mod uuid_as_python_legacy_binary {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_c_sharp_legacy_binary {
-    use crate::{bson::UuidRepresentation, Binary};
+    use crate::{bson::UuidRepresentation, de::Error, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -501,7 +510,7 @@ pub mod uuid_as_c_sharp_legacy_binary {
     /// Serializes a Uuid as a Binary in a C# Legacy UUID format.
     #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
     pub fn serialize<S: Serializer>(val: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
-        let binary = Binary::from_uuid_with_representation(val, UuidRepresentation::CSharpLegacy);
+        let binary = Binary::from_uuid_with_representation(*val, UuidRepresentation::CSharpLegacy);
         binary.serialize(serializer)
     }
 
@@ -512,9 +521,12 @@ pub mod uuid_as_c_sharp_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        match binary.to_uuid_with_representation(UuidRepresentation::CSharpLegacy) {
-            Ok(x) => Ok(x),
-            Err(msg) => Err(de::Error::custom(msg)),
+        let res = binary.to_uuid_with_representation(UuidRepresentation::CSharpLegacy);
+        if let Err(Error::DeserializationError { message: msg }) = res {
+            Err(de::Error::custom(msg))
+        } else {
+            // Guaranteed to not error because to_uuid_with_representation
+            Ok(res.unwrap())
         }
     }
 }

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -378,7 +378,8 @@ pub mod uuid_as_binary {
         if let Err(Error::DeserializationError { message: msg }) = res {
             Err(de::Error::custom(msg))
         } else {
-            // Guaranteed to not error because to_uuid_with_representation
+            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
+            // Or it succeeds
             Ok(res.unwrap())
         }
     }
@@ -427,7 +428,8 @@ pub mod uuid_as_java_legacy_binary {
         if let Err(Error::DeserializationError { message: msg }) = res {
             Err(de::Error::custom(msg))
         } else {
-            // Guaranteed to not error because to_uuid_with_representation
+            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
+            // Or it succeeds
             Ok(res.unwrap())
         }
     }
@@ -476,7 +478,8 @@ pub mod uuid_as_python_legacy_binary {
         if let Err(Error::DeserializationError { message: msg }) = res {
             Err(de::Error::custom(msg))
         } else {
-            // Guaranteed to not error because to_uuid_with_representation
+            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
+            // Or it succeeds
             Ok(res.unwrap())
         }
     }
@@ -525,7 +528,8 @@ pub mod uuid_as_c_sharp_legacy_binary {
         if let Err(Error::DeserializationError { message: msg }) = res {
             Err(de::Error::custom(msg))
         } else {
-            // Guaranteed to not error because to_uuid_with_representation
+            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
+            // Or it succeeds
             Ok(res.unwrap())
         }
     }

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -355,7 +355,7 @@ pub mod hex_string_as_object_id {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_binary {
-    use crate::{de::Error, Binary};
+    use crate::Binary;
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -374,14 +374,7 @@ pub mod uuid_as_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        let res = binary.to_uuid();
-        if let Err(Error::DeserializationError { message: msg }) = res {
-            Err(de::Error::custom(msg))
-        } else {
-            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
-            // Or it succeeds
-            Ok(res.unwrap())
-        }
+        binary.to_uuid().map_err(de::Error::custom)
     }
 }
 
@@ -405,7 +398,7 @@ pub mod uuid_as_binary {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_java_legacy_binary {
-    use crate::{bson::UuidRepresentation, de::Error, Binary};
+    use crate::{bson::UuidRepresentation, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -424,14 +417,7 @@ pub mod uuid_as_java_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        let res = binary.to_uuid_with_representation(UuidRepresentation::JavaLegacy);
-        if let Err(Error::DeserializationError { message: msg }) = res {
-            Err(de::Error::custom(msg))
-        } else {
-            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
-            // Or it succeeds
-            Ok(res.unwrap())
-        }
+        binary.to_uuid_with_representation(UuidRepresentation::JavaLegacy).map_err(de::Error::custom)
     }
 }
 
@@ -455,7 +441,7 @@ pub mod uuid_as_java_legacy_binary {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_python_legacy_binary {
-    use crate::{bson::UuidRepresentation, de::Error, Binary};
+    use crate::{bson::UuidRepresentation, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -474,14 +460,7 @@ pub mod uuid_as_python_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        let res = binary.to_uuid_with_representation(UuidRepresentation::PythonLegacy);
-        if let Err(Error::DeserializationError { message: msg }) = res {
-            Err(de::Error::custom(msg))
-        } else {
-            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
-            // Or it succeeds
-            Ok(res.unwrap())
-        }
+        binary.to_uuid_with_representation(UuidRepresentation::PythonLegacy).map_err(de::Error::custom)
     }
 }
 
@@ -505,7 +484,7 @@ pub mod uuid_as_python_legacy_binary {
 #[cfg(feature = "uuid-0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
 pub mod uuid_as_c_sharp_legacy_binary {
-    use crate::{bson::UuidRepresentation, de::Error, Binary};
+    use crate::{bson::UuidRepresentation, Binary};
     use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;
     use uuid::Uuid;
@@ -524,14 +503,7 @@ pub mod uuid_as_c_sharp_legacy_binary {
         D: Deserializer<'de>,
     {
         let binary = Binary::deserialize(deserializer)?;
-        let res = binary.to_uuid_with_representation(UuidRepresentation::CSharpLegacy);
-        if let Err(Error::DeserializationError { message: msg }) = res {
-            Err(de::Error::custom(msg))
-        } else {
-            // Guaranteed to not error because to_uuid_with_representation only returns Err(Error::DeserializationError)
-            // Or it succeeds
-            Ok(res.unwrap())
-        }
+        binary.to_uuid_with_representation(UuidRepresentation::CSharpLegacy).map_err(de::Error::custom)
     }
 }
 

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -359,6 +359,10 @@ fn test_binary_constructors() {
     assert_eq!(bin.bytes, uuid.as_bytes());
     assert_eq!(bin.subtype, BinarySubtype::Uuid);
 
+    let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::Standard);
+    assert_eq!(bin.bytes, uuid.as_bytes());
+    assert_eq!(bin.subtype, BinarySubtype::Uuid);
+
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::JavaLegacy);
     assert_eq!(
         bin.bytes,
@@ -415,13 +419,9 @@ fn test_binary_to_uuid_standard_rep() {
 #[test]
 fn test_binary_to_uuid_explicitly_standard_rep() {
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
-    let bin = Binary::from_uuid(uuid);
+    let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::Standard);
 
-    assert_eq!(
-        bin.to_uuid_with_representation(UuidRepresentation::Standard)
-            .unwrap(),
-        uuid
-    );
+    assert_eq!(bin.to_uuid().unwrap(), uuid);
     assert_eq!(
         bin.to_uuid_with_representation(UuidRepresentation::Standard)
             .unwrap(),

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -381,6 +381,7 @@ fn test_binary_constructors() {
     );
     assert_eq!(bin.subtype, BinarySubtype::UuidOld);
 
+    // Same byte ordering as standard representation
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::PythonLegacy);
     assert_eq!(
         bin.bytes,

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -349,7 +349,7 @@ fn debug_print() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_constructors() {
-    use bson::UuidRepresentation;
+    use crate::bson::UuidRepresentation;
     use uuid::Uuid;
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
@@ -388,7 +388,7 @@ fn test_binary_constructors() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid() {
-    use bson::UuidRepresentation;
+    use crate::bson::UuidRepresentation;
     use uuid::Uuid;
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
@@ -417,7 +417,7 @@ fn test_binary_to_uuid() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid_java_rep() {
-    use bson::UuidRepresentation;
+    use crate::bson::UuidRepresentation;
     use uuid::Uuid;
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
@@ -441,7 +441,7 @@ fn test_binary_to_uuid_java_rep() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid_csharp_legacy_rep() {
-    use bson::UuidRepresentation;
+    use crate::bson::UuidRepresentation;
     use uuid::Uuid;
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
@@ -465,7 +465,7 @@ fn test_binary_to_uuid_csharp_legacy_rep() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid_python_legacy_rep() {
-    use bson::UuidRepresentation;
+    use crate::bson::UuidRepresentation;
     use uuid::Uuid;
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -393,9 +393,10 @@ fn test_binary_to_uuid() {
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid(uuid);
-    // Error message for attempting to deserialize binary to a UUID using a non-standard representation
-    // when the representation is standard.
-    let error_msg = "expected binary subtype 3 when converting to UUID with a non-standard representation, instead got 0x04";
+    // Error message for attempting to deserialize binary to a UUID using a non-standard
+    // representation when the representation is standard.
+    let error_msg = "expected binary subtype 3 when converting to UUID with a non-standard \
+                     representation, instead got 0x04";
 
     assert_eq!(bin.to_uuid().unwrap(), uuid);
     assert_eq!(
@@ -408,30 +409,21 @@ fn test_binary_to_uuid() {
         .to_uuid_with_representation(UuidRepresentation::CSharpLegacy)
         .unwrap_err()
     {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     if let Error::DeserializationError { message: msg } = bin
         .to_uuid_with_representation(UuidRepresentation::PythonLegacy)
         .unwrap_err()
     {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     if let Error::DeserializationError { message: msg } = bin
         .to_uuid_with_representation(UuidRepresentation::PythonLegacy)
         .unwrap_err()
     {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 }
 
@@ -445,23 +437,18 @@ fn test_binary_to_uuid_java_rep() {
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::JavaLegacy);
     // Error message for attempting to deserialize binary to uuid using standard representation
     // when the representation is non-standard.
-    let error_msg = "expected binary subtype 4 when converting to UUID with the standard representation, instead got 0x03";
+    let error_msg = "expected binary subtype 4 when converting to UUID with the standard \
+                     representation, instead got 0x03";
 
     if let Error::DeserializationError { message: msg } = bin.to_uuid().unwrap_err() {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     if let Error::DeserializationError { message: msg } = bin
         .to_uuid_with_representation(UuidRepresentation::Standard)
         .unwrap_err()
     {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     assert_eq!(
@@ -479,25 +466,20 @@ fn test_binary_to_uuid_csharp_legacy_rep() {
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::CSharpLegacy);
-    // Error message for attempting to deserialize from binary to UUID using the standard representation
-    // when the representation is actually non-standard.
-    let error_msg = "expected binary subtype 4 when converting to UUID with the standard representation, instead got 0x03";
+    // Error message for attempting to deserialize from binary to UUID using the standard
+    // representation when the representation is actually non-standard.
+    let error_msg = "expected binary subtype 4 when converting to UUID with the standard \
+                     representation, instead got 0x03";
 
     if let Error::DeserializationError { message: msg } = bin.to_uuid().unwrap_err() {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     if let Error::DeserializationError { message: msg } = bin
         .to_uuid_with_representation(UuidRepresentation::Standard)
         .unwrap_err()
     {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     assert_eq!(
@@ -517,23 +499,18 @@ fn test_binary_to_uuid_python_legacy_rep() {
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::PythonLegacy);
     // Error message for attempting to deserialize binary to UUID using the standard representation,
     // when the  representation is actually non-standard
-    let error_msg = "expected binary subtype 4 when converting to UUID with the standard representation, instead got 0x03";
+    let error_msg = "expected binary subtype 4 when converting to UUID with the standard \
+                     representation, instead got 0x03";
 
     if let Error::DeserializationError { message: msg } = bin.to_uuid().unwrap_err() {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     if let Error::DeserializationError { message: msg } = bin
         .to_uuid_with_representation(UuidRepresentation::Standard)
         .unwrap_err()
     {
-        assert_eq!(
-            msg,
-            error_msg
-        );
+        assert_eq!(msg, error_msg);
     }
 
     assert_eq!(

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -393,6 +393,9 @@ fn test_binary_to_uuid() {
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid(uuid);
+    // Error message for attempting to deserialize binary to a UUID using a non-standard representation
+    // when the representation is standard.
+    let error_msg = "expected binary subtype 3 when converting to UUID with a non-standard representation, instead got 0x04";
 
     assert_eq!(bin.to_uuid().unwrap(), uuid);
     assert_eq!(
@@ -407,7 +410,7 @@ fn test_binary_to_uuid() {
     {
         assert_eq!(
             msg,
-            "expecting binary subtype 3 for non-standard representations"
+            error_msg
         );
     }
 
@@ -417,7 +420,7 @@ fn test_binary_to_uuid() {
     {
         assert_eq!(
             msg,
-            "expecting binary subtype 3 for non-standard representations"
+            error_msg
         );
     }
 
@@ -427,7 +430,7 @@ fn test_binary_to_uuid() {
     {
         assert_eq!(
             msg,
-            "expecting binary subtype 3 for non-standard representations"
+            error_msg
         );
     }
 }
@@ -440,11 +443,14 @@ fn test_binary_to_uuid_java_rep() {
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::JavaLegacy);
+    // Error message for attempting to deserialize binary to uuid using standard representation
+    // when the representation is non-standard.
+    let error_msg = "expected binary subtype 4 when converting to UUID with the standard representation, instead got 0x03";
 
     if let Error::DeserializationError { message: msg } = bin.to_uuid().unwrap_err() {
         assert_eq!(
             msg,
-            "expecting binary subtype 4 for standard representation"
+            error_msg
         );
     }
 
@@ -454,7 +460,7 @@ fn test_binary_to_uuid_java_rep() {
     {
         assert_eq!(
             msg,
-            "expecting binary subtype 4 for standard representation"
+            error_msg
         );
     }
 
@@ -473,11 +479,14 @@ fn test_binary_to_uuid_csharp_legacy_rep() {
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::CSharpLegacy);
+    // Error message for attempting to deserialize from binary to UUID using the standard representation
+    // when the representation is actually non-standard.
+    let error_msg = "expected binary subtype 4 when converting to UUID with the standard representation, instead got 0x03";
 
     if let Error::DeserializationError { message: msg } = bin.to_uuid().unwrap_err() {
         assert_eq!(
             msg,
-            "expecting binary subtype 4 for standard representation"
+            error_msg
         );
     }
 
@@ -487,7 +496,7 @@ fn test_binary_to_uuid_csharp_legacy_rep() {
     {
         assert_eq!(
             msg,
-            "expecting binary subtype 4 for standard representation"
+            error_msg
         );
     }
 
@@ -506,11 +515,14 @@ fn test_binary_to_uuid_python_legacy_rep() {
 
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid_with_representation(uuid, UuidRepresentation::PythonLegacy);
+    // Error message for attempting to deserialize binary to UUID using the standard representation,
+    // when the  representation is actually non-standard
+    let error_msg = "expected binary subtype 4 when converting to UUID with the standard representation, instead got 0x03";
 
     if let Error::DeserializationError { message: msg } = bin.to_uuid().unwrap_err() {
         assert_eq!(
             msg,
-            "expecting binary subtype 4 for standard representation"
+            error_msg
         );
     }
 
@@ -520,7 +532,7 @@ fn test_binary_to_uuid_python_legacy_rep() {
     {
         assert_eq!(
             msg,
-            "expecting binary subtype 4 for standard representation"
+            error_msg
         );
     }
 

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use crate::{
-    bson::UuidRepresentation,
     doc,
     oid::ObjectId,
     spec::BinarySubtype,
@@ -18,7 +17,6 @@ use crate::{
     Timestamp,
 };
 use serde_json::{json, Value};
-use uuid::Uuid;
 
 #[test]
 fn to_json() {
@@ -351,6 +349,9 @@ fn debug_print() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_constructors() {
+    use bson::UuidRepresentation;
+    use uuid::Uuid;
+
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid(&uuid);
     assert_eq!(bin.bytes, uuid.as_bytes());
@@ -387,6 +388,9 @@ fn test_binary_constructors() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid() {
+    use bson::UuidRepresentation;
+    use uuid::Uuid;
+
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid(&uuid);
 
@@ -413,6 +417,9 @@ fn test_binary_to_uuid() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid_java_rep() {
+    use bson::UuidRepresentation;
+    use uuid::Uuid;
+
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid_with_representation(&uuid, UuidRepresentation::JavaLegacy);
     assert_eq!(
@@ -434,6 +441,9 @@ fn test_binary_to_uuid_java_rep() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid_csharp_legacy_rep() {
+    use bson::UuidRepresentation;
+    use uuid::Uuid;
+
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid_with_representation(&uuid, UuidRepresentation::CSharpLegacy);
     assert_eq!(
@@ -455,6 +465,9 @@ fn test_binary_to_uuid_csharp_legacy_rep() {
 #[cfg(feature = "uuid-0_8")]
 #[test]
 fn test_binary_to_uuid_python_legacy_rep() {
+    use bson::UuidRepresentation;
+    use uuid::Uuid;
+
     let uuid = Uuid::parse_str("00112233445566778899AABBCCDDEEFF").unwrap();
     let bin = Binary::from_uuid_with_representation(&uuid, UuidRepresentation::PythonLegacy);
     assert_eq!(


### PR DESCRIPTION
Refactor Binary serde implementation.  Add Binary constructors consistent with [specs](https://github.com/mongodb/specifications/blob/master/source/uuid.rst).