### PR TITLE
minor: fix `Binary` deserialization with `serde(flatten)`

### DIFF
--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -1082,7 +1082,7 @@ impl<'de> Deserialize<'de> for Binary {
     where
         D: de::Deserializer<'de>,
     {
-        match deserializer.deserialize_byte_buf(BsonVisitor)? {
+        match Bson::deserialize(deserializer)? {
             Bson::Binary(binary) => Ok(binary),
             d => Err(D::Error::custom(format!(
                 "expecting Binary but got {:?} instead",


### PR DESCRIPTION
This fixes an issue caused by some changes made in the raw BSON `Serialize`/`Deserialize` PR. I think the changes were meant as a minor improvement, but they accidentally broke deserialization of `Binary` in a `#[serde(flatten)]` chain. I've just gone ahead and reverted it to what it was before.