### PR TITLE
RUST-1022 Support configuring `Serializer` and `Deserializer` to be non-human-readable

### DIFF
--- a/serde-tests/options.rs
+++ b/serde-tests/options.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+
+use bson::{doc, Bson, DeserializerOptions, SerializerOptions};
+
+use serde::{
+    ser::{
+        SerializeMap,
+        SerializeSeq,
+        SerializeStruct,
+        SerializeStructVariant,
+        SerializeTupleStruct,
+        SerializeTupleVariant,
+    },
+    Deserialize,
+    Serialize,
+};
+
+/// Type whose serialize and deserialize implementations assert that the (de)serializer
+/// is not human readable.
+#[derive(Deserialize)]
+struct Foo {
+    a: i32,
+    unit: Unit,
+    tuple: Tuple,
+    map: Map,
+    unit_variant: Bar,
+    tuple_variant: Bar,
+    struct_variant: Bar,
+    seq: Seq,
+}
+
+impl Serialize for Foo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        assert!(!serializer.is_human_readable());
+
+        let mut state = serializer.serialize_struct("Foo", 7)?;
+        state.serialize_field("a", &self.a)?;
+        state.serialize_field("unit", &self.unit)?;
+        state.serialize_field("tuple", &self.tuple)?;
+        state.serialize_field("map", &self.map)?;
+        state.serialize_field("unit_variant", &self.unit_variant)?;
+        state.serialize_field("tuple_variant", &self.tuple_variant)?;
+        state.serialize_field("struct_variant", &self.struct_variant)?;
+        state.serialize_field("seq", &self.seq)?;
+        state.end()
+    }
+}
+
+#[derive(Deserialize)]
+enum Bar {
+    Unit,
+    Tuple(Unit),
+    Struct { a: Unit },
+}
+
+impl Serialize for Bar {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        assert!(!serializer.is_human_readable());
+        match self {
+            Self::Unit => serializer.serialize_unit_variant("Bar", 0, "Unit"),
+            Self::Tuple(t) => {
+                let mut state = serializer.serialize_tuple_variant("Bar", 1, "Tuple", 1)?;
+                state.serialize_field(t)?;
+                state.end()
+            }
+            Self::Struct { a } => {
+                let mut state = serializer.serialize_struct_variant("Foo", 2, "Struct", 1)?;
+                state.serialize_field("a", a)?;
+                state.end()
+            }
+        }
+    }
+}
+
+struct Unit;
+
+impl Serialize for Unit {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        assert!(!serializer.is_human_readable());
+        serializer.serialize_unit_struct("Unit")
+    }
+}
+
+impl<'de> Deserialize<'de> for Unit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        assert!(!deserializer.is_human_readable());
+        Ok(Unit)
+    }
+}
+
+#[derive(Deserialize)]
+struct Tuple(Unit);
+
+impl Serialize for Tuple {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        assert!(!serializer.is_human_readable());
+        let mut state = serializer.serialize_tuple_struct("Tuple", 1)?;
+        state.serialize_field(&self.0)?;
+        state.end()
+    }
+}
+
+struct Map {
+    map: HashMap<String, Unit>,
+}
+
+impl Serialize for Map {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        assert!(!serializer.is_human_readable());
+
+        let mut state = serializer.serialize_map(Some(self.map.len()))?;
+        for (k, v) in self.map.iter() {
+            state.serialize_entry(k, &v)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Map {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        assert!(!deserializer.is_human_readable());
+        let map = Deserialize::deserialize(deserializer)?;
+        Ok(Self { map })
+    }
+}
+
+struct Seq {
+    seq: Vec<Unit>,
+}
+
+impl Serialize for Seq {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        assert!(!serializer.is_human_readable());
+
+        let mut state = serializer.serialize_seq(Some(self.seq.len()))?;
+        for v in self.seq.iter() {
+            state.serialize_element(&v)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Seq {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        assert!(!deserializer.is_human_readable());
+        let v = Vec::<Unit>::deserialize(deserializer)?;
+        Ok(Self { seq: v })
+    }
+}
+
+#[test]
+fn to_bson_with_options() {
+    let options = SerializerOptions::builder().human_readable(false).build();
+
+    let mut hm = HashMap::new();
+    hm.insert("ok".to_string(), Unit);
+    hm.insert("other".to_string(), Unit);
+    let f = Foo {
+        a: 5,
+        unit: Unit,
+        tuple: Tuple(Unit),
+        unit_variant: Bar::Unit,
+        tuple_variant: Bar::Tuple(Unit),
+        struct_variant: Bar::Struct { a: Unit },
+        map: Map { map: hm },
+        seq: Seq {
+            seq: vec![Unit, Unit],
+        },
+    };
+    bson::to_bson_with_options(&f, options).unwrap();
+}
+
+#[test]
+fn from_bson_with_options() {
+    let options = DeserializerOptions::builder().human_readable(false).build();
+
+    let doc = doc! {
+        "a": 5,
+        "unit": Bson::Null,
+        "tuple": [Bson::Null],
+        "unit_variant": { "Unit": Bson::Null },
+        "tuple_variant": { "Tuple": [Bson::Null] },
+        "struct_variant": { "Struct": { "a": Bson::Null } },
+        "map": { "a": Bson::Null, "b": Bson::Null },
+        "seq": [Bson::Null, Bson::Null],
+    };
+
+    let _: Foo = bson::from_bson_with_options(doc.into(), options).unwrap();
+}

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -1264,7 +1264,7 @@ fn hint_cleared() {
 }
 
 #[test]
-fn raw_to_bson() {
+fn non_human_readable() {
     let bytes = vec![1, 2, 3, 4];
     let binary = RawBinary {
         bytes: &bytes,
@@ -1275,6 +1275,7 @@ fn raw_to_bson() {
     let doc = RawDocument::new(doc_bytes.as_slice()).unwrap();
     let arr = doc.get_array("array").unwrap();
     let oid = ObjectId::new();
+    let uuid = Uuid::new();
 
     #[derive(Debug, Deserialize, Serialize)]
     struct Foo<'a> {
@@ -1285,6 +1286,7 @@ fn raw_to_bson() {
         #[serde(borrow)]
         arr: &'a RawArray,
         oid: ObjectId,
+        uuid: Uuid,
     }
 
     let val = Foo {
@@ -1292,6 +1294,7 @@ fn raw_to_bson() {
         doc,
         arr,
         oid,
+        uuid
     };
 
     let human_readable = bson::to_bson(&val).unwrap();
@@ -1308,7 +1311,8 @@ fn raw_to_bson() {
             "array": [1, 2, 3],
         },
         "arr": [1, 2, 3],
-        "oid": oid
+        "oid": oid,
+        "uuid": uuid
     });
     assert_eq!(human_readable, expected);
     assert_eq!(human_readable, non_human_readable);

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -1294,7 +1294,7 @@ fn non_human_readable() {
         doc,
         arr,
         oid,
-        uuid
+        uuid,
     };
 
     let human_readable = bson::to_bson(&val).unwrap();

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::vec_init_then_push)]
 
+mod options;
+
 use pretty_assertions::assert_eq;
 use serde::{
     self,

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1062,19 +1062,30 @@ impl Display for Binary {
 
 impl Binary {
     pub(crate) fn from_extended_doc(doc: &Document) -> Option<Self> {
-        let binary = doc.get_document("$binary").ok()?;
-        let bytes = binary.get_str("base64").ok()?;
-        let bytes = base64::decode(bytes).ok()?;
-        let subtype = binary.get_str("subType").ok()?;
-        let subtype = hex::decode(subtype).ok()?;
+        let binary_doc = doc.get_document("$binary").ok()?;
 
-        if subtype.len() == 1 {
-            Some(Self {
-                bytes,
-                subtype: subtype[0].into(),
-            })
+        if let Some(bytes) = binary_doc.get_str("base64").ok() {
+            let bytes = base64::decode(bytes).ok()?;
+            let subtype = binary_doc.get_str("subType").ok()?;
+            let subtype = hex::decode(subtype).ok()?;
+            if subtype.len() == 1 {
+                Some(Self {
+                    bytes,
+                    subtype: subtype[0].into(),
+                })
+            } else {
+                None
+            }
         } else {
-            None
+            // in non-human-readable mode, RawBinary will serialize as
+            // { "$binary": { "bytes": <bytes>, "subType": <i32> } };
+            let binary = binary_doc.get_binary_generic("bytes").ok()?;
+            let subtype = binary_doc.get_i32("subType").ok()?;
+
+            Some(Self {
+                bytes: binary.clone(),
+                subtype: u8::try_from(subtype).ok()?.into(),
+            })
         }
     }
 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1064,7 +1064,7 @@ impl Binary {
     pub(crate) fn from_extended_doc(doc: &Document) -> Option<Self> {
         let binary_doc = doc.get_document("$binary").ok()?;
 
-        if let Some(bytes) = binary_doc.get_str("base64").ok() {
+        if let Ok(bytes) = binary_doc.get_str("base64") {
             let bytes = base64::decode(bytes).ok()?;
             let subtype = binary_doc.get_str("subType").ok()?;
             let subtype = hex::decode(subtype).ok()?;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -415,6 +415,13 @@ impl JavaScriptCodeWithScope {
 }
 
 /// Deserialize a `T` from the provided [`Bson`] value.
+///
+/// The `Deserializer` used by this function presents itself as human readable, whereas the
+/// one used in [`from_slice`] does not. This means that this function may deserialize differently
+/// than [`from_slice`] for types that change their deserialization logic depending on whether
+/// the format is human readable or not. To deserialize from [`Bson`] with a deserializer that
+/// presents itself as not human readable, use [`from_bson_with_options`] with
+/// [`DeserializerOptions::human_readable`] set to false.
 pub fn from_bson<T>(bson: Bson) -> Result<T>
 where
     T: DeserializeOwned,
@@ -425,6 +432,20 @@ where
 
 /// Deserialize a `T` from the provided [`Bson`] value, configuring the underlying
 /// deserializer with the provided options.
+/// ```
+/// # use serde::Deserialize;
+/// # use bson::{bson, DeserializerOptions};
+/// #[derive(Debug, Deserialize, PartialEq)]
+/// struct MyData {
+///     a: String,
+/// }
+///
+/// let bson = bson!({ "a": "hello" });
+/// let options = DeserializerOptions::builder().human_readable(false).build();
+/// let data: MyData = bson::from_bson_with_options(bson, options)?;
+/// assert_eq!(data, MyData { a: "hello".to_string() });
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub fn from_bson_with_options<T>(bson: Bson, options: DeserializerOptions) -> Result<T>
 where
     T: DeserializeOwned,
@@ -434,6 +455,13 @@ where
 }
 
 /// Deserialize a `T` from the provided [`Document`].
+///
+/// The `Deserializer` used by this function presents itself as human readable, whereas the
+/// one used in [`from_slice`] does not. This means that this function may deserialize differently
+/// than [`from_slice`] for types that change their deserialization logic depending on whether
+/// the format is human readable or not. To deserialize from [`Document`] with a deserializer that
+/// presents itself as not human readable, use [`from_document_with_options`] with
+/// [`DeserializerOptions::human_readable`] set to false.
 pub fn from_document<T>(doc: Document) -> Result<T>
 where
     T: DeserializeOwned,
@@ -443,6 +471,20 @@ where
 
 /// Deserialize a `T` from the provided [`Document`], configuring the underlying
 /// deserializer with the provided options.
+/// ```
+/// # use serde::Deserialize;
+/// # use bson::{doc, DeserializerOptions};
+/// #[derive(Debug, Deserialize, PartialEq)]
+/// struct MyData {
+///     a: String,
+/// }
+///
+/// let doc = doc! { "a": "hello" };
+/// let options = DeserializerOptions::builder().human_readable(false).build();
+/// let data: MyData = bson::from_document_with_options(doc, options)?;
+/// assert_eq!(data, MyData { a: "hello".to_string() });
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub fn from_document_with_options<T>(doc: Document, options: DeserializerOptions) -> Result<T>
 where
     T: DeserializeOwned,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -27,7 +27,7 @@ mod serde;
 
 pub use self::{
     error::{Error, Result},
-    serde::Deserializer,
+    serde::{Deserializer, DeserializerOptions},
 };
 
 use std::io::Read;
@@ -414,7 +414,7 @@ impl JavaScriptCodeWithScope {
     }
 }
 
-/// Decode a BSON `Value` into a `T` Deserializable.
+/// Deserialize a `T` from the provided [`Bson`] value.
 pub fn from_bson<T>(bson: Bson) -> Result<T>
 where
     T: DeserializeOwned,
@@ -423,12 +423,32 @@ where
     Deserialize::deserialize(de)
 }
 
-/// Decode a BSON `Document` into a `T` Deserializable.
+/// Deserialize a `T` from the provided [`Bson`] value, configuring the underlying
+/// deserializer with the provided options.
+pub fn from_bson_with_options<T>(bson: Bson, options: DeserializerOptions) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let de = Deserializer::new_with_options(bson, options);
+    Deserialize::deserialize(de)
+}
+
+/// Deserialize a `T` from the provided [`Document`].
 pub fn from_document<T>(doc: Document) -> Result<T>
 where
     T: DeserializeOwned,
 {
     from_bson(Bson::Document(doc))
+}
+
+/// Deserialize a `T` from the provided [`Document`], configuring the underlying
+/// deserializer with the provided options.
+pub fn from_document_with_options<T>(doc: Document, options: DeserializerOptions) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let de = Deserializer::new_with_options(Bson::Document(doc), options);
+    Deserialize::deserialize(de)
 }
 
 fn reader_to_vec<R: Read>(mut reader: R) -> Result<Vec<u8>> {

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -1179,7 +1179,7 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut BinaryDeserializer<'de> {
             BinaryDeserializationStage::Subtype => {
                 self.stage = BinaryDeserializationStage::Bytes;
                 match self.hint {
-                    DeserializerHint::RawBson => visitor.visit_u8(self.binary.subtype().into()),
+                    DeserializerHint::RawBson => visitor.visit_u8(self.binary.subtype.into()),
                     _ => visitor.visit_string(hex::encode([u8::from(self.binary.subtype)])),
                 }
             }

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -720,6 +720,19 @@ impl<'de> de::Deserializer<'de> for Deserializer {
     }
 
     #[inline]
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Some(Bson::ObjectId(oid)) if !self.is_human_readable() => {
+                visitor.visit_bytes(&oid.bytes())
+            }
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
+    #[inline]
     fn deserialize_option<V>(self, visitor: V) -> crate::de::Result<V::Value>
     where
         V: Visitor<'de>,
@@ -833,7 +846,6 @@ impl<'de> de::Deserializer<'de> for Deserializer {
         deserialize_string();
         deserialize_unit();
         deserialize_seq();
-        deserialize_bytes();
         deserialize_map();
         deserialize_unit_struct(name: &'static str);
         deserialize_tuple_struct(name: &'static str, len: usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,15 +271,18 @@ pub use self::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
     de::{
-        from_bson, from_document, from_reader, from_reader_utf8_lossy, from_slice,
-        from_slice_utf8_lossy, Deserializer,
+        from_bson, from_bson_with_options, from_document, from_document_with_options, from_reader, from_reader_utf8_lossy,
+        from_slice, from_slice_utf8_lossy, Deserializer, DeserializerOptions,
     },
     decimal128::Decimal128,
     raw::{
         RawArray, RawBinary, RawBson, RawDbPointer, RawDocument, RawDocumentBuf, RawJavaScriptCodeWithScope,
         RawRegex,
     },
-    ser::{to_bson, to_document, to_vec, Serializer},
+    ser::{
+        to_bson, to_bson_with_options, to_document, to_document_with_options, to_vec, Serializer,
+        SerializerOptions,
+    },
     uuid::{Uuid, UuidRepresentation},
 };
 

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -610,20 +610,11 @@ impl<'a> TryFrom<RawBson<'a>> for Bson {
 /// A BSON binary value referencing raw bytes stored elsewhere.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RawBinary<'a> {
-    pub(crate) subtype: BinarySubtype,
-    pub(crate) bytes: &'a [u8],
-}
+    /// The subtype of the binary value.
+    pub subtype: BinarySubtype,
 
-impl<'a> RawBinary<'a> {
-    /// Gets the subtype of the binary value.
-    pub fn subtype(self) -> BinarySubtype {
-        self.subtype
-    }
-
-    /// Gets the contained bytes of the binary value.
-    pub fn as_bytes(self) -> &'a [u8] {
-        self.bytes
-    }
+    /// The binary bytes.
+    pub bytes: &'a [u8],
 }
 
 impl<'de: 'a, 'a> Deserialize<'de> for RawBinary<'a> {

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -312,7 +312,7 @@ impl RawDocument {
     ///     "bool": true,
     /// })?;
     ///
-    /// assert_eq!(doc.get_binary("binary")?.as_bytes(), &[1, 2, 3][..]);
+    /// assert_eq!(&doc.get_binary("binary")?.bytes, &[1, 2, 3]);
     /// assert!(matches!(doc.get_binary("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
     /// assert!(matches!(doc.get_binary("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
     /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -191,7 +191,7 @@ pub(crate) fn serialize_bson<W: Write + ?Sized>(
 /// [`to_vec`] for types that change their serialization output depending on whether
 /// the format is human readable or not. To serialize to a [`Document`] with a serializer that
 /// presents itself as not human readable, use [`to_bson_with_options`] with
-/// [`SerializerOptions::is_human_readable`] set to false.
+/// [`SerializerOptions::human_readable`] set to false.
 pub fn to_bson<T: ?Sized>(value: &T) -> Result<Bson>
 where
     T: Serialize,
@@ -231,7 +231,7 @@ where
 /// [`to_vec`] for types that change their serialization output depending on whether
 /// the format is human readable or not. To serialize to a [`Document`] with a serializer that
 /// presents itself as not human readable, use [`to_document_with_options`] with
-/// [`SerializerOptions::is_human_readable`] set to false.
+/// [`SerializerOptions::human_readable`] set to false.
 pub fn to_document<T: ?Sized>(value: &T) -> Result<Document>
 where
     T: Serialize,


### PR DESCRIPTION
RUST-1022

This PR introduces two new options structs that enable users to configure `Serializer` and `Deserializer` (used in `to_bson` and `from_bson`) to be considered not-human-readable, just as the raw serializer/deserializer is (used in `to_vec` and `from_slice`). As part of that, several `to_x_with_options` functions were introduced. 