### PR TITLE
RUST-1109 Implement `rawbson!` and `rawdoc!` macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -212,3 +212,212 @@ macro_rules! doc {
         object
     }};
 }
+
+/// Construct a [`crate::RawBson`] value from a literal.
+///
+/// ```rust
+/// use bson::rawbson;
+///
+/// let value = rawbson!({
+///     "code": 200,
+///     "success": true,
+///     "payload": {
+///       "some": [
+///           "pay",
+///           "loads",
+///       ]
+///     }
+/// });
+/// ```
+#[macro_export]
+macro_rules! rawbson {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a
+    // RawArrayBuf containing the elements.
+    //
+    // Must be invoked as: bson!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Finished with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        <$crate::RawArrayBuf as std::iter::FromIterator::<$crate::RawBson>>::from_iter(vec![$($elems,)*])
+    };
+
+    // Finished without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        <$crate::RawArrayBuf as std::iter::FromIterator::<$crate::RawBson>>::from_iter(vec![$($elems),*])
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        $crate::rawbson!(@array [$($elems,)* $crate::rawbson!(null)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        $crate::rawbson!(@array [$($elems,)* $crate::rawbson!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        $crate::rawbson!(@array [$($elems,)* $crate::rawbson!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        $crate::rawbson!(@array [$($elems,)* $crate::rawbson!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        $crate::rawbson!(@array [$($elems,)* $crate::rawbson!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        $crate::rawbson!(@array [$($elems,)*] $($rest)*)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: rawbson!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Finished.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        $object.append(($($key)+), $value);
+        $crate::rawbson!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        $object.append(($($key)+), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        $crate::rawbson!(@object $object [$($key)+] ($crate::rawbson!(null)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        $crate::rawbson!(@object $object [$($key)+] ($crate::rawbson!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        $crate::rawbson!(@object $object [$($key)+] ($crate::rawbson!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        $crate::rawbson!(@object $object [$($key)+] ($crate::rawbson!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        $crate::rawbson!(@object $object [$($key)+] ($crate::rawbson!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        $crate::rawbson!();
+    };
+
+    // Missing key-value separator and value for last entry.
+    // Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        $crate::rawbson!();
+    };
+
+    // Misplaced key-value separator. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($kv_separator:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        unimplemented!($kv_separator);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        unimplemented!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        $crate::rawbson!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        $crate::rawbson!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: rawbson!($($bson)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::RawBson::Null
+    };
+
+    ([]) => {
+        $crate::RawBson::Array($crate::RawArrayBuf::new())
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::RawBson::Array($crate::rawbson!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::RawBson::Document($crate::rawdoc!{})
+    };
+
+    ({$($tt:tt)+}) => {
+        $crate::RawBson::Document($crate::rawdoc!{$($tt)+})
+    };
+
+    // Any Into<RawBson> type.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $crate::RawBson::from($other)
+    };
+}
+
+/// Construct a [`crate::RawDocumentBuf`] value.
+///
+/// ```rust
+/// use bson::rawdoc;
+///
+/// let value = rawdoc! {
+///     "code": 200,
+///     "success": true,
+///     "payload": {
+///       "some": [
+///           "pay",
+///           "loads",
+///       ]
+///     }
+/// };
+/// ```
+#[macro_export]
+macro_rules! rawdoc {
+    () => {{ $crate::RawDocumentBuf::new() }};
+    ( $($tt:tt)+ ) => {{
+        let mut object = $crate::RawDocumentBuf::new();
+        $crate::rawbson!(@object object () ($($tt)+) ($($tt)+));
+        object
+    }};
+}

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -137,7 +137,7 @@ impl RawDocument {
         unsafe { &*(data.as_ref() as *const [u8] as *const RawDocument) }
     }
 
-    /// Creates a new [`RawDocument`] with an owned copy of the BSON bytes.
+    /// Creates a new [`RawDocumentBuf`] with an owned copy of the BSON bytes.
     ///
     /// ```
     /// use bson::raw::{RawDocument, RawDocumentBuf, Error};
@@ -156,12 +156,12 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, oid::ObjectId, raw::{RawDocumentBuf, RawBson}};
+    /// use bson::{rawdoc, oid::ObjectId};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "_id": ObjectId::new(),
     ///     "f64": 2.5,
-    /// })?;
+    /// };
     ///
     /// let element = doc.get("f64")?.expect("finding key f64");
     /// assert_eq!(element.as_f64(), Some(2.5));
@@ -213,13 +213,13 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::raw::{ValueAccessErrorKind, RawDocumentBuf};
-    /// use bson::doc;
+    /// use bson::raw::ValueAccessErrorKind;
+    /// use bson::rawdoc;
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "bool": true,
     ///     "f64": 2.5,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(doc.get_f64("f64")?, 2.5);
     /// assert!(matches!(doc.get_f64("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -234,12 +234,12 @@ impl RawDocument {
     /// key corresponds to a value which isn't a string.
     ///
     /// ```
-    /// use bson::{doc, raw::{RawDocumentBuf, ValueAccessErrorKind}};
+    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "string": "hello",
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(doc.get_str("string")?, "hello");
     /// assert!(matches!(doc.get_str("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -255,12 +255,12 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{ValueAccessErrorKind, RawDocumentBuf}};
+    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "doc": { "key": "value"},
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(doc.get_document("doc")?.get_str("key")?, "value");
     /// assert!(matches!(doc.get_document("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -275,12 +275,12 @@ impl RawDocument {
     /// the key corresponds to a value which isn't an array.
     ///
     /// ```
-    /// use bson::{doc, raw::{RawDocumentBuf, ValueAccessErrorKind}};
+    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "array": [true, 3],
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// let mut arr_iter = doc.get_array("array")?.into_iter();
     /// let _: bool = arr_iter.next().unwrap()?.as_bool().unwrap();
@@ -300,16 +300,16 @@ impl RawDocument {
     ///
     /// ```
     /// use bson::{
-    ///     doc,
-    ///     raw::{ValueAccessErrorKind, RawDocumentBuf, RawBinaryRef},
+    ///     rawdoc,
+    ///     raw::ValueAccessErrorKind,
     ///     spec::BinarySubtype,
     ///     Binary,
     /// };
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "binary": Binary { subtype: BinarySubtype::Generic, bytes: vec![1, 2, 3] },
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(&doc.get_binary("binary")?.bytes, &[1, 2, 3]);
     /// assert!(matches!(doc.get_binary("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -325,12 +325,12 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, oid::ObjectId, raw::{ValueAccessErrorKind, RawDocumentBuf}};
+    /// use bson::{rawdoc, oid::ObjectId, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "_id": ObjectId::new(),
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// let oid = doc.get_object_id("_id")?;
     /// assert!(matches!(doc.get_object_id("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -346,12 +346,12 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, oid::ObjectId, raw::{RawDocumentBuf, ValueAccessErrorKind}};
+    /// use bson::{rawdoc, oid::ObjectId, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "_id": ObjectId::new(),
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// assert!(doc.get_bool("bool")?);
     /// assert!(matches!(doc.get_bool("_id").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -367,13 +367,13 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{ValueAccessErrorKind, RawDocumentBuf}, DateTime};
+    /// use bson::{rawdoc, raw::ValueAccessErrorKind, DateTime};
     ///
     /// let dt = DateTime::now();
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "created_at": dt,
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(doc.get_datetime("created_at")?, dt);
     /// assert!(matches!(doc.get_datetime("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -388,15 +388,15 @@ impl RawDocument {
     /// the key corresponds to a value which isn't a regex.
     ///
     /// ```
-    /// use bson::{doc, Regex, raw::{RawDocumentBuf, ValueAccessErrorKind}};
+    /// use bson::{rawdoc, Regex, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "regex": Regex {
     ///         pattern: r"end\s*$".into(),
     ///         options: "i".into(),
     ///     },
     ///     "bool": true,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(doc.get_regex("regex")?.pattern(), r"end\s*$");
     /// assert_eq!(doc.get_regex("regex")?.options(), "i");
@@ -413,12 +413,12 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, Timestamp, raw::{RawDocumentBuf, ValueAccessErrorKind}};
+    /// use bson::{rawdoc, Timestamp, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "bool": true,
     ///     "ts": Timestamp { time: 649876543, increment: 9 },
-    /// })?;
+    /// };
     ///
     /// let timestamp = doc.get_timestamp("ts")?;
     ///
@@ -437,12 +437,12 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{RawDocumentBuf, ValueAccessErrorKind}};
+    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "bool": true,
     ///     "i32": 1_000_000,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(doc.get_i32("i32")?, 1_000_000);
     /// assert!(matches!(doc.get_i32("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { ..}));
@@ -458,12 +458,12 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, raw::{ValueAccessErrorKind, RawDocumentBuf}};
+    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
     ///
-    /// let doc = RawDocumentBuf::from_document(&doc! {
+    /// let doc = rawdoc! {
     ///     "bool": true,
     ///     "i64": 9223372036854775807_i64,
-    /// })?;
+    /// };
     ///
     /// assert_eq!(doc.get_i64("i64")?, 9223372036854775807);
     /// assert!(matches!(doc.get_i64("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
@@ -478,8 +478,8 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{doc, raw::RawDocumentBuf};
-    /// let docbuf = RawDocumentBuf::from_document(&doc!{})?;
+    /// use bson::rawdoc;
+    /// let docbuf = rawdoc! {};
     /// assert_eq!(docbuf.as_bytes(), b"\x05\x00\x00\x00\x00");
     /// # Ok::<(), Error>(())
     /// ```

--- a/src/raw/test/append.rs
+++ b/src/raw/test/append.rs
@@ -412,3 +412,26 @@ fn from_iter() {
         doc.append("expected", doc_buf);
     });
 }
+
+#[test]
+fn array_buf() {
+    let mut arr_buf = RawArrayBuf::new();
+    arr_buf.push(true);
+
+    let mut doc_buf = RawDocumentBuf::new();
+    doc_buf.append("x", 3_i32);
+    doc_buf.append("string", "string");
+    arr_buf.push(doc_buf);
+
+    let mut sub_arr = RawArrayBuf::new();
+    sub_arr.push("a string");
+    arr_buf.push(sub_arr);
+
+    let arr = rawbson!([
+        true,
+        { "x": 3_i32, "string": "string" },
+        [ "a string" ]
+    ]);
+
+    assert_eq!(arr_buf.as_ref(), arr.as_array().unwrap());
+}

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -1,4 +1,14 @@
-use crate::{doc, oid::ObjectId, spec::BinarySubtype, tests::LOCK, Binary, Bson, Regex, Timestamp};
+use crate::{
+    doc,
+    oid::ObjectId,
+    spec::BinarySubtype,
+    tests::LOCK,
+    Binary,
+    Bson,
+    RawBson,
+    Regex,
+    Timestamp,
+};
 use chrono::offset::Utc;
 use pretty_assertions::assert_eq;
 
@@ -36,6 +46,29 @@ fn standard_format() {
         "date": Bson::DateTime(crate::DateTime::from_chrono(date)),
     };
 
+    let rawdoc = rawdoc! {
+        "float": 2.4,
+        "string": "hello",
+        "array": ["testing", 1, true, [1, 2]],
+        "doc": {
+            "fish": "in",
+            "a": "barrel",
+            "!": 1,
+        },
+        "bool": true,
+        "null": null,
+        "regexp": Regex { pattern: "s[ao]d".to_owned(), options: "i".to_owned() },
+        "with_wrapped_parens": (-20),
+        "code": RawBson::JavaScriptCode("function(x) { return x._id; }".to_owned()),
+        "i32": 12,
+        "i64": -55,
+        "timestamp": Timestamp { time: 0, increment: 229_999_444 },
+        "binary": Binary { subtype: BinarySubtype::Md5, bytes: "thingies".to_owned().into_bytes() },
+        "encrypted": Binary { subtype: BinarySubtype::Encrypted, bytes: "secret".to_owned().into_bytes() },
+        "_id": id,
+        "date": crate::DateTime::from_chrono(date),
+    };
+
     let expected = format!(
         "{{ \"float\": 2.4, \"string\": \"hello\", \"array\": [\"testing\", 1, true, [1, 2]], \
          \"doc\": {{ \"fish\": \"in\", \"a\": \"barrel\", \"!\": 1 }}, \"bool\": true, \"null\": \
@@ -50,6 +83,8 @@ fn standard_format() {
     );
 
     assert_eq!(expected, format!("{}", doc));
+
+    assert_eq!(rawdoc.into_bytes(), crate::to_vec(&doc).unwrap());
 }
 
 #[test]
@@ -85,6 +120,24 @@ fn recursive_macro() {
         ],
         "e": { "single": "test" },
         "n": (Bson::Null),
+    };
+    let rawdoc = rawdoc! {
+        "a": "foo",
+        "b": {
+            "bar": {
+                "harbor": ["seal", false],
+                "jelly": 42.0,
+            },
+            "grape": 27,
+        },
+        "c": [-7],
+        "d": [
+            {
+                "apple": "ripe",
+            }
+        ],
+        "e": { "single": "test" },
+        "n": (RawBson::Null),
     };
 
     match doc.get("a") {
@@ -184,4 +237,6 @@ fn recursive_macro() {
         }
         _ => panic!("Null was not inserted correctly."),
     }
+
+    assert_eq!(rawdoc.into_bytes(), crate::to_vec(&doc).unwrap());
 }


### PR DESCRIPTION
RUST-1109

This PR implements the `rawbson!` and `rawdoc!` macros to allow easier creation of raw BSON types. They are largely copy/pasted from the existing `bson!` and `doc!` macros with just a few modifications to build raw BSON. This PR also updates a number of examples and tests to use `rawdoc!` instead of building `RawDocumentBuf` values manually or from `Document`.