### PR TITLE
[De]sserialize u64 as string instead of failing if greater than i64::MAX 

### DIFF
--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -138,9 +138,10 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     fn serialize_u64(self, v: u64) -> Result<Self::Ok> {
         use std::convert::TryFrom;
 
-        match i64::try_from(v) {
-            Ok(ivalue) => self.serialize_i64(ivalue),
-            Err(_) => Err(Error::UnsignedIntegerExceededRange(v)),
+        if let Ok(ivalue) = i64::try_from(v) {
+            self.serialize_i64(ivalue)
+        } else {
+            self.serialize_str(&v.to_string())
         }
     }
 

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -1,13 +1,6 @@
 use serde::ser::{
-    self,
-    Serialize,
-    SerializeMap,
-    SerializeSeq,
-    SerializeStruct,
-    SerializeStructVariant,
-    SerializeTuple,
-    SerializeTupleStruct,
-    SerializeTupleVariant,
+    self, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
+    SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
 };
 use serde_bytes::Bytes;
 
@@ -172,9 +165,10 @@ impl ser::Serializer for Serializer {
     fn serialize_u64(self, value: u64) -> crate::ser::Result<Bson> {
         use std::convert::TryFrom;
 
-        match i64::try_from(value) {
-            Ok(ivalue) => Ok(Bson::Int64(ivalue)),
-            Err(_) => Err(Error::UnsignedIntegerExceededRange(value)),
+        if let Ok(ivalue) = i64::try_from(value) {
+            Ok(Bson::Int64(ivalue))
+        } else {
+            self.serialize_str(&value.to_string())
         }
     }
 

--- a/src/tests/modules/ser.rs
+++ b/src/tests/modules/ser.rs
@@ -109,11 +109,10 @@ fn uint64_u2i() {
     let deser_min: u64 = from_bson(obj_min).unwrap();
     assert_eq!(deser_min, u64::MIN);
 
-    let obj_max: ser::Result<Bson> = to_bson(&u64::MAX);
-    assert_matches!(
-        obj_max,
-        Err(ser::Error::UnsignedIntegerExceededRange(u64::MAX))
-    );
+    let obj_max = to_bson(&u64::MAX).unwrap();
+    assert_eq!(obj_max, Bson::String(u64::MAX.to_string()));
+    let deser_max: u64 = from_bson(obj_max).unwrap();
+    assert_eq!(deser_max, u64::MAX);
 }
 
 #[test]


### PR DESCRIPTION
It can be surprising that serializing `u64` values greater than `i64::MAX` fails. This MR [de]serializes these values as a string. 