### PR TITLE
RUST-1082 Implement `Serialize` and `Deserialize` for raw BSON types

### DIFF
--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -13,6 +13,11 @@ serde = { version = "1.0", features = ["derive"] }
 pretty_assertions = "0.6.1"
 hex = "0.4.2"
 
+[dev-dependencies]
+serde_json = "1"
+rmp-serde = "0.15"
+base64 = "0.13.0"
+
 [lib]
 name = "serde_tests"
 path = "lib.rs"

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -270,7 +270,7 @@ pub(crate) fn deserialize_bson_kvp<R: Read + ?Sized>(
 
 impl Binary {
     pub(crate) fn from_reader<R: Read>(mut reader: R) -> Result<Self> {
-        let len = read_i32(&mut reader)?;
+        let mut len = read_i32(&mut reader)?;
         if !(0..=MAX_BSON_SIZE).contains(&len) {
             return Err(Error::invalid_length(
                 len as usize,
@@ -278,21 +278,6 @@ impl Binary {
             ));
         }
         let subtype = BinarySubtype::from(read_u8(&mut reader)?);
-        Self::from_reader_with_len_and_payload(reader, len, subtype)
-    }
-
-    // TODO: RUST-976: call through to the RawBinary version of this instead of duplicating code
-    pub(crate) fn from_reader_with_len_and_payload<R: Read>(
-        mut reader: R,
-        mut len: i32,
-        subtype: BinarySubtype,
-    ) -> Result<Self> {
-        if !(0..=MAX_BSON_SIZE).contains(&len) {
-            return Err(Error::invalid_length(
-                len as usize,
-                &format!("binary length must be between 0 and {}", MAX_BSON_SIZE).as_str(),
-            ));
-        }
 
         // Skip length data in old binary.
         if let BinarySubtype::BinaryOld = subtype {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -345,7 +345,6 @@ impl<'a> RawBinary<'a> {
         // Skip length data in old binary.
         if let BinarySubtype::BinaryOld = subtype {
             let data_len = read_i32(&mut bytes)?;
-            println!("data_len={}", data_len);
 
             if data_len + 4 != len {
                 return Err(Error::invalid_length(

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -46,10 +46,10 @@ use ::serde::{
     Deserialize,
 };
 
-pub(crate) use self::{
-    raw::Deserializer as RawDeserializer,
-    serde::{convert_unsigned_to_signed_raw, BsonVisitor},
-};
+pub(crate) use self::serde::{convert_unsigned_to_signed_raw, BsonVisitor};
+
+#[cfg(test)]
+pub(crate) use self::raw::Deserializer as RawDeserializer;
 
 pub(crate) const MAX_BSON_SIZE: i32 = 16 * 1024 * 1024;
 pub(crate) const MIN_BSON_DOCUMENT_SIZE: i32 = 4 + 1; // 4 bytes for length, one byte for null terminator

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -46,7 +46,10 @@ use ::serde::{
     Deserialize,
 };
 
-pub(crate) use self::serde::{convert_unsigned_to_signed_raw, BsonVisitor};
+pub(crate) use self::{
+    raw::Deserializer as RawDeserializer,
+    serde::{convert_unsigned_to_signed_raw, BsonVisitor},
+};
 
 pub(crate) const MAX_BSON_SIZE: i32 = 16 * 1024 * 1024;
 pub(crate) const MIN_BSON_DOCUMENT_SIZE: i32 = 4 + 1; // 4 bytes for length, one byte for null terminator

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -643,6 +643,10 @@ impl<'d, 'de> serde::de::Deserializer<'de> for DocumentKeyDeserializer<'d, 'de> 
         }
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     forward_to_deserialize_any! {
         bool char str bytes byte_buf option unit unit_struct string
         identifier newtype_struct seq tuple tuple_struct struct map enum
@@ -663,6 +667,10 @@ impl<'de> serde::de::Deserializer<'de> for FieldDeserializer {
         V: serde::de::Visitor<'de>,
     {
         visitor.visit_borrowed_str(self.field_name)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 
     serde::forward_to_deserialize_any! {
@@ -750,6 +758,10 @@ impl<'de> serde::de::Deserializer<'de> for RawDocumentDeserializer<'de> {
         visitor.visit_borrowed_bytes(self.raw_doc.as_bytes())
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map struct option unit newtype_struct
@@ -818,6 +830,10 @@ impl<'de> serde::de::Deserializer<'de> for ObjectIdDeserializer {
         }
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map struct option unit newtype_struct
@@ -874,6 +890,10 @@ impl<'de> serde::de::Deserializer<'de> for Decimal128Deserializer {
         V: serde::de::Visitor<'de>,
     {
         visitor.visit_bytes(&self.0.bytes)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 
     serde::forward_to_deserialize_any! {
@@ -965,6 +985,10 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut TimestampDeserializer {
                 Err(Error::custom("timestamp fully deserialized already"))
             }
         }
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 
     serde::forward_to_deserialize_any! {
@@ -1065,6 +1089,10 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut DateTimeDeserializer {
                 Err(Error::custom("DateTime fully deserialized already"))
             }
         }
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 
     serde::forward_to_deserialize_any! {
@@ -1196,6 +1224,10 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut BinaryDeserializer<'de> {
         }
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map struct option unit newtype_struct
@@ -1325,6 +1357,10 @@ impl<'de, 'a, 'b> serde::de::Deserializer<'de> for &'b mut CodeWithScopeDeserial
         }
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map struct option unit newtype_struct
@@ -1430,6 +1466,10 @@ impl<'de, 'a, 'b> serde::de::Deserializer<'de> for &'b mut DbPointerDeserializer
         }
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map struct option unit newtype_struct
@@ -1533,6 +1573,10 @@ impl<'de, 'a, 'b> serde::de::Deserializer<'de> for &'b mut RegexDeserializer<'de
         }
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map struct option unit newtype_struct
@@ -1628,6 +1672,10 @@ impl<'de, 'a> serde::de::Deserializer<'de> for RawBsonDeserializer<'de> {
             BsonContent::Str(s) => visitor.visit_borrowed_str(s),
             BsonContent::Int32(i) => visitor.visit_i32(i),
         }
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 
     serde::forward_to_deserialize_any! {

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -693,7 +693,7 @@ struct RawDocumentAccess<'d> {
     /// Whether the first key has been deserialized yet or not.
     deserialized_first: bool,
 
-    /// Whether or not this document being deserialized is for anarray or not.
+    /// Whether or not this document being deserialized is for an array or not.
     array: bool,
 }
 

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -1060,7 +1060,7 @@ impl<'de, 'd> serde::de::MapAccess<'de> for BinaryAccess<'d, 'de> {
                 .map(Some),
             BinaryDeserializationStage::Bytes => seed
                 .deserialize(FieldDeserializer {
-                    field_name: "base64",
+                    field_name: "bytes",
                 })
                 .map(Some),
             BinaryDeserializationStage::Done => Ok(None),

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -13,17 +13,13 @@ use serde::{
 
 use crate::{
     oid::ObjectId,
-    raw::{RawBinary, RawBson, RAW_ARRAY_NEWTYPE, RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
+    raw::{RawBinary, RAW_ARRAY_NEWTYPE, RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
     spec::{BinarySubtype, ElementType},
     uuid::UUID_NEWTYPE_NAME,
-    Binary,
     Bson,
     DateTime,
-    DbPointer,
     Decimal128,
-    JavaScriptCodeWithScope,
     RawDocument,
-    Regex,
     Timestamp,
 };
 
@@ -1507,7 +1503,7 @@ impl<'de, 'a> RegexDeserializer<'de, 'a> {
 impl<'de, 'a, 'b> serde::de::Deserializer<'de> for &'b mut RegexDeserializer<'de, 'a> {
     type Error = Error;
 
-    fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'de>,
     {

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -447,6 +447,26 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 DeserializerHint::BinarySubtype(BinarySubtype::Uuid),
             ),
             RAW_BSON_NEWTYPE => self.deserialize_next(visitor, DeserializerHint::RawBson),
+            RAW_DOCUMENT_NEWTYPE => {
+                if self.current_type != ElementType::EmbeddedDocument {
+                    return Err(serde::de::Error::custom(format!(
+                        "expected raw document, instead got {:?}",
+                        self.current_type
+                    )));
+                }
+
+                self.deserialize_next(visitor, DeserializerHint::RawBson)
+            }
+            RAW_ARRAY_NEWTYPE => {
+                if self.current_type != ElementType::Array {
+                    return Err(serde::de::Error::custom(format!(
+                        "expected raw array, instead got {:?}",
+                        self.current_type
+                    )));
+                }
+
+                self.deserialize_next(visitor, DeserializerHint::RawBson)
+            }
             _ => visitor.visit_newtype_struct(self),
         }
     }

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -1082,9 +1082,12 @@ impl<'de> Deserialize<'de> for Binary {
     where
         D: de::Deserializer<'de>,
     {
-        match Bson::deserialize(deserializer)? {
+        match deserializer.deserialize_byte_buf(BsonVisitor)? {
             Bson::Binary(binary) => Ok(binary),
-            _ => Err(D::Error::custom("expecting Binary")),
+            d => Err(D::Error::custom(format!(
+                "expecting Binary but got {:?} instead",
+                d
+            ))),
         }
     }
 }

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -18,7 +18,7 @@ use serde::de::{
     VariantAccess,
     Visitor,
 };
-use serde_bytes::{ByteBuf, Bytes};
+use serde_bytes::ByteBuf;
 
 use crate::{
     bson::{Binary, Bson, DbPointer, JavaScriptCodeWithScope, Regex, Timestamp},

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -369,10 +369,7 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
                 "$regularExpression" => {
                     let re = visitor.next_value::<extjson::models::RegexBody>()?;
-                    return Ok(Bson::RegularExpression(Regex {
-                        pattern: re.pattern,
-                        options: re.options,
-                    }));
+                    return Ok(Bson::RegularExpression(Regex::new(re.pattern, re.options)));
                 }
 
                 "$dbPointer" => {

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -1,6 +1,6 @@
 //! [BSON Decimal128](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst) data type representation
 
-use std::fmt;
+use std::{array::TryFromSliceError, convert::TryInto, fmt};
 
 /// Struct representing a BSON Decimal128 type.
 ///
@@ -21,6 +21,13 @@ impl Decimal128 {
     /// Returns the raw byte representation of this `Decimal128`.
     pub fn bytes(&self) -> [u8; 128 / 8] {
         self.bytes
+    }
+
+    pub(crate) fn deserialize_from_slice<E: serde::de::Error>(
+        bytes: &[u8],
+    ) -> std::result::Result<Self, E> {
+        let arr: [u8; 128 / 8] = bytes.try_into().map_err(E::custom)?;
+        return Ok(Decimal128 { bytes: arr });
     }
 }
 

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -1,6 +1,6 @@
 //! [BSON Decimal128](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst) data type representation
 
-use std::{array::TryFromSliceError, convert::TryInto, fmt};
+use std::{convert::TryInto, fmt};
 
 /// Struct representing a BSON Decimal128 type.
 ///
@@ -27,7 +27,7 @@ impl Decimal128 {
         bytes: &[u8],
     ) -> std::result::Result<Self, E> {
         let arr: [u8; 128 / 8] = bytes.try_into().map_err(E::custom)?;
-        return Ok(Decimal128 { bytes: arr });
+        Ok(Decimal128 { bytes: arr })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ pub use self::{
     },
     decimal128::Decimal128,
     raw::{
-        RawArray, RawBinary, RawDbPointer, RawDocument, RawDocumentBuf, RawJavaScriptCodeWithScope,
+        RawArray, RawBinary, RawBson, RawDbPointer, RawDocument, RawDocumentBuf, RawJavaScriptCodeWithScope,
         RawRegex,
     },
     ser::{to_bson, to_document, to_vec, Serializer},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,16 +271,14 @@ pub use self::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
     de::{
-        from_bson,
-        from_document,
-        from_reader,
-        from_reader_utf8_lossy,
-        from_slice,
-        from_slice_utf8_lossy,
-        Deserializer,
+        from_bson, from_document, from_reader, from_reader_utf8_lossy, from_slice,
+        from_slice_utf8_lossy, Deserializer,
     },
     decimal128::Decimal128,
-    raw::{RawDocument, RawDocumentBuf, RawArray},
+    raw::{
+        RawArray, RawBinary, RawDbPointer, RawDocument, RawDocumentBuf, RawJavaScriptCodeWithScope,
+        RawRegex,
+    },
     ser::{to_bson, to_document, to_vec, Serializer},
     uuid::{Uuid, UuidRepresentation},
 };

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -270,12 +270,16 @@ impl<'a> Serialize for &'a RawArray {
             where
                 S: serde::Serializer,
             {
-                let mut seq = serializer.serialize_seq(None)?;
-                for v in self.0 {
-                    let v = v.map_err(serde::ser::Error::custom)?;
-                    seq.serialize_element(&v)?;
+                if serializer.is_human_readable() {
+                    let mut seq = serializer.serialize_seq(None)?;
+                    for v in self.0 {
+                        let v = v.map_err(serde::ser::Error::custom)?;
+                        seq.serialize_element(&v)?;
+                    }
+                    seq.end()
+                } else {
+                    serializer.serialize_bytes(self.0.as_bytes())
                 }
-                seq.end()
             }
         }
 

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -1,5 +1,7 @@
 use std::convert::TryFrom;
 
+use serde::Deserialize;
+
 use super::{
     error::{ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
     Error,
@@ -237,6 +239,21 @@ impl<'a> Iterator for RawArrayIter<'a> {
             Some(Ok((_, v))) => Some(Ok(v)),
             Some(Err(e)) => Some(Err(e)),
             None => None,
+        }
+    }
+}
+
+impl<'de: 'a, 'a> Deserialize<'de> for &'a RawArray {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match RawBson::deserialize(deserializer)? {
+            RawBson::Array(d) => Ok(d),
+            b => Err(serde::de::Error::custom(format!(
+                "expected raw array reference, instead got {:?}",
+                b
+            ))),
         }
     }
 }

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -690,8 +690,8 @@ impl<'a> Serialize for RawBinary<'a> {
 /// A BSON regex referencing raw bytes stored elsewhere.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RawRegex<'a> {
-    pub(super) pattern: &'a str,
-    pub(super) options: &'a str,
+    pub(crate) pattern: &'a str,
+    pub(crate) options: &'a str,
 }
 
 impl<'a> RawRegex<'a> {
@@ -726,7 +726,19 @@ impl<'a> Serialize for RawRegex<'a> {
     where
         S: serde::Serializer,
     {
-        todo!()
+        #[derive(Serialize)]
+        struct BorrowedRegexBody<'a> {
+            pattern: &'a str,
+            options: &'a str,
+        }
+
+        let mut state = serializer.serialize_struct("$regularExpression", 1)?;
+        let body = BorrowedRegexBody {
+            pattern: self.pattern,
+            options: self.options,
+        };
+        state.serialize_field("$regularExpression", &body)?;
+        state.end()
     }
 }
 

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -5,6 +5,7 @@ use serde_bytes::{ByteBuf, Bytes};
 
 use super::{Error, RawArray, RawDocument, Result};
 use crate::{
+    de::convert_unsigned_to_signed_raw,
     extjson,
     oid::{self, ObjectId},
     raw::{RAW_ARRAY_NEWTYPE, RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
@@ -304,28 +305,28 @@ impl<'de> Visitor<'de> for RawBsonVisitor {
     where
         E: serde::de::Error,
     {
-        crate::de::convert_unsigned_to_signed_raw(value.into())
+        convert_unsigned_to_signed_raw(value.into())
     }
 
     fn visit_u16<E>(self, value: u16) -> std::result::Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        crate::de::convert_unsigned_to_signed_raw(value.into())
+        convert_unsigned_to_signed_raw(value.into())
     }
 
     fn visit_u32<E>(self, value: u32) -> std::result::Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        crate::de::convert_unsigned_to_signed_raw(value.into())
+        convert_unsigned_to_signed_raw(value.into())
     }
 
     fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        crate::de::convert_unsigned_to_signed_raw(value)
+        convert_unsigned_to_signed_raw(value)
     }
 
     fn visit_bool<E>(self, v: bool) -> std::result::Result<Self::Value, E>

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -816,6 +816,21 @@ impl<'a> Serialize for RawDbPointer<'a> {
     where
         S: serde::Serializer,
     {
-        todo!()
+        #[derive(Serialize)]
+        struct BorrowedDbPointerBody<'a> {
+            #[serde(rename = "$ref")]
+            ref_ns: &'a str,
+
+            #[serde(rename = "$id")]
+            id: ObjectId,
+        }
+
+        let mut state = serializer.serialize_struct("$dbPointer", 1)?;
+        let body = BorrowedDbPointerBody {
+            ref_ns: self.namespace,
+            id: self.id,
+        };
+        state.serialize_field("$dbPointer", &body)?;
+        state.end()
     }
 }

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -1,18 +1,13 @@
 use std::convert::{TryFrom, TryInto};
 
-use serde::{
-    de::{MapAccess, Unexpected, Visitor},
-    ser::SerializeStruct,
-    Deserialize,
-    Serialize,
-};
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Serialize};
 use serde_bytes::{ByteBuf, Bytes};
 
 use super::{Error, RawArray, RawDocument, Result};
 use crate::{
     extjson,
     oid::{self, ObjectId},
-    raw::{RAW_ARRAY_NEWTYPE, RAW_BINARY_NEWTYPE, RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
+    raw::{RAW_ARRAY_NEWTYPE, RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
     spec::{BinarySubtype, ElementType},
     Bson,
     DateTime,

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -782,7 +782,10 @@ impl<'a> Serialize for RawJavaScriptCodeWithScope<'a> {
     where
         S: serde::Serializer,
     {
-        todo!()
+        let mut state = serializer.serialize_struct("$codeWithScope", 2)?;
+        state.serialize_field("$code", &self.code)?;
+        state.serialize_field("$scope", &self.scope)?;
+        state.end()
     }
 }
 

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -6,7 +6,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use serde_bytes::Bytes;
+use serde_bytes::{ByteBuf, Bytes};
 
 use super::{Error, RawArray, RawDocument, Result};
 use crate::{
@@ -397,7 +397,12 @@ impl<'de: 'a, 'a> Deserialize<'de> for RawBson<'a> {
                         let s: &str = map.next_value()?;
                         Ok(RawBson::Symbol(s))
                     }
-                    "$numberDecimalBytes" => Ok(RawBson::Decimal128(map.next_value()?)),
+                    "$numberDecimalBytes" => {
+                        let bytes = map.next_value::<ByteBuf>()?;
+                        return Ok(RawBson::Decimal128(Decimal128::deserialize_from_slice(
+                            &bytes,
+                        )?));
+                    }
                     "$regularExpression" => {
                         #[derive(Debug, Deserialize)]
                         struct BorrowedRegexBody<'a> {

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -534,11 +534,7 @@ impl<'a> Serialize for RawBson<'a> {
             }
             RawBson::RegularExpression(re) => re.serialize(serializer),
             RawBson::Timestamp(t) => t.serialize(serializer),
-            RawBson::Decimal128(d) => {
-                let mut state = serializer.serialize_struct("$numberDecimal", 1)?;
-                state.serialize_field("$numberDecimalBytes", Bytes::new(&d.bytes))?;
-                state.end()
-            }
+            RawBson::Decimal128(d) => d.serialize(serializer),
             RawBson::Undefined => {
                 let mut state = serializer.serialize_struct("$undefined", 1)?;
                 state.serialize_field("$undefined", &true)?;

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -245,260 +245,252 @@ impl<'a> RawBson<'a> {
     }
 }
 
+/// A visitor used to deserialize types backed by raw BSON.
+pub(crate) struct RawBsonVisitor;
+
+impl<'de> Visitor<'de> for RawBsonVisitor {
+    type Value = RawBson<'de>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "a raw BSON reference")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::String(v))
+    }
+
+    fn visit_borrowed_bytes<E>(self, bytes: &'de [u8]) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Binary(RawBinary {
+            bytes,
+            subtype: BinarySubtype::Generic,
+        }))
+    }
+
+    fn visit_i8<E>(self, v: i8) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Int32(v.into()))
+    }
+
+    fn visit_i16<E>(self, v: i16) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Int32(v.into()))
+    }
+
+    fn visit_i32<E>(self, v: i32) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Int32(v))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Int64(v))
+    }
+
+    fn visit_u8<E>(self, value: u8) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        crate::de::convert_unsigned_to_signed_raw(value.into())
+    }
+
+    fn visit_u16<E>(self, value: u16) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        crate::de::convert_unsigned_to_signed_raw(value.into())
+    }
+
+    fn visit_u32<E>(self, value: u32) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        crate::de::convert_unsigned_to_signed_raw(value.into())
+    }
+
+    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        crate::de::convert_unsigned_to_signed_raw(value)
+    }
+
+    fn visit_bool<E>(self, v: bool) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Boolean(v))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Double(v))
+    }
+
+    fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Null)
+    }
+
+    fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(RawBson::Null)
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let k = map
+            .next_key::<&str>()?
+            .ok_or_else(|| serde::de::Error::custom("expected a key when deserializing RawBson"))?;
+        match k {
+            "$oid" => {
+                let oid: ObjectId = map.next_value()?;
+                Ok(RawBson::ObjectId(oid))
+            }
+            "$symbol" => {
+                let s: &str = map.next_value()?;
+                Ok(RawBson::Symbol(s))
+            }
+            "$numberDecimalBytes" => {
+                let bytes = map.next_value::<ByteBuf>()?;
+                return Ok(RawBson::Decimal128(Decimal128::deserialize_from_slice(
+                    &bytes,
+                )?));
+            }
+            "$regularExpression" => {
+                #[derive(Debug, Deserialize)]
+                struct BorrowedRegexBody<'a> {
+                    pattern: &'a str,
+
+                    options: &'a str,
+                }
+                let body: BorrowedRegexBody = map.next_value()?;
+                Ok(RawBson::RegularExpression(RawRegex {
+                    pattern: body.pattern,
+                    options: body.options,
+                }))
+            }
+            "$undefined" => {
+                let _: bool = map.next_value()?;
+                Ok(RawBson::Undefined)
+            }
+            "$binary" => {
+                #[derive(Debug, Deserialize)]
+                struct BorrowedBinaryBody<'a> {
+                    bytes: &'a [u8],
+
+                    #[serde(rename = "subType")]
+                    subtype: u8,
+                }
+
+                let v = map.next_value::<BorrowedBinaryBody>()?;
+
+                Ok(RawBson::Binary(RawBinary {
+                    bytes: v.bytes,
+                    subtype: v.subtype.into(),
+                }))
+            }
+            "$date" => {
+                let v = map.next_value::<i64>()?;
+                Ok(RawBson::DateTime(DateTime::from_millis(v)))
+            }
+            "$timestamp" => {
+                let v = map.next_value::<extjson::models::TimestampBody>()?;
+                Ok(RawBson::Timestamp(Timestamp {
+                    time: v.t,
+                    increment: v.i,
+                }))
+            }
+            "$minKey" => {
+                let _ = map.next_value::<i32>()?;
+                Ok(RawBson::MinKey)
+            }
+            "$maxKey" => {
+                let _ = map.next_value::<i32>()?;
+                Ok(RawBson::MaxKey)
+            }
+            "$code" => {
+                let code = map.next_value::<&str>()?;
+                if let Some(key) = map.next_key::<&str>()? {
+                    if key == "$scope" {
+                        let scope = map.next_value::<&RawDocument>()?;
+                        Ok(RawBson::JavaScriptCodeWithScope(
+                            RawJavaScriptCodeWithScope { code, scope },
+                        ))
+                    } else {
+                        Err(serde::de::Error::unknown_field(key, &["$scope"]))
+                    }
+                } else {
+                    Ok(RawBson::JavaScriptCode(code))
+                }
+            }
+            "$dbPointer" => {
+                #[derive(Deserialize)]
+                struct BorrowedDbPointerBody<'a> {
+                    #[serde(rename = "$ref")]
+                    ns: &'a str,
+
+                    #[serde(rename = "$id")]
+                    id: ObjectId,
+                }
+
+                let body: BorrowedDbPointerBody = map.next_value()?;
+                Ok(RawBson::DbPointer(RawDbPointer {
+                    namespace: body.ns,
+                    id: body.id,
+                }))
+            }
+            RAW_DOCUMENT_NEWTYPE => {
+                let bson = map.next_value::<&[u8]>()?;
+                let doc = RawDocument::new(bson).map_err(serde::de::Error::custom)?;
+                Ok(RawBson::Document(doc))
+            }
+            RAW_ARRAY_NEWTYPE => {
+                let bson = map.next_value::<&[u8]>()?;
+                let doc = RawDocument::new(bson).map_err(serde::de::Error::custom)?;
+                Ok(RawBson::Array(RawArray::from_doc(doc)))
+            }
+            k => Err(serde::de::Error::custom(format!(
+                "can't deserialize RawBson from map, key={}",
+                k
+            ))),
+        }
+    }
+}
+
 impl<'de: 'a, 'a> Deserialize<'de> for RawBson<'a> {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        use serde::de::Error as SerdeError;
-
-        struct RawBsonVisitor;
-
-        impl<'de> Visitor<'de> for RawBsonVisitor {
-            type Value = RawBson<'de>;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(formatter, "a raw BSON reference")
-            }
-
-            fn visit_borrowed_str<E>(self, v: &'de str) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(RawBson::String(v))
-            }
-
-            fn visit_borrowed_bytes<E>(
-                self,
-                bytes: &'de [u8],
-            ) -> std::result::Result<Self::Value, E>
-            where
-                E: SerdeError,
-            {
-                Ok(RawBson::Binary(RawBinary {
-                    bytes,
-                    subtype: BinarySubtype::Generic,
-                }))
-            }
-
-            fn visit_i8<E>(self, v: i8) -> std::result::Result<Self::Value, E>
-            where
-                E: SerdeError,
-            {
-                Ok(RawBson::Int32(v.into()))
-            }
-
-            fn visit_i16<E>(self, v: i16) -> std::result::Result<Self::Value, E>
-            where
-                E: SerdeError,
-            {
-                Ok(RawBson::Int32(v.into()))
-            }
-
-            fn visit_i32<E>(self, v: i32) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(RawBson::Int32(v))
-            }
-
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(RawBson::Int64(v))
-            }
-
-            fn visit_u8<E>(self, value: u8) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                crate::de::convert_unsigned_to_signed_raw(value.into())
-            }
-
-            fn visit_u16<E>(self, value: u16) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                crate::de::convert_unsigned_to_signed_raw(value.into())
-            }
-
-            fn visit_u32<E>(self, value: u32) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                crate::de::convert_unsigned_to_signed_raw(value.into())
-            }
-
-            fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                crate::de::convert_unsigned_to_signed_raw(value)
-            }
-
-            fn visit_bool<E>(self, v: bool) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(RawBson::Boolean(v))
-            }
-
-            fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(RawBson::Double(v))
-            }
-
-            fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(RawBson::Null)
-            }
-
-            fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(RawBson::Null)
-            }
-
-            fn visit_newtype_struct<D>(
-                self,
-                deserializer: D,
-            ) -> std::result::Result<Self::Value, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                deserializer.deserialize_any(self)
-            }
-
-            // use extjson for: ObjectId, datetime, timestamp, symbol, minkey, maxkey
-            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                let k = map.next_key::<&str>()?.ok_or_else(|| {
-                    SerdeError::custom("expected a key when deserializing RawBson")
-                })?;
-                match k {
-                    "$oid" => {
-                        let oid: ObjectId = map.next_value()?;
-                        Ok(RawBson::ObjectId(oid))
-                    }
-                    "$symbol" => {
-                        let s: &str = map.next_value()?;
-                        Ok(RawBson::Symbol(s))
-                    }
-                    "$numberDecimalBytes" => {
-                        let bytes = map.next_value::<ByteBuf>()?;
-                        return Ok(RawBson::Decimal128(Decimal128::deserialize_from_slice(
-                            &bytes,
-                        )?));
-                    }
-                    "$regularExpression" => {
-                        #[derive(Debug, Deserialize)]
-                        struct BorrowedRegexBody<'a> {
-                            pattern: &'a str,
-
-                            options: &'a str,
-                        }
-                        let body: BorrowedRegexBody = map.next_value()?;
-                        Ok(RawBson::RegularExpression(RawRegex {
-                            pattern: body.pattern,
-                            options: body.options,
-                        }))
-                    }
-                    "$undefined" => {
-                        let _: bool = map.next_value()?;
-                        Ok(RawBson::Undefined)
-                    }
-                    "$binary" => {
-                        #[derive(Debug, Deserialize)]
-                        struct BorrowedBinaryBody<'a> {
-                            bytes: &'a [u8],
-
-                            #[serde(rename = "subType")]
-                            subtype: u8,
-                        }
-
-                        let v = map.next_value::<BorrowedBinaryBody>()?;
-
-                        Ok(RawBson::Binary(RawBinary {
-                            bytes: v.bytes,
-                            subtype: v.subtype.into(),
-                        }))
-                    }
-                    "$date" => {
-                        let v = map.next_value::<i64>()?;
-                        Ok(RawBson::DateTime(DateTime::from_millis(v)))
-                    }
-                    "$timestamp" => {
-                        let v = map.next_value::<extjson::models::TimestampBody>()?;
-                        Ok(RawBson::Timestamp(Timestamp {
-                            time: v.t,
-                            increment: v.i,
-                        }))
-                    }
-                    "$minKey" => {
-                        let _ = map.next_value::<i32>()?;
-                        Ok(RawBson::MinKey)
-                    }
-                    "$maxKey" => {
-                        let _ = map.next_value::<i32>()?;
-                        Ok(RawBson::MaxKey)
-                    }
-                    "$code" => {
-                        let code = map.next_value::<&str>()?;
-                        if let Some(key) = map.next_key::<&str>()? {
-                            if key == "$scope" {
-                                let scope = map.next_value::<&RawDocument>()?;
-                                Ok(RawBson::JavaScriptCodeWithScope(
-                                    RawJavaScriptCodeWithScope { code, scope },
-                                ))
-                            } else {
-                                Err(SerdeError::unknown_field(key, &["$scope"]))
-                            }
-                        } else {
-                            Ok(RawBson::JavaScriptCode(code))
-                        }
-                    }
-                    "$dbPointer" => {
-                        #[derive(Deserialize)]
-                        struct BorrowedDbPointerBody<'a> {
-                            #[serde(rename = "$ref")]
-                            ns: &'a str,
-
-                            #[serde(rename = "$id")]
-                            id: ObjectId,
-                        }
-
-                        let body: BorrowedDbPointerBody = map.next_value()?;
-                        Ok(RawBson::DbPointer(RawDbPointer {
-                            namespace: body.ns,
-                            id: body.id,
-                        }))
-                    }
-                    RAW_DOCUMENT_NEWTYPE => {
-                        let bson = map.next_value::<&[u8]>()?;
-                        let doc = RawDocument::new(bson).map_err(SerdeError::custom)?;
-                        Ok(RawBson::Document(doc))
-                    }
-                    RAW_ARRAY_NEWTYPE => {
-                        let bson = map.next_value::<&[u8]>()?;
-                        let doc = RawDocument::new(bson).map_err(SerdeError::custom)?;
-                        Ok(RawBson::Array(RawArray::from_doc(doc)))
-                    }
-                    k => Err(SerdeError::custom(format!(
-                        "can't deserialize RawBson from map, key={}",
-                        k
-                    ))),
-                }
-            }
-        }
-
         deserializer.deserialize_newtype_struct(RAW_BSON_NEWTYPE, RawBsonVisitor)
     }
 }

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -515,13 +515,13 @@ impl<'a> Serialize for &'a RawDocument {
         //     where
         //         S: serde::Serializer,
         //     {
-                let mut map = serializer.serialize_map(None)?;
-                for kvp in *self {
-                    let (k, v) = kvp.map_err(serde::ser::Error::custom)?;
-                    map.serialize_entry(k, &v)?;
-                }
-                map.end()
-            // }
+        let mut map = serializer.serialize_map(None)?;
+        for kvp in *self {
+            let (k, v) = kvp.map_err(serde::ser::Error::custom)?;
+            map.serialize_entry(k, &v)?;
+        }
+        map.end()
+        // }
         // }
 
         // serializer.serialize_newtype_struct(RAW_DOCUMENT_NEWTYPE, &KvpSerializer(self))

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -498,7 +498,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a RawDocument {
             RawBson::Document(d) => Ok(d),
 
             // For non-BSON formats, RawDocument gets serialized as bytes, so we need to deserialize
-            // from them here too. For BSON, the deserialzier will return an error if it
+            // from them here too. For BSON, the deserializier will return an error if it
             // sees the RAW_DOCUMENT_NEWTYPE but the next type isn't a document.
             RawBson::Binary(b) if b.subtype == BinarySubtype::Generic => {
                 RawDocument::new(b.bytes).map_err(serde::de::Error::custom)

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -508,23 +508,23 @@ impl<'a> Serialize for &'a RawDocument {
     where
         S: serde::Serializer,
     {
-        struct KvpSerializer<'a>(&'a RawDocument);
+        // struct KvpSerializer<'a>(&'a RawDocument);
 
-        impl<'a> Serialize for KvpSerializer<'a> {
-            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
+        // impl<'a> Serialize for KvpSerializer<'a> {
+        //     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        //     where
+        //         S: serde::Serializer,
+        //     {
                 let mut map = serializer.serialize_map(None)?;
-                for kvp in self.0 {
+                for kvp in *self {
                     let (k, v) = kvp.map_err(serde::ser::Error::custom)?;
                     map.serialize_entry(k, &v)?;
                 }
                 map.end()
-            }
-        }
+            // }
+        // }
 
-        serializer.serialize_newtype_struct(RAW_DOCUMENT_NEWTYPE, &KvpSerializer(self))
+        // serializer.serialize_newtype_struct(RAW_DOCUMENT_NEWTYPE, &KvpSerializer(self))
     }
 }
 

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -4,7 +4,7 @@ use std::{
     ops::Deref,
 };
 
-use serde::{de::Visitor, Deserialize, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
 
 use crate::{
     raw::{RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
@@ -152,6 +152,16 @@ impl<'de> Deserialize<'de> for RawDocumentBuf {
         // TODO: RUST-1045 implement visit_map to deserialize from arbitrary maps.
         let doc: &'de RawDocument = Deserialize::deserialize(deserializer)?;
         Ok(doc.to_owned())
+    }
+}
+
+impl Serialize for RawDocumentBuf {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let doc: &RawDocument = &self;
+        doc.serialize(serializer)
     }
 }
 

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -4,12 +4,9 @@ use std::{
     ops::Deref,
 };
 
-use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
-use crate::{
-    raw::{RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
-    Document,
-};
+use crate::Document;
 
 use super::{Error, ErrorKind, Iter, RawBson, RawDocument, Result};
 
@@ -160,7 +157,7 @@ impl Serialize for RawDocumentBuf {
     where
         S: serde::Serializer,
     {
-        let doc: &RawDocument = &self;
+        let doc: &RawDocument = self.deref();
         doc.serialize(serializer)
     }
 }

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -4,7 +4,12 @@ use std::{
     ops::Deref,
 };
 
-use crate::Document;
+use serde::{de::Visitor, Deserialize, Deserializer};
+
+use crate::{
+    raw::{RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
+    Document,
+};
 
 use super::{Error, ErrorKind, Iter, RawBson, RawDocument, Result};
 
@@ -136,6 +141,17 @@ impl RawDocumentBuf {
     /// ```
     pub fn into_vec(self) -> Vec<u8> {
         self.data
+    }
+}
+
+impl<'de> Deserialize<'de> for RawDocumentBuf {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // TODO: RUST-1045 implement visit_map to deserialize from arbitrary maps.
+        let doc: &'de RawDocument = Deserialize::deserialize(deserializer)?;
+        Ok(doc.to_owned())
     }
 }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -134,6 +134,8 @@ pub use self::{
     iter::Iter,
 };
 
+pub(crate) use self::bson::RawBsonVisitor;
+
 /// Special newtype name indicating that the type being (de)serialized is a raw BSON document.
 pub(crate) const RAW_DOCUMENT_NEWTYPE: &str = "$__private__bson_RawDocument";
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -143,9 +143,6 @@ pub(crate) const RAW_ARRAY_NEWTYPE: &str = "$__private__bson_RawArray";
 /// Special newtype name indicating that the type being (de)serialized is a raw BSON value.
 pub(crate) const RAW_BSON_NEWTYPE: &str = "$__private__bson_RawBson";
 
-/// Special newtype name indicating that the type being (de)serialized is a raw BSON value.
-pub(crate) const RAW_BINARY_NEWTYPE: &str = "$__private__bson_RawBinary";
-
 /// Given a u8 slice, return an i32 calculated from the first four bytes in
 /// little endian order.
 fn f64_from_slice(val: &[u8]) -> Result<f64> {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -134,6 +134,10 @@ pub use self::{
     iter::Iter,
 };
 
+pub(crate) const RAW_DOCUMENT_NEWTYPE: &str = "$__private__bson_RawDocument";
+pub(crate) const RAW_ARRAY_NEWTYPE: &str = "$__private__bson_RawArray";
+pub(crate) const RAW_BSON_NEWTYPE: &str = "$__private__bson_RawBson";
+
 /// Given a u8 slice, return an i32 calculated from the first four bytes in
 /// little endian order.
 fn f64_from_slice(val: &[u8]) -> Result<f64> {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -134,8 +134,13 @@ pub use self::{
     iter::Iter,
 };
 
+/// Special newtype name indicating that the type being (de)serialized is a raw BSON document.
 pub(crate) const RAW_DOCUMENT_NEWTYPE: &str = "$__private__bson_RawDocument";
+
+/// Special newtype name indicating that the type being (de)serialized is a raw BSON array.
 pub(crate) const RAW_ARRAY_NEWTYPE: &str = "$__private__bson_RawArray";
+
+/// Special newtype name indicating that the type being (de)serialized is a raw BSON value.
 pub(crate) const RAW_BSON_NEWTYPE: &str = "$__private__bson_RawBson";
 
 /// Given a u8 slice, return an i32 calculated from the first four bytes in

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -143,6 +143,9 @@ pub(crate) const RAW_ARRAY_NEWTYPE: &str = "$__private__bson_RawArray";
 /// Special newtype name indicating that the type being (de)serialized is a raw BSON value.
 pub(crate) const RAW_BSON_NEWTYPE: &str = "$__private__bson_RawBson";
 
+/// Special newtype name indicating that the type being (de)serialized is a raw BSON value.
+pub(crate) const RAW_BINARY_NEWTYPE: &str = "$__private__bson_RawBinary";
+
 /// Given a u8 slice, return an i32 calculated from the first four bytes in
 /// little endian order.
 fn f64_from_slice(val: &[u8]) -> Result<f64> {

--- a/src/raw/test/props.rs
+++ b/src/raw/test/props.rs
@@ -22,11 +22,7 @@ pub(crate) fn arbitrary_bson() -> impl Strategy<Value = Bson> {
         any::<i32>().prop_map(Bson::Int32),
         any::<i64>().prop_map(Bson::Int64),
         any::<(String, String)>().prop_map(|(pattern, options)| {
-            let mut chars: Vec<_> = options.chars().collect();
-            chars.sort_unstable();
-
-            let options: String = chars.into_iter().collect();
-            Bson::RegularExpression(Regex { pattern, options })
+            Bson::RegularExpression(Regex::new(pattern, options))
         }),
         any::<[u8; 12]>().prop_map(|bytes| Bson::ObjectId(crate::oid::ObjectId::from_bytes(bytes))),
         (arbitrary_binary_subtype(), any::<Vec<u8>>()).prop_map(|(subtype, bytes)| {

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -334,7 +334,6 @@ impl<'a> serde::Serializer for &'a mut Serializer {
 
     #[inline]
     fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        // println!("struct {}", name);
         let value_type = match name {
             "$oid" => Some(ValueType::ObjectId),
             "$date" => Some(ValueType::DateTime),

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -12,7 +12,7 @@ use self::value_serializer::{ValueSerializer, ValueType};
 
 use super::{write_binary, write_cstring, write_f64, write_i32, write_i64, write_string};
 use crate::{
-    raw::{RAW_ARRAY_NEWTYPE, RAW_BINARY_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
+    raw::{RAW_ARRAY_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
     ser::{Error, Result},
     spec::{BinarySubtype, ElementType},
     uuid::UUID_NEWTYPE_NAME,

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -205,6 +205,10 @@ impl<'a> serde::Serializer for &'a mut Serializer {
                 self.update_element_type(ElementType::EmbeddedDocument)?;
                 self.bytes.write_all(v)?;
             }
+            SerializerHint::RawArray => {
+                self.update_element_type(ElementType::Array)?;
+                self.bytes.write_all(v)?;
+            }
             _ => {
                 self.update_element_type(ElementType::Binary)?;
 

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -246,12 +246,8 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     where
         T: serde::Serialize,
     {
-        if name == UUID_NEWTYPE_NAME {
-            self.hint = SerializerHint::Uuid;
-        }
         match name {
             UUID_NEWTYPE_NAME => self.hint = SerializerHint::Uuid,
-            RAW_BINARY_NEWTYPE => self.hint = SerializerHint::RawBinary,
             _ => {}
         }
         value.serialize(self)
@@ -309,14 +305,13 @@ impl<'a> serde::Serializer for &'a mut Serializer {
 
     #[inline]
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        println!("map");
         self.update_element_type(ElementType::EmbeddedDocument)?;
         DocumentSerializer::start(&mut *self)
     }
 
     #[inline]
     fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        println!("struct {}", name);
+        // println!("struct {}", name);
         let value_type = match name {
             "$oid" => Some(ValueType::ObjectId),
             "$date" => Some(ValueType::DateTime),

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -12,7 +12,7 @@ use self::value_serializer::{ValueSerializer, ValueType};
 
 use super::{write_binary, write_cstring, write_f64, write_i32, write_i64, write_string};
 use crate::{
-    raw::RAW_BINARY_NEWTYPE,
+    raw::{RAW_ARRAY_NEWTYPE, RAW_BINARY_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
     ser::{Error, Result},
     spec::{BinarySubtype, ElementType},
     uuid::UUID_NEWTYPE_NAME,
@@ -37,8 +37,15 @@ pub(crate) struct Serializer {
 #[derive(Debug, Clone, Copy)]
 enum SerializerHint {
     None,
+
+    /// The next call to `serialize_bytes` is for the purposes of serializing a UUID.
     Uuid,
+
+    /// The next call to `serialize_bytes` is for the purposes of serializing a raw document.
     RawDocument,
+
+    /// The next call to `serialize_bytes` is for the purposes of serializing a raw array.
+    RawArray,
 }
 
 impl SerializerHint {
@@ -259,6 +266,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         match name {
             UUID_NEWTYPE_NAME => self.hint = SerializerHint::Uuid,
             RAW_DOCUMENT_NEWTYPE => self.hint = SerializerHint::RawDocument,
+            RAW_ARRAY_NEWTYPE => self.hint = SerializerHint::RawArray,
             _ => {}
         }
         value.serialize(self)

--- a/src/ser/raw/value_serializer.rs
+++ b/src/ser/raw/value_serializer.rs
@@ -470,7 +470,7 @@ impl<'a, 'b> SerializeStruct for &'b mut ValueSerializer<'a> {
                 self.state = SerializationStep::BinaryBytes;
                 value.serialize(&mut **self)?;
             }
-            (SerializationStep::BinaryBytes, "base64" | "bytes") => {
+            (SerializationStep::BinaryBytes, key) if key == "bytes" || key == "base64" => {
                 // state is updated in serialize
                 value.serialize(&mut **self)?;
             }

--- a/src/ser/raw/value_serializer.rs
+++ b/src/ser/raw/value_serializer.rs
@@ -256,8 +256,15 @@ impl<'a, 'b> serde::Serializer for &'b mut ValueSerializer<'a> {
             SerializationStep::Symbol | SerializationStep::DbPointerRef => {
                 write_string(&mut self.root_serializer.bytes, v)?;
             }
-            SerializationStep::RegExPattern | SerializationStep::RegExOptions => {
+            SerializationStep::RegExPattern => {
                 write_cstring(&mut self.root_serializer.bytes, v)?;
+            }
+            SerializationStep::RegExOptions => {
+                let mut chars: Vec<_> = v.chars().collect();
+                chars.sort_unstable();
+
+                let sorted = chars.into_iter().collect::<String>();
+                write_cstring(&mut self.root_serializer.bytes, sorted.as_str())?;
             }
             SerializationStep::Code => {
                 write_string(&mut self.root_serializer.bytes, v)?;

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -574,22 +574,17 @@ impl Serialize for Binary {
     where
         S: ser::Serializer,
     {
-        // if let BinarySubtype::Generic = self.subtype {
-        //     serializer.serialize_bytes(self.bytes.as_slice())
-        // } else {
-        //     let mut state = serializer.serialize_struct("$binary", 1)?;
-        //     let body = extjson::models::BinaryBody {
-        //         base64: base64::encode(self.bytes.as_slice()),
-        //         subtype: hex::encode([self.subtype.into()]),
-        //     };
-        //     state.serialize_field("$binary", &body)?;
-        //     state.end()
-        // }
-        let raw_binary = RawBinary {
-            bytes: self.bytes.as_slice(),
-            subtype: self.subtype,
-        };
-        raw_binary.serialize(serializer)
+        if let BinarySubtype::Generic = self.subtype {
+            serializer.serialize_bytes(self.bytes.as_slice())
+        } else {
+            let mut state = serializer.serialize_struct("$binary", 1)?;
+            let body = extjson::models::BinaryBody {
+                base64: base64::encode(self.bytes.as_slice()),
+                subtype: hex::encode([self.subtype.into()]),
+            };
+            state.serialize_field("$binary", &body)?;
+            state.end()
+        }
     }
 }
 

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -17,6 +17,7 @@ use crate::{
     datetime::DateTime,
     extjson,
     oid::ObjectId,
+    raw::RawBinary,
     spec::BinarySubtype,
     uuid::UUID_NEWTYPE_NAME,
     Binary,
@@ -575,17 +576,22 @@ impl Serialize for Binary {
     where
         S: ser::Serializer,
     {
-        if let BinarySubtype::Generic = self.subtype {
-            serializer.serialize_bytes(self.bytes.as_slice())
-        } else {
-            let mut state = serializer.serialize_struct("$binary", 1)?;
-            let body = extjson::models::BinaryBody {
-                base64: base64::encode(self.bytes.as_slice()),
-                subtype: hex::encode([self.subtype.into()]),
-            };
-            state.serialize_field("$binary", &body)?;
-            state.end()
-        }
+        // if let BinarySubtype::Generic = self.subtype {
+        //     serializer.serialize_bytes(self.bytes.as_slice())
+        // } else {
+        //     let mut state = serializer.serialize_struct("$binary", 1)?;
+        //     let body = extjson::models::BinaryBody {
+        //         base64: base64::encode(self.bytes.as_slice()),
+        //         subtype: hex::encode([self.subtype.into()]),
+        //     };
+        //     state.serialize_field("$binary", &body)?;
+        //     state.end()
+        // }
+        let raw_binary = RawBinary {
+            bytes: self.bytes.as_slice(),
+            subtype: self.subtype,
+        };
+        raw_binary.serialize(serializer)
     }
 }
 

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -17,7 +17,7 @@ use crate::{
     datetime::DateTime,
     extjson,
     oid::ObjectId,
-    raw::{RawBinary, RawRegex},
+    raw::{RawBinary, RawDbPointer, RawRegex},
     spec::BinarySubtype,
     uuid::UUID_NEWTYPE_NAME,
     Binary,
@@ -624,12 +624,10 @@ impl Serialize for DbPointer {
     where
         S: ser::Serializer,
     {
-        let mut state = serializer.serialize_struct("$dbPointer", 1)?;
-        let body = extjson::models::DbPointerBody {
-            ref_ns: self.namespace.clone(),
-            id: self.id.into(),
+        let raw = RawDbPointer {
+            namespace: self.namespace.as_str(),
+            id: self.id,
         };
-        state.serialize_field("$dbPointer", &body)?;
-        state.end()
+        raw.serialize(serializer)
     }
 }

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -17,7 +17,7 @@ use crate::{
     datetime::DateTime,
     extjson,
     oid::ObjectId,
-    raw::RawBinary,
+    raw::{RawBinary, RawRegex},
     spec::BinarySubtype,
     uuid::UUID_NEWTYPE_NAME,
     Binary,
@@ -547,13 +547,11 @@ impl Serialize for Regex {
     where
         S: ser::Serializer,
     {
-        let mut state = serializer.serialize_struct("$regularExpression", 1)?;
-        let body = extjson::models::RegexBody {
-            pattern: self.pattern.clone(),
-            options: self.options.clone(),
+        let raw = RawRegex {
+            pattern: self.pattern.as_str(),
+            options: self.options.as_str(),
         };
-        state.serialize_field("$regularExpression", &body)?;
-        state.end()
+        raw.serialize(serializer)
     }
 }
 

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -17,7 +17,7 @@ use crate::{
     datetime::DateTime,
     extjson,
     oid::ObjectId,
-    raw::{RawBinary, RawDbPointer, RawRegex},
+    raw::{RawDbPointer, RawRegex},
     spec::BinarySubtype,
     uuid::UUID_NEWTYPE_NAME,
     Binary,

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -11,7 +11,7 @@ use crate::{
     Document,
 };
 use pretty_assertions::assert_eq;
-use serde::{de::DeserializeSeed, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer};
 
 use super::run_spec_test;
 
@@ -189,7 +189,7 @@ fn run_test(test: TestFile) {
                 };
 
                 // deserialize the field from a Bson into a Bson
-                let mut deserializer_value_value =
+                let deserializer_value_value =
                     crate::Deserializer::new(Bson::Document(documentfromreader_cb.clone()));
                 let bson_field = deserializer_value_value
                     .deserialize_any(FieldVisitor(test_key.as_str(), PhantomData::<Bson>))


### PR DESCRIPTION
RUST-1082

This PR adds `Serialize` and `Deserialize` implementations for the raw BSON types.

e.g. the following is now possible:

``` rust
#[derive(Debug, Deserialize, Serialize)]
struct MyData<'a> {
    name: &'a str,

    #[serde(borrow)]
    binary: RawBinary<'a>,

    #[serde(borrow)]
    doc: &'a RawDocument,

    #[serde(borrow)]
    some_field: RawBson<'a>,
}
```

The implementations behave as follows:
- `&RawDocument`:
  - for human readable formats: iterate over document and serialize each kvp
  - for binary formats: serialize the document as a newtype around a slice of bytes.
      - The BSON serializers handle this by interpreting the name of the newtype
  - Open Question: should this use something like `{ "$rawBsonDocument": <bytes> }` for binary, non-BSON formats? This will allow `RawBson` to round trip, but that's about it.
- `RawDocumentBuf`: same as `RawDocument`. In a future PR it will be able to deserialize from arbitrary maps, but that requires the ability to append.
- `RawBson`:
  - Defer to the wrapped type
   - The types that map directly to the serde data model (e.g. integers) are deserialized as-is, similar to `Bson`.
    - For everything else, the extended JSON serde data model equivalent is used, also similar to `Bson`
        - for many types, the model needed to be changed a little bit to ensure to extra allocations are done
- `&RawArray`
  - Same as `&RawDocument`, but uses a different newtype name to signal an array.
- `RawJavaScriptCodeWithScope`
  - serialize to/from: `{ "$code": <borrowed string>, "$scope": <borrowed string> }`
- `RawDbPointer`
  - serialize to/from: `{ "$ref": <borrowed string>, "$id": <objectid> }`
- `ObjectId`
  - Same as before, but it can now also deserialize from `{ "$oid": <12 byte slice> }`
- `RawBinary`
  - On human readable platforms, serializes to ext JSON format in serde data model
  - On binary formats, serializes to `{ "$binary": { "bytes": <borrowed bytes>, subType: <u8> } }` in the serde data model
  - In both cases, the corresponding serializer handles it and correctly encodes as BSON
  - In order for `RawBinary` to round trip on non-BSON formats, the separate bytes model (rather than base64 string model) was required. It is also much faster.
  - Unfortunately, we can't also update `Binary` to exhibit this behavior, as it would technically be a breaking change.
- `RawRegex`:
  - serialize to/from extended JSON format but uses borrowed instead of owned strings
- `DateTime`: updated to also deserialize from `{ "$date": <i64> }` to avoid a string allocation during deserialization.
