### PR TITLE
minor: rename to_rfc3339

### DIFF
--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -252,7 +252,7 @@ fn datetime() {
         .expect("no key datetime")
         .as_datetime()
         .expect("result was not datetime");
-    assert_eq!(datetime.to_rfc3339(), "2000-10-31T12:30:45Z");
+    assert_eq!(datetime.to_rfc3339_string(), "2000-10-31T12:30:45Z");
 }
 
 #[test]


### PR DESCRIPTION
Changing a method call to `to_rfc3339` to correctly use `to_rfc3339_string` instead.