### PR TITLE
deps: Remove `time` transitive dep from chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ name = "bson"
 
 [dependencies]
 ahash = "0.7.2"
-chrono = { version = "0.4.15", features = ["clock", "std"], default-features = false }
+chrono = { version = "0.4.15", features = ["std"], default-features = false }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ name = "bson"
 
 [dependencies]
 ahash = "0.7.2"
-chrono = "0.4.15"
+chrono = { version = "0.4.15", features = ["clock", "std"], default-features = false }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
@@ -59,7 +59,7 @@ criterion = "0.3.0"
 pretty_assertions = "0.6.1"
 proptest = "1.0.0"
 serde_bytes = "0.11"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde", "clock", "std"], default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Currently, [`chrono`](https://lib.rs/chrono) depends on a really old version of [`time`](https://lib.rs/time), which is affected by CVE-2020-26235.  
This dependency is withheld by the `oldtime` feature in `chrono`, which is enabled by default.

Unfortunately, Cargo doesn't support disabling specific default features just yet, so the only way to get rid of the default feature is to re-import them all.

Code-wise, all tests seem to pass and I couldn't find any re-exports of the `time` crate (or even `chrono`'s replacements, for that matter), so this shouldn't break the API.