### PR TITLE
RUST-1107 Fix array relaxed extended json

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -379,7 +379,7 @@ impl Bson {
             }
             Bson::Double(v) => json!(v),
             Bson::String(v) => json!(v),
-            Bson::Array(v) => json!(v),
+            Bson::Array(v) => Value::Array(v.into_iter().map(Bson::into_relaxed_extjson).collect()),
             Bson::Document(v) => {
                 Value::Object(v.into_iter().map(|(k, v)| (k, Value::from(v))).collect())
             }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -380,9 +380,11 @@ impl Bson {
             Bson::Double(v) => json!(v),
             Bson::String(v) => json!(v),
             Bson::Array(v) => Value::Array(v.into_iter().map(Bson::into_relaxed_extjson).collect()),
-            Bson::Document(v) => {
-                Value::Object(v.into_iter().map(|(k, v)| (k, Value::from(v))).collect())
-            }
+            Bson::Document(v) => Value::Object(
+                v.into_iter()
+                    .map(|(k, v)| (k, v.into_relaxed_extjson()))
+                    .collect(),
+            ),
             Bson::Boolean(v) => json!(v),
             Bson::Null => Value::Null,
             Bson::RegularExpression(Regex { pattern, options }) => {


### PR DESCRIPTION
Hi,

It seems that relaxed extended json doesn't work for arrays, here is an example:
```rust
use bson::serde_helpers::chrono_datetime_as_bson_datetime;
use serde_json::Value;
use chrono::Utc;
use chrono::TimeZone;
use serde::{
    Deserialize,
    Serialize,
};

#[derive(Serialize, Deserialize, Debug, Clone)]
pub struct Foo {
    #[serde(with = "chrono_datetime_as_bson_datetime")]
    pub date: chrono::DateTime<Utc>,
}

fn main() {
    let foo = Foo {
        date: Utc.ymd(2018, 1, 1).and_hms(0, 0, 0),
    };
    let bson = bson::to_bson(&foo).unwrap();
    let expected: Value = serde_json::from_str(r#"{"date":{"$date": "2018-01-01T00:00:00Z"}}"#).unwrap();
    println!("{:?}", expected); //Object({"date": Object({"$date": String("2018-01-01T00:00:00Z")})})
    assert_eq!(expected, bson.into_relaxed_extjson()); // WORK

    let list = vec![foo];
    let bson = bson::to_bson(&list).unwrap();
    let expected: Value = serde_json::from_str(r#"[{"date":{"$date": "2018-01-01T00:00:00Z"}}]"#).unwrap();
    println!("{:?}", expected); //Array([Object({"date": Object({"$date": String("2018-01-01T00:00:00Z")})})])
    assert_eq!(expected, bson.into_relaxed_extjson()); // NOT WORK
}
```

If i run, i get:
```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `Array([Object({"date": Object({"$date": String("2018-01-01T00:00:00Z")})})])`,
 right: `Array([Object({"date": Object({"$date": Object({"$numberLong": String("1514764800000")})})})])`', src/main.rs:30:5
```

So i changed this:
```rust
Bson::Array(v) => json!(v)
```
to this:
```rust
Bson::Array(v) => Value::Array(v.into_iter().map(Bson::into_relaxed_extjson).collect())
```