### PR TITLE
minor: hide work-in-progress raw BSON API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,20 +272,19 @@ pub use self::{
     bson::{Array, Binary, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},
     datetime::DateTime,
     de::{
-        from_bson, from_bson_with_options, from_document, from_document_with_options, from_reader, from_reader_utf8_lossy,
-        from_slice, from_slice_utf8_lossy, Deserializer, DeserializerOptions,
+        from_bson, from_bson_with_options, from_document, from_document_with_options, from_reader,
+        from_reader_utf8_lossy, from_slice, from_slice_utf8_lossy, Deserializer,
+        DeserializerOptions,
     },
     decimal128::Decimal128,
-    raw::{
-        RawArray, RawBinary, RawBson, RawDbPointer, RawDocument, RawDocumentBuf, RawJavaScriptCodeWithScope,
-        RawRegex,
-    },
     ser::{
         to_bson, to_bson_with_options, to_document, to_document_with_options, to_vec, Serializer,
         SerializerOptions,
     },
     uuid::{Uuid, UuidRepresentation},
 };
+
+pub(crate) use self::raw::RawDocument;
 
 #[macro_use]
 mod macros;
@@ -296,7 +295,7 @@ pub mod decimal128;
 pub mod document;
 pub mod extjson;
 pub mod oid;
-pub mod raw;
+pub(crate) mod raw;
 pub mod ser;
 pub mod serde_helpers;
 pub mod spec;

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -33,43 +33,10 @@ use crate::{
 /// Iterating over a [`RawArray`] yields either an error or a value that borrows from the
 /// original document without making any additional allocations.
 ///
-/// ```
-/// use bson::{doc, raw::RawDocument};
-///
-/// let doc = doc! {
-///     "x": [1, true, "two", 5.5]
-/// };
-/// let bytes = bson::to_vec(&doc)?;
-///
-/// let rawdoc = RawDocument::new(bytes.as_slice())?;
-/// let rawarray = rawdoc.get_array("x")?;
-///
-/// for v in rawarray {
-///     println!("{:?}", v?);
-/// }
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
-///
 /// Individual elements can be accessed using [`RawArray::get`] or any of
 /// the type-specific getters, such as [`RawArray::get_object_id`] or
 /// [`RawArray::get_str`]. Note that accessing elements is an O(N) operation, as it
 /// requires iterating through the array from the beginning to find the requested index.
-///
-/// ```
-/// # use bson::raw::{ValueAccessError};
-/// use bson::{doc, raw::RawDocument};
-///
-/// let doc = doc! {
-///     "x": [1, true, "two", 5.5]
-/// };
-/// let bytes = bson::to_vec(&doc)?;
-///
-/// let rawdoc = RawDocument::new(bytes.as_slice())?;
-/// let rawarray = rawdoc.get_array("x")?;
-///
-/// assert_eq!(rawarray.get_bool(1)?, true);
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
 #[derive(PartialEq)]
 #[repr(transparent)]
 pub struct RawArray {

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -39,31 +39,11 @@ use crate::{oid::ObjectId, spec::ElementType, Document};
 ///
 /// Iterating over a [`RawDocument`] yields either an error or a key-value pair that borrows from
 /// the original document without making any additional allocations.
-/// ```
-/// # use bson::raw::{Error};
-/// use bson::raw::RawDocument;
-///
-/// let doc = RawDocument::new(b"\x13\x00\x00\x00\x02hi\x00\x06\x00\x00\x00y'all\x00\x00")?;
-/// let mut iter = doc.into_iter();
-/// let (key, value) = iter.next().unwrap()?;
-/// assert_eq!(key, "hi");
-/// assert_eq!(value.as_str(), Some("y'all"));
-/// assert!(iter.next().is_none());
-/// # Ok::<(), Error>(())
-/// ```
 ///
 /// Individual elements can be accessed using [`RawDocument::get`] or any of
 /// the type-specific getters, such as [`RawDocument::get_object_id`] or
 /// [`RawDocument::get_str`]. Note that accessing elements is an O(N) operation, as it
 /// requires iterating through the document from the beginning to find the requested key.
-///
-/// ```
-/// use bson::raw::RawDocument;
-///
-/// let doc = RawDocument::new(b"\x13\x00\x00\x00\x02hi\x00\x06\x00\x00\x00y'all\x00\x00")?;
-/// assert_eq!(doc.get_str("hi")?, "y'all");
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
 #[derive(PartialEq)]
 #[repr(transparent)]
 pub struct RawDocument {
@@ -82,13 +62,6 @@ impl RawDocument {
     /// BSON elements is _not_ validated at all by this method. If the
     /// bytes do not conform to the BSON spec, then method calls on
     /// the [`RawDocument`] will return Errors where appropriate.
-    ///
-    /// ```
-    /// use bson::raw::RawDocument;
-    ///
-    /// let doc = RawDocument::new(b"\x05\0\0\0\0")?;
-    /// # Ok::<(), bson::raw::Error>(())
-    /// ```
     pub fn new<D: AsRef<[u8]> + ?Sized>(data: &D) -> Result<&RawDocument> {
         let data = data.as_ref();
 
@@ -139,14 +112,6 @@ impl RawDocument {
     }
 
     /// Creates a new [`RawDocument`] with an owned copy of the BSON bytes.
-    ///
-    /// ```
-    /// use bson::raw::{RawDocument, RawDocumentBuf, Error};
-    ///
-    /// let data = b"\x05\0\0\0\0";
-    /// let doc_ref = RawDocument::new(data)?;
-    /// let doc: RawDocumentBuf = doc_ref.to_raw_document_buf();
-    /// # Ok::<(), Error>(())
     pub fn to_raw_document_buf(&self) -> RawDocumentBuf {
         // unwrap is ok here because we already verified the bytes in `RawDocumentRef::new`
         RawDocumentBuf::new(self.data.to_owned()).unwrap()
@@ -154,21 +119,6 @@ impl RawDocument {
 
     /// Gets a reference to the value corresponding to the given key by iterating until the key is
     /// found.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, oid::ObjectId, raw::{RawDocumentBuf, RawBson}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "_id": ObjectId::new(),
-    ///     "f64": 2.5,
-    /// })?;
-    ///
-    /// let element = doc.get("f64")?.expect("finding key f64");
-    /// assert_eq!(element.as_f64(), Some(2.5));
-    /// assert!(doc.get("unknown")?.is_none());
-    /// # Ok::<(), Error>(())
-    /// ```
     pub fn get(&self, key: impl AsRef<str>) -> Result<Option<RawBson<'_>>> {
         for result in self.into_iter() {
             let (k, v) = result?;
@@ -211,279 +161,77 @@ impl RawDocument {
 
     /// Gets a reference to the BSON double value corresponding to a given key or returns an error
     /// if the key corresponds to a value which isn't a double.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::raw::{ValueAccessErrorKind, RawDocumentBuf};
-    /// use bson::doc;
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "bool": true,
-    ///     "f64": 2.5,
-    /// })?;
-    ///
-    /// assert_eq!(doc.get_f64("f64")?, 2.5);
-    /// assert!(matches!(doc.get_f64("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_f64("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_f64(&self, key: impl AsRef<str>) -> ValueAccessResult<f64> {
         self.get_with(key, ElementType::Double, RawBson::as_f64)
     }
 
     /// Gets a reference to the string value corresponding to a given key or returns an error if the
     /// key corresponds to a value which isn't a string.
-    ///
-    /// ```
-    /// use bson::{doc, raw::{RawDocumentBuf, ValueAccessErrorKind}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "string": "hello",
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// assert_eq!(doc.get_str("string")?, "hello");
-    /// assert!(matches!(doc.get_str("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_str("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_str(&self, key: impl AsRef<str>) -> ValueAccessResult<&'_ str> {
         self.get_with(key, ElementType::String, RawBson::as_str)
     }
 
     /// Gets a reference to the document value corresponding to a given key or returns an error if
     /// the key corresponds to a value which isn't a document.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{ValueAccessErrorKind, RawDocumentBuf}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "doc": { "key": "value"},
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// assert_eq!(doc.get_document("doc")?.get_str("key")?, "value");
-    /// assert!(matches!(doc.get_document("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_document("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_document(&self, key: impl AsRef<str>) -> ValueAccessResult<&'_ RawDocument> {
         self.get_with(key, ElementType::EmbeddedDocument, RawBson::as_document)
     }
 
     /// Gets a reference to the array value corresponding to a given key or returns an error if
     /// the key corresponds to a value which isn't an array.
-    ///
-    /// ```
-    /// use bson::{doc, raw::{RawDocumentBuf, ValueAccessErrorKind}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "array": [true, 3],
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// let mut arr_iter = doc.get_array("array")?.into_iter();
-    /// let _: bool = arr_iter.next().unwrap()?.as_bool().unwrap();
-    /// let _: i32 = arr_iter.next().unwrap()?.as_i32().unwrap();
-    ///
-    /// assert!(arr_iter.next().is_none());
-    /// assert!(doc.get_array("bool").is_err());
-    /// assert!(matches!(doc.get_array("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_array(&self, key: impl AsRef<str>) -> ValueAccessResult<&'_ RawArray> {
         self.get_with(key, ElementType::Array, RawBson::as_array)
     }
 
     /// Gets a reference to the BSON binary value corresponding to a given key or returns an error
     /// if the key corresponds to a value which isn't a binary value.
-    ///
-    /// ```
-    /// use bson::{
-    ///     doc,
-    ///     raw::{ValueAccessErrorKind, RawDocumentBuf, RawBinary},
-    ///     spec::BinarySubtype,
-    ///     Binary,
-    /// };
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "binary": Binary { subtype: BinarySubtype::Generic, bytes: vec![1, 2, 3] },
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// assert_eq!(&doc.get_binary("binary")?.bytes, &[1, 2, 3]);
-    /// assert!(matches!(doc.get_binary("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_binary("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_binary(&self, key: impl AsRef<str>) -> ValueAccessResult<RawBinary<'_>> {
         self.get_with(key, ElementType::Binary, RawBson::as_binary)
     }
 
     /// Gets a reference to the ObjectId value corresponding to a given key or returns an error if
     /// the key corresponds to a value which isn't an ObjectId.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, oid::ObjectId, raw::{ValueAccessErrorKind, RawDocumentBuf}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "_id": ObjectId::new(),
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// let oid = doc.get_object_id("_id")?;
-    /// assert!(matches!(doc.get_object_id("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_object_id("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_object_id(&self, key: impl AsRef<str>) -> ValueAccessResult<ObjectId> {
         self.get_with(key, ElementType::ObjectId, RawBson::as_object_id)
     }
 
     /// Gets a reference to the boolean value corresponding to a given key or returns an error if
     /// the key corresponds to a value which isn't a boolean.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, oid::ObjectId, raw::{RawDocumentBuf, ValueAccessErrorKind}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "_id": ObjectId::new(),
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// assert!(doc.get_bool("bool")?);
-    /// assert!(matches!(doc.get_bool("_id").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_bool("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_bool(&self, key: impl AsRef<str>) -> ValueAccessResult<bool> {
         self.get_with(key, ElementType::Boolean, RawBson::as_bool)
     }
 
     /// Gets a reference to the BSON DateTime value corresponding to a given key or returns an
     /// error if the key corresponds to a value which isn't a DateTime.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{ValueAccessErrorKind, RawDocumentBuf}, DateTime};
-    ///
-    /// let dt = DateTime::now();
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "created_at": dt,
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// assert_eq!(doc.get_datetime("created_at")?, dt);
-    /// assert!(matches!(doc.get_datetime("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_datetime("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_datetime(&self, key: impl AsRef<str>) -> ValueAccessResult<DateTime> {
         self.get_with(key, ElementType::DateTime, RawBson::as_datetime)
     }
 
     /// Gets a reference to the BSON regex value corresponding to a given key or returns an error if
     /// the key corresponds to a value which isn't a regex.
-    ///
-    /// ```
-    /// use bson::{doc, Regex, raw::{RawDocumentBuf, ValueAccessErrorKind}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "regex": Regex {
-    ///         pattern: r"end\s*$".into(),
-    ///         options: "i".into(),
-    ///     },
-    ///     "bool": true,
-    /// })?;
-    ///
-    /// assert_eq!(doc.get_regex("regex")?.pattern(), r"end\s*$");
-    /// assert_eq!(doc.get_regex("regex")?.options(), "i");
-    /// assert!(matches!(doc.get_regex("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_regex("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_regex(&self, key: impl AsRef<str>) -> ValueAccessResult<RawRegex<'_>> {
         self.get_with(key, ElementType::RegularExpression, RawBson::as_regex)
     }
 
     /// Gets a reference to the BSON timestamp value corresponding to a given key or returns an
     /// error if the key corresponds to a value which isn't a timestamp.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, Timestamp, raw::{RawDocumentBuf, ValueAccessErrorKind}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "bool": true,
-    ///     "ts": Timestamp { time: 649876543, increment: 9 },
-    /// })?;
-    ///
-    /// let timestamp = doc.get_timestamp("ts")?;
-    ///
-    /// assert_eq!(timestamp.time, 649876543);
-    /// assert_eq!(timestamp.increment, 9);
-    /// assert!(matches!(doc.get_timestamp("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_timestamp("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_timestamp(&self, key: impl AsRef<str>) -> ValueAccessResult<Timestamp> {
         self.get_with(key, ElementType::Timestamp, RawBson::as_timestamp)
     }
 
     /// Gets a reference to the BSON int32 value corresponding to a given key or returns an error if
     /// the key corresponds to a value which isn't a 32-bit integer.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{RawDocumentBuf, ValueAccessErrorKind}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "bool": true,
-    ///     "i32": 1_000_000,
-    /// })?;
-    ///
-    /// assert_eq!(doc.get_i32("i32")?, 1_000_000);
-    /// assert!(matches!(doc.get_i32("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { ..}));
-    /// assert!(matches!(doc.get_i32("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_i32(&self, key: impl AsRef<str>) -> ValueAccessResult<i32> {
         self.get_with(key, ElementType::Int32, RawBson::as_i32)
     }
 
     /// Gets a reference to the BSON int64 value corresponding to a given key or returns an error if
     /// the key corresponds to a value which isn't a 64-bit integer.
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{ValueAccessErrorKind, RawDocumentBuf}};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
-    ///     "bool": true,
-    ///     "i64": 9223372036854775807_i64,
-    /// })?;
-    ///
-    /// assert_eq!(doc.get_i64("i64")?, 9223372036854775807);
-    /// assert!(matches!(doc.get_i64("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_i64("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn get_i64(&self, key: impl AsRef<str>) -> ValueAccessResult<i64> {
         self.get_with(key, ElementType::Int64, RawBson::as_i64)
     }
 
     /// Return a reference to the contained data as a `&[u8]`
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, raw::RawDocumentBuf};
-    /// let docbuf = RawDocumentBuf::from_document(&doc!{})?;
-    /// assert_eq!(docbuf.as_bytes(), b"\x05\x00\x00\x00\x00");
-    /// # Ok::<(), Error>(())
-    /// ```
     pub fn as_bytes(&self) -> &[u8] {
         &self.data
     }

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -20,32 +20,11 @@ use super::{Error, ErrorKind, Iter, RawBson, RawDocument, Result};
 /// Iterating over a [`RawDocumentBuf`] yields either an error or a key-value pair that borrows from
 /// the original document without making any additional allocations.
 ///
-/// ```
-/// # use bson::raw::Error;
-/// use bson::raw::RawDocumentBuf;
-///
-/// let doc = RawDocumentBuf::new(b"\x13\x00\x00\x00\x02hi\x00\x06\x00\x00\x00y'all\x00\x00".to_vec())?;
-/// let mut iter = doc.iter();
-/// let (key, value) = iter.next().unwrap()?;
-/// assert_eq!(key, "hi");
-/// assert_eq!(value.as_str(), Some("y'all"));
-/// assert!(iter.next().is_none());
-/// # Ok::<(), Error>(())
-/// ```
-///
 /// This type implements `Deref` to [`RawDocument`], meaning that all methods on [`RawDocument`] are
 /// available on [`RawDocumentBuf`] values as well. This includes [`RawDocument::get`] or any of the
 /// type-specific getters, such as [`RawDocument::get_object_id`] or [`RawDocument::get_str`]. Note
 /// that accessing elements is an O(N) operation, as it requires iterating through the document from
 /// the beginning to find the requested key.
-///
-/// ```
-/// use bson::raw::RawDocumentBuf;
-///
-/// let doc = RawDocumentBuf::new(b"\x13\x00\x00\x00\x02hi\x00\x06\x00\x00\x00y'all\x00\x00".to_vec())?;
-/// assert_eq!(doc.get_str("hi")?, "y'all");
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
 #[derive(Clone, PartialEq)]
 pub struct RawDocumentBuf {
     data: Vec<u8>,
@@ -63,31 +42,12 @@ impl RawDocumentBuf {
     /// BSON elements is _not_ validated at all by this method. If the
     /// bytes do not conform to the BSON spec, then method calls on
     /// the RawDocument will return Errors where appropriate.
-    ///
-    /// ```
-    /// # use bson::raw::{RawDocumentBuf, Error};
-    /// let doc = RawDocumentBuf::new(b"\x05\0\0\0\0".to_vec())?;
-    /// # Ok::<(), Error>(())
-    /// ```
     pub fn new(data: Vec<u8>) -> Result<RawDocumentBuf> {
         let _ = RawDocument::new(data.as_slice())?;
         Ok(Self { data })
     }
 
     /// Create a [`RawDocumentBuf`] from a [`Document`].
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, oid::ObjectId, raw::RawDocumentBuf};
-    ///
-    /// let document = doc! {
-    ///     "_id": ObjectId::new(),
-    ///     "name": "Herman Melville",
-    ///     "title": "Moby-Dick",
-    /// };
-    /// let doc = RawDocumentBuf::from_document(&document)?;
-    /// # Ok::<(), Error>(())
-    /// ```
     pub fn from_document(doc: &Document) -> Result<RawDocumentBuf> {
         let mut data = Vec::new();
         doc.to_writer(&mut data).map_err(|e| Error {
@@ -103,20 +63,6 @@ impl RawDocumentBuf {
     /// Gets an iterator over the elements in the [`RawDocumentBuf`], which yields
     /// `Result<(&str, RawBson<'_>)>`.
     ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, raw::RawDocumentBuf};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc! { "ferris": true })?;
-    ///
-    /// for element in doc.iter() {
-    ///     let (key, value) = element?;
-    ///     assert_eq!(key, "ferris");
-    ///     assert_eq!(value.as_bool(), Some(true));
-    /// }
-    /// # Ok::<(), Error>(())
-    /// ```
-    ///
     /// # Note:
     ///
     /// There is no owning iterator for [`RawDocumentBuf`]. If you need ownership over
@@ -127,15 +73,6 @@ impl RawDocumentBuf {
     }
 
     /// Return the contained data as a `Vec<u8>`
-    ///
-    /// ```
-    /// # use bson::raw::Error;
-    /// use bson::{doc, raw::RawDocumentBuf};
-    ///
-    /// let doc = RawDocumentBuf::from_document(&doc!{})?;
-    /// assert_eq!(doc.into_vec(), b"\x05\x00\x00\x00\x00".to_vec());
-    /// # Ok::<(), Error>(())
-    /// ```
     pub fn into_vec(self) -> Vec<u8> {
         self.data
     }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -16,52 +16,11 @@
 //! implementation) returns a `Result`, since the bytes contained in the document are not fully
 //! validated until trying to access the contained data.
 //!
-//! ```rust
-//! use bson::raw::{
-//!     RawBson,
-//!     RawDocumentBuf,
-//! };
-//!
-//! // See http://bsonspec.org/spec.html for details on the binary encoding of BSON.
-//! let doc = RawDocumentBuf::new(b"\x13\x00\x00\x00\x02hi\x00\x06\x00\x00\x00y'all\x00\x00".to_vec())?;
-//! let elem = doc.get("hi")?.unwrap();
-//!
-//! assert_eq!(
-//!   elem.as_str(),
-//!   Some("y'all"),
-//! );
-//! # Ok::<(), bson::raw::Error>(())
-//! ```
-//!
 //! ### [`crate::Document`] interop
 //!
 //! A [`RawDocument`] can be created from a [`crate::Document`]. Internally, this
 //! serializes the [`crate::Document`] to a `Vec<u8>`, and then includes those bytes in the
 //! [`RawDocument`].
-//!
-//! ```rust
-//! use bson::{
-//!     raw::RawDocumentBuf,
-//!     doc,
-//! };
-//!
-//! let document = doc! {
-//!    "goodbye": {
-//!        "cruel": "world"
-//!    }
-//! };
-//!
-//! let raw = RawDocumentBuf::from_document(&document)?;
-//! let value = raw
-//!     .get_document("goodbye")?
-//!     .get_str("cruel")?;
-//!
-//! assert_eq!(
-//!     value,
-//!     "world",
-//! );
-//! # Ok::<(), Box<dyn std::error::Error>>(())
-//! ```
 //!
 //! ### Reference type ([`RawDocument`])
 //!
@@ -72,45 +31,11 @@
 //!
 //! The below example constructs a bson document in a stack-based array,
 //! and extracts a `&str` from it, performing no heap allocation.
-//! ```rust
-//! use bson::raw::RawDocument;
-//!
-//! let bytes = b"\x13\x00\x00\x00\x02hi\x00\x06\x00\x00\x00y'all\x00\x00";
-//! assert_eq!(RawDocument::new(bytes)?.get_str("hi")?, "y'all");
-//! # Ok::<(), Box<dyn std::error::Error>>(())
-//! ```
 //!
 //! ### Iteration
 //!
 //! [`RawDocument`] implements [`IntoIterator`](std::iter::IntoIterator), which can also be
 //! accessed via [`RawDocumentBuf::iter`].
-
-//! ```rust
-//! use bson::{
-//!    raw::{
-//!        RawBson,
-//!        RawDocumentBuf,
-//!    },
-//!    doc,
-//! };
-//!
-//! let original_doc = doc! {
-//!     "crate": "bson",
-//!     "year": "2021",
-//! };
-//!
-//! let doc = RawDocumentBuf::from_document(&original_doc)?;
-//! let mut doc_iter = doc.iter();
-//!
-//! let (key, value): (&str, RawBson) = doc_iter.next().unwrap()?;
-//! assert_eq!(key, "crate");
-//! assert_eq!(value.as_str(), Some("bson"));
-//!
-//! let (key, value): (&str, RawBson) = doc_iter.next().unwrap()?;
-//! assert_eq!(key, "year");
-//! assert_eq!(value.as_str(), Some("2021"));
-//! # Ok::<(), bson::raw::Error>(())
-//! ```
 
 mod array;
 mod bson;


### PR DESCRIPTION
This PR hides the not yet complete raw BSON API from the public API in preparation for the 2.1 release. The raw BSON stuff will land in 2.2 instead.

I've gone ahead and made a `2.1.x` branch which this will merge into, since master won't need to have these changes in it.

evg patch: https://evergreen.mongodb.com/version/618ed47757e85a14b56c83e1