### PR TITLE
RUST-977 Support RFC 3339 to `bson::DateTime` conversion without chrono feature flag

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -423,7 +423,7 @@ impl Bson {
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
             Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 99999 => {
                 json!({
-                    "$date": v.to_rfc3339(),
+                    "$date": v.to_rfc3339_string(),
                 })
             }
             Bson::DateTime(v) => json!({
@@ -573,7 +573,7 @@ impl Bson {
             }
             Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 9999 => {
                 doc! {
-                    "$date": v.to_rfc3339(),
+                    "$date": v.to_rfc3339_string(),
                 }
             }
             Bson::DateTime(v) => doc! {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -172,12 +172,13 @@ impl crate::DateTime {
             .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
     }
 
+    /// Convert the given RFC 3339 format string to a [`DateTime`].
     pub fn from_rfc3339(s: &str) -> Result<Self, crate::de::Error> {
         match chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s) {
-            Ok(d)  => Ok(Self::from_chrono(d)),
+            Ok(d) => Ok(Self::from_chrono(d)),
             Err(_) => Err(crate::de::Error::InvalidTimestamp {
-                message: format!("cannot convert {} to chrono::Datetime", s)
-            })
+                message: format!("cannot convert {} to chrono::Datetime", s),
+            }),
         }
     }
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -167,13 +167,14 @@ impl crate::DateTime {
         self.0
     }
 
-    pub(crate) fn to_rfc3339(self) -> String {
+    pub(crate) fn to_rfc3339_string(self) -> String {
         self.to_chrono()
             .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
     }
 
-    /// Convert the given RFC 3339 format string to a [`DateTime`].
-    pub fn from_rfc3339(s: impl AsRef<str>) -> Result<Self, crate::de::Error> {
+    /// Convert the given RFC 3339 format string to a [`DateTime`], truncating it to millisecond
+    /// precision.
+    pub fn parse_rfc3339_str(s: impl AsRef<str>) -> Result<Self, crate::de::Error> {
         match chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s.as_ref()) {
             Ok(d) => Ok(Self::from_chrono(d)),
             Err(e) => Err(crate::de::Error::InvalidTimestamp {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -167,12 +167,13 @@ impl crate::DateTime {
         self.0
     }
 
+    /// Convert this [`DateTime`] to an RFC 3339 formatted string.
     pub fn to_rfc3339_string(self) -> String {
         self.to_chrono()
             .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
     }
 
-    /// Convert the given RFC 3339 format string to a [`DateTime`], truncating it to millisecond
+    /// Convert the given RFC 3339 formatted string to a [`DateTime`], truncating it to millisecond
     /// precision.
     pub fn parse_rfc3339_str(s: impl AsRef<str>) -> Result<Self, crate::de::Error> {
         match chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s.as_ref()) {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -167,7 +167,7 @@ impl crate::DateTime {
         self.0
     }
 
-    pub(crate) fn to_rfc3339_string(self) -> String {
+    pub fn to_rfc3339_string(self) -> String {
         self.to_chrono()
             .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
     }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -173,11 +173,11 @@ impl crate::DateTime {
     }
 
     /// Convert the given RFC 3339 format string to a [`DateTime`].
-    pub fn from_rfc3339(s: &str) -> Result<Self, crate::de::Error> {
-        match chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s) {
+    pub fn from_rfc3339(s: impl AsRef<str>) -> Result<Self, crate::de::Error> {
+        match chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s.as_ref()) {
             Ok(d) => Ok(Self::from_chrono(d)),
-            Err(_) => Err(crate::de::Error::InvalidTimestamp {
-                message: format!("cannot convert {} to chrono::Datetime", s),
+            Err(e) => Err(crate::de::Error::InvalidTimestamp {
+                message: e.to_string(),
             }),
         }
     }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -171,6 +171,15 @@ impl crate::DateTime {
         self.to_chrono()
             .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
     }
+
+    pub fn from_rfc3339(s: &str) -> Result<Self, crate::de::Error> {
+        match chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s) {
+            Ok(d)  => Ok(Self::from_chrono(d)),
+            Err(_) => Err(crate::de::Error::InvalidTimestamp {
+                message: format!("cannot convert {} to chrono::Datetime", s)
+            })
+        }
+    }
 }
 
 impl fmt::Debug for crate::DateTime {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,5 +1,7 @@
 use std::{
+    error,
     fmt::{self, Display},
+    result,
     time::{Duration, SystemTime},
 };
 
@@ -175,13 +177,12 @@ impl crate::DateTime {
 
     /// Convert the given RFC 3339 formatted string to a [`DateTime`], truncating it to millisecond
     /// precision.
-    pub fn parse_rfc3339_str(s: impl AsRef<str>) -> Result<Self, crate::de::Error> {
-        match chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s.as_ref()) {
-            Ok(d) => Ok(Self::from_chrono(d)),
-            Err(e) => Err(crate::de::Error::InvalidTimestamp {
+    pub fn parse_rfc3339_str(s: impl AsRef<str>) -> Result<Self> {
+        let date = chrono::DateTime::<chrono::FixedOffset>::parse_from_rfc3339(s.as_ref())
+            .map_err(|e| Error::InvalidTimestamp {
                 message: e.to_string(),
-            }),
-        }
+            })?;
+        Ok(Self::from_chrono(date))
     }
 }
 
@@ -232,3 +233,27 @@ impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for crate::DateTime {
         Self::from_chrono(x)
     }
 }
+
+/// Errors that can occur during [`DateTime`] construction and generation.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Error returned when an invalid datetime format is provided to a conversion method.
+    #[non_exhaustive]
+    InvalidTimestamp { message: String },
+}
+
+/// Alias for `Result<T, DateTime::Error>`
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidTimestamp { message } => {
+                write!(fmt, "{}", message)
+            }
+        }
+    }
+}
+
+impl error::Error for Error {}

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -15,12 +15,6 @@ pub enum Error {
     /// while decoding a UTF-8 String from the input data.
     InvalidUtf8String(string::FromUtf8Error),
 
-    /// An error encountered during the conversion of one datetime format to another.
-    InvalidTimestamp {
-        /// A message describing the error.
-        message: String,
-    },
-
     /// While decoding a `Document` from bytes, an unexpected or unsupported element type was
     /// encountered.
     #[non_exhaustive]
@@ -61,7 +55,6 @@ impl fmt::Display for Error {
         match *self {
             Error::Io(ref inner) => inner.fmt(fmt),
             Error::InvalidUtf8String(ref inner) => inner.fmt(fmt),
-            Error::InvalidTimestamp { ref message } => message.fmt(fmt),
             Error::UnrecognizedDocumentElementType {
                 ref key,
                 element_type,

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -15,6 +15,12 @@ pub enum Error {
     /// while decoding a UTF-8 String from the input data.
     InvalidUtf8String(string::FromUtf8Error),
 
+    /// An error encountered during the conversion of one datetime format to another.
+    InvalidTimestamp {
+        /// A message describing the error.
+        message: String,
+    },
+
     /// While decoding a `Document` from bytes, an unexpected or unsupported element type was
     /// encountered.
     #[non_exhaustive]
@@ -55,6 +61,7 @@ impl fmt::Display for Error {
         match *self {
             Error::Io(ref inner) => inner.fmt(fmt),
             Error::InvalidUtf8String(ref inner) => inner.fmt(fmt),
+            Error::InvalidTimestamp { ref message } => message.fmt(fmt),
             Error::UnrecognizedDocumentElementType {
                 ref key,
                 element_type,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ pub use self::{
 #[macro_use]
 mod macros;
 mod bson;
-mod datetime;
+pub mod datetime;
 pub mod de;
 pub mod decimal128;
 pub mod document;

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -252,7 +252,7 @@ pub mod rfc3339_string_as_bson_datetime {
         D: Deserializer<'de>,
     {
         let date = DateTime::deserialize(deserializer)?;
-        Ok(date.to_rfc3339())
+        Ok(date.to_rfc3339_string())
     }
 
     /// Serializes an ISO string as a DateTime.
@@ -297,7 +297,7 @@ pub mod bson_datetime_as_rfc3339_string {
 
     /// Serializes a [`crate::DateTime`] as an RFC 3339 (ISO 8601) formatted string.
     pub fn serialize<S: Serializer>(val: &DateTime, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&val.to_rfc3339())
+        serializer.serialize_str(&val.to_rfc3339_string())
     }
 }
 

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -9,3 +9,13 @@ fn rfc3339_to_datetime() {
         crate::DateTime::from_chrono(date)
     );
 }
+
+#[test]
+fn invalid_rfc3339_to_datetime() {
+    let a = "2020-06-09T10:58:07-095Z";
+    let b = "2020-06-09T10:58:07.095";
+    let c = "2020-06-09T10:62:07.095Z";
+    assert!(crate::DateTime::from_rfc3339(a).is_err());
+    assert!(crate::DateTime::from_rfc3339(b).is_err());
+    assert!(crate::DateTime::from_rfc3339(c).is_err());
+}

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -1,17 +1,21 @@
+use crate::tests::LOCK;
 use std::str::FromStr;
 
 #[test]
 fn rfc3339_to_datetime() {
+    let _guard = LOCK.run_concurrently();
+
     let rfc = "2020-06-09T10:58:07.095Z";
     let date = chrono::DateTime::<chrono::Utc>::from_str(rfc).unwrap();
-    assert_eq!(
-        crate::DateTime::parse_rfc3339_str(rfc).unwrap(),
-        crate::DateTime::from_chrono(date)
-    );
+    let parsed = crate::DateTime::parse_rfc3339_str(rfc).unwrap();
+    assert_eq!(parsed, crate::DateTime::from_chrono(date));
+    assert_eq!(crate::DateTime::to_rfc3339_string(parsed), rfc);
 }
 
 #[test]
 fn invalid_rfc3339_to_datetime() {
+    let _guard = LOCK.run_concurrently();
+
     let a = "2020-06-09T10:58:07-095Z";
     let b = "2020-06-09T10:58:07.095";
     let c = "2020-06-09T10:62:07.095Z";

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -1,0 +1,11 @@
+use std::str::FromStr;
+
+#[test]
+fn rfc3339_to_datetime() {
+    let rfc = "2020-06-09T10:58:07.095Z";
+    let date = chrono::DateTime::<chrono::Utc>::from_str(rfc).unwrap();
+    assert_eq!(
+        crate::DateTime::from_rfc3339(rfc).unwrap(),
+        crate::DateTime::from_chrono(date)
+    );
+}

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -5,7 +5,7 @@ fn rfc3339_to_datetime() {
     let rfc = "2020-06-09T10:58:07.095Z";
     let date = chrono::DateTime::<chrono::Utc>::from_str(rfc).unwrap();
     assert_eq!(
-        crate::DateTime::from_rfc3339(rfc).unwrap(),
+        crate::DateTime::parse_rfc3339_str(rfc).unwrap(),
         crate::DateTime::from_chrono(date)
     );
 }
@@ -15,7 +15,7 @@ fn invalid_rfc3339_to_datetime() {
     let a = "2020-06-09T10:58:07-095Z";
     let b = "2020-06-09T10:58:07.095";
     let c = "2020-06-09T10:62:07.095Z";
-    assert!(crate::DateTime::from_rfc3339(a).is_err());
-    assert!(crate::DateTime::from_rfc3339(b).is_err());
-    assert!(crate::DateTime::from_rfc3339(c).is_err());
+    assert!(crate::DateTime::parse_rfc3339_str(a).is_err());
+    assert!(crate::DateTime::parse_rfc3339_str(b).is_err());
+    assert!(crate::DateTime::parse_rfc3339_str(c).is_err());
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod binary_subtype;
+mod datetime;
 mod modules;
 mod serde;
 mod spec;


### PR DESCRIPTION
[RUST-977](https://jira.mongodb.org/browse/RUST-977)

Add a method to convert a RFC 3339 formatting string to `bson::DateTime` even without the chrono feature flag.