### PR TITLE
RUST-1024 Add `serde_with` integration for `Uuid` and `DateTime`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ default = []
 chrono-0_4 = []
 # if enabled, include API for interfacing with uuid 0.8
 uuid-0_8 = []
+# if enabled, include serde_with interop.
+# should be used in conjunction with chrono-0_4 or uuid-0_8.
+# it's commented out here because Cargo implicitly adds a feature flag for
+# all optional dependencies.
+# serde_with
 
 [lib]
 name = "bson"
@@ -52,6 +57,7 @@ base64 = "0.13.0"
 lazy_static = "1.4.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
+serde_with = { version = "1", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 
 #### Feature Flags
 
-| Feature      | Description                                                                            | Extra dependencies | Default |
-|:-------------|:---------------------------------------------------------------------------------------|:-------------------|:--------|
-| `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API. | n/a                | no      |
-| `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API.     | n/a                | no      |
+| Feature      | Description                                                                                         | Extra dependencies | Default |
+|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------|:--------|
+| `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API.              | n/a                | no      |
+| `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API.                  | n/a                | no      |
+| `serde_with` | Enable [`serde_with`](docs.rs/serde_with/latest) integrations for `bson::DateTime` and `bson::Uuid` | serde_with         | no      |
 
 ## Overview of the BSON Format
 

--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -6,16 +6,15 @@ edition = "2018"
 
 [features]
 default = []
-chrono-0_4 = ["chrono", "bson/chrono-0_4"]
-serde-with = ["serde_with", "bson/serde_with"]
 
 [dependencies]
-bson = { path = "..", default-features = false }
+bson = { path = "..", features = ["uuid-0_8", "chrono-0_4", "serde_with"] }
 serde = { version = "1.0", features = ["derive"] }
 pretty_assertions = "0.6.1"
 hex = "0.4.2"
-serde_with = { version = "1", optional = true }
-chrono = { version = "0.4", optional = true }
+serde_with = "1"
+chrono = "0.4"
+uuid = "0.8"
 
 [dev-dependencies]
 serde_json = "1"

--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -6,12 +6,16 @@ edition = "2018"
 
 [features]
 default = []
+chrono-0_4 = ["chrono", "bson/chrono-0_4"]
+serde-with = ["serde_with", "bson/serde_with"]
 
 [dependencies]
 bson = { path = "..", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 pretty_assertions = "0.6.1"
 hex = "0.4.2"
+serde_with = { version = "1", optional = true }
+chrono = { version = "0.4", optional = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -58,10 +58,6 @@ where
 
     let expected_bytes_serde = bson::to_vec(&expected_value).expect(description);
 
-    let e = Document::from_reader(expected_bytes.as_slice()).unwrap();
-    let es = Document::from_reader(expected_bytes_serde.as_slice()).unwrap();
-
-    assert_eq!(e, es, "{}", description);
     assert_eq!(expected_bytes_serde, expected_bytes, "{}", description);
 
     let expected_bytes_from_doc_serde = bson::to_vec(&expected_doc).expect(description);
@@ -1226,16 +1222,16 @@ fn serde_with_chrono() {
         none_bson: Option<chrono::DateTime<chrono::Utc>>,
     }
 
-    let foo = Foo {
+    let f = Foo {
         as_bson: Some(bson::DateTime::now().into()),
         none_bson: None,
     };
     let expected = doc! {
-        "as_bson": Bson::DateTime(foo.as_bson.unwrap().into()),
+        "as_bson": Bson::DateTime(f.as_bson.unwrap().into()),
         "none_bson": Bson::Null
     };
 
-    run_test(&foo, &expected, "serde_with - chrono");
+    run_test(&f, &expected, "serde_with - chrono");
 }
 
 #[test]
@@ -1250,16 +1246,16 @@ fn serde_with_uuid() {
         none_bson: Option<uuid::Uuid>,
     }
 
-    let foo = Foo {
+    let f = Foo {
         as_bson: Some(uuid::Uuid::new_v4()),
         none_bson: None,
     };
     let expected = doc! {
-        "as_bson": bson::Uuid::from(foo.as_bson.unwrap()),
+        "as_bson": bson::Uuid::from(f.as_bson.unwrap()),
         "none_bson": Bson::Null
     };
 
-    run_test(&foo, &expected, "serde_with - uuid");
+    run_test(&f, &expected, "serde_with - uuid");
 }
 
 #[test]

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -1214,7 +1214,6 @@ fn u2i() {
     bson::to_vec(&v).unwrap_err();
 }
 
-#[cfg(all(feature = "chrono-0_4", feature = "serde_with"))]
 #[test]
 fn serde_with_chrono() {
     #[serde_with::serde_as]
@@ -1237,6 +1236,30 @@ fn serde_with_chrono() {
     };
 
     run_test(&foo, &expected, "serde_with - chrono");
+}
+
+#[test]
+fn serde_with_uuid() {
+    #[serde_with::serde_as]
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    struct Foo {
+        #[serde_as(as = "Option<bson::Uuid>")]
+        as_bson: Option<uuid::Uuid>,
+
+        #[serde_as(as = "Option<bson::Uuid>")]
+        none_bson: Option<uuid::Uuid>,
+    }
+
+    let foo = Foo {
+        as_bson: Some(uuid::Uuid::new_v4()),
+        none_bson: None,
+    };
+    let expected = doc! {
+        "as_bson": bson::Uuid::from(foo.as_bson.unwrap()),
+        "none_bson": Bson::Null
+    };
+
+    run_test(&foo, &expected, "serde_with - uuid");
 }
 
 #[test]

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -5,6 +5,10 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(all(feature = "serde_with", feature = "chrono-0_4"))]
+use serde_with::{DeserializeAs, SerializeAs};
+
 use chrono::{LocalResult, TimeZone, Utc};
 
 /// Struct representing a BSON datetime.
@@ -231,6 +235,33 @@ impl From<crate::DateTime> for chrono::DateTime<Utc> {
 impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for crate::DateTime {
     fn from(x: chrono::DateTime<T>) -> Self {
         Self::from_chrono(x)
+    }
+}
+
+#[cfg(all(feature = "chrono-0_4", feature = "serde_with"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "chrono-0_4", feature = "serde_with"))))]
+impl<'de> DeserializeAs<'de, chrono::DateTime<Utc>> for crate::DateTime {
+    fn deserialize_as<D>(deserializer: D) -> std::result::Result<chrono::DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let dt = DateTime::deserialize(deserializer)?;
+        Ok(dt.to_chrono())
+    }
+}
+
+#[cfg(all(feature = "chrono-0_4", feature = "serde_with"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "chrono-0_4", feature = "chrono-0_4"))))]
+impl SerializeAs<chrono::DateTime<Utc>> for crate::DateTime {
+    fn serialize_as<S>(
+        source: &chrono::DateTime<Utc>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let dt = DateTime::from_chrono(*source);
+        dt.serialize(serializer)
     }
 }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+#[cfg(all(feature = "serde_with", feature = "chrono-0_4"))]
 use serde::{Deserialize, Deserializer, Serialize};
 #[cfg(all(feature = "serde_with", feature = "chrono-0_4"))]
 use serde_with::{DeserializeAs, SerializeAs};

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -59,6 +59,40 @@ use chrono::{LocalResult, TimeZone, Utc};
 /// }
 /// # }
 /// ```
+/// ## The `serde_with` feature flag
+///
+/// The `serde_with` feature can be enabled to support more ergonomic serde attributes for
+/// (de)serializing `chrono::DateTime` from/to BSON via the [`serde_with`](https://docs.rs/serde_with/1.11.0/serde_with/)
+/// crate. The main benefit of this compared to the regular `serde_helpers` is that `serde_with` can
+/// handle nested `chrono::DateTime` values (e.g. in `Option`), whereas the former only works on
+/// fields that are exactly `chrono::DateTime`.
+/// ```
+/// # #[cfg(all(feature = "chrono-0_4", feature = "serde_with"))]
+/// # {
+/// use serde::{Deserialize, Serialize};
+/// use bson::doc;
+///
+/// #[serde_with::serde_as]
+/// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+/// struct Foo {
+///   /// Serializes as a BSON datetime rather than using `chrono::DateTime`'s serialization
+///   #[serde_as(as = "Option<bson::DateTime>")]
+///   as_bson: Option<chrono::DateTime<chrono::Utc>>,
+/// }
+///
+/// let dt = chrono::Utc::now();
+/// let foo = Foo {
+///   as_bson: Some(dt),
+/// };
+///
+/// let expected = doc! {
+///   "as_bson": bson::DateTime::from_chrono(dt),
+/// };
+///
+/// assert_eq!(bson::to_document(&foo)?, expected);
+/// # }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Copy, Clone)]
 pub struct DateTime(i64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,11 @@
 //!
 //! #### Feature Flags
 //!
-//! | Feature      | Description                                                                            | Extra dependencies | Default |
-//! |:-------------|:---------------------------------------------------------------------------------------|:-------------------|:--------|
-//! | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API. | n/a                | no      |
-//! | `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API.     | n/a                | no      |
+//! | Feature      | Description                                                                                         | Extra dependencies | Default |
+//! |:-------------|:----------------------------------------------------------------------------------------------------|:-------------------|:--------|
+//! | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API.              | n/a                | no      |
+//! | `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API.                  | n/a                | no      |
+//! | `serde_with` | Enable [`serde_with`](docs.rs/serde_with/latest) integrations for `bson::DateTime` and `bson::Uuid` | serde_with         | no      |
 //!
 //! ## BSON values
 //!

--- a/src/uuid/mod.rs
+++ b/src/uuid/mod.rs
@@ -69,6 +69,40 @@
 //! # };
 //! ```
 //!
+//! ## The `serde_with` feature flag
+//!
+//! The `serde_with` feature can be enabled to support more ergonomic serde attributes for
+//! (de)serializing `uuid::Uuid` from/to BSON via the [`serde_with`](https://docs.rs/serde_with/1.11.0/serde_with/)
+//! crate. The main benefit of this compared to the regular `serde_helpers` is that `serde_with` can
+//! handle nested `uuid::Uuid` values (e.g. in `Option`), whereas the former only works on fields
+//! that are exactly `uuid::Uuid`.
+//! ```
+//! # #[cfg(all(feature = "uuid-0_8", feature = "serde_with"))]
+//! # {
+//! use serde::{Deserialize, Serialize};
+//! use bson::doc;
+//!
+//! #[serde_with::serde_as]
+//! #[derive(Deserialize, Serialize, PartialEq, Debug)]
+//! struct Foo {
+//!   /// Serializes as a BSON binary rather than using `uuid::Uuid`'s serialization
+//!   #[serde_as(as = "Option<bson::Uuid>")]
+//!   as_bson: Option<uuid::Uuid>,
+//! }
+//!
+//! let foo = Foo {
+//!   as_bson: Some(uuid::Uuid::new_v4()),
+//! };
+//!
+//! let expected = doc! {
+//!   "as_bson": bson::Uuid::from(foo.as_bson.unwrap()),
+//! };
+//!
+//! assert_eq!(bson::to_document(&foo)?, expected);
+//! # }
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
 //! ## Using `crate::Uuid` with non-BSON formats
 //!
 //! [`crate::Uuid`]'s `serde` implementation is the same as `uuid::Uuid`'s

--- a/src/uuid/mod.rs
+++ b/src/uuid/mod.rs
@@ -413,6 +413,30 @@ impl From<uuid::Uuid> for Binary {
     }
 }
 
+#[cfg(all(feature = "uuid-0_8", feature = "serde_with"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "uuid-0_8", feature = "serde_with"))))]
+impl<'de> serde_with::DeserializeAs<'de, uuid::Uuid> for crate::Uuid {
+    fn deserialize_as<D>(deserializer: D) -> std::result::Result<uuid::Uuid, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let uuid = Uuid::deserialize(deserializer)?;
+        Ok(uuid.into())
+    }
+}
+
+#[cfg(all(feature = "uuid-0_8", feature = "serde_with"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "uuid-0_8", feature = "sere_with"))))]
+impl serde_with::SerializeAs<uuid::Uuid> for crate::Uuid {
+    fn serialize_as<S>(source: &uuid::Uuid, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let uuid = Uuid::from_external_uuid(*source);
+        uuid.serialize(serializer)
+    }
+}
+
 /// Errors that can occur during [`Uuid`] construction and generation.
 #[derive(Clone, Debug)]
 #[non_exhaustive]


### PR DESCRIPTION
RUST-1024

This PR adds support for serializing/deserializing `uuid::Uuid` and `chrono::DateTime` as `bson::Uuid` and `bson::DateTime` respectively. This improves upon the existing serde helpers by including support for nested types, such as `Option<uuid::Uuid>`.