### PR TITLE
RUST-1119 Add `bson::to_raw_document_buf` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,12 +278,12 @@ pub use self::{
     },
     decimal128::Decimal128,
     raw::{
-        RawBson, RawArray, RawArrayBuf, RawBinaryRef, RawBsonRef, RawDbPointerRef, RawDocument,
+        RawArray, RawArrayBuf, RawBinaryRef, RawBson, RawBsonRef, RawDbPointerRef, RawDocument,
         RawDocumentBuf, RawJavaScriptCodeWithScopeRef, RawRegexRef,
     },
     ser::{
-        to_bson, to_bson_with_options, to_document, to_document_with_options, to_vec, Serializer,
-        SerializerOptions,
+        to_bson, to_bson_with_options, to_document, to_document_with_options, to_raw_document_buf,
+        to_vec, Serializer, SerializerOptions,
     },
     uuid::{Uuid, UuidRepresentation},
 };

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -289,6 +289,7 @@ where
 ///
 /// ```rust
 /// use serde::Serialize;
+/// use bson::rawdoc;
 ///
 /// #[derive(Serialize)]
 /// struct Cat {
@@ -298,7 +299,7 @@ where
 ///
 /// let cat = Cat { name: "Garfield".to_string(), age: 43 };
 /// let doc = bson::to_raw_document_buf(&cat)?;
-/// // assert_eq!(doc, rawdoc! { "name": "Garfield", "age": 43 })
+/// assert_eq!(doc, rawdoc! { "name": "Garfield", "age": 43 });
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[inline]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     de::MAX_BSON_SIZE,
     spec::BinarySubtype,
     Binary,
+    RawDocumentBuf,
 };
 use ::serde::{ser::Error as SerdeError, Serialize};
 
@@ -282,4 +283,28 @@ where
     let mut serializer = raw::Serializer::new();
     value.serialize(&mut serializer)?;
     Ok(serializer.into_vec())
+}
+
+/// Serialize the given `T` as a [`RawDocumentBuf`].
+///
+/// ```rust
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct Cat {
+///     name: String,
+///     age: i32
+/// }
+///
+/// let cat = Cat { name: "Garfield".to_string(), age: 43 };
+/// let doc = bson::to_raw_document_buf(&cat)?;
+/// // assert_eq!(doc, rawdoc! { "name": "Garfield", "age": 43 })
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[inline]
+pub fn to_raw_document_buf<T>(value: &T) -> Result<RawDocumentBuf>
+where
+    T: Serialize,
+{
+    RawDocumentBuf::from_bytes(to_vec(value)?).map_err(Error::custom)
 }


### PR DESCRIPTION
RUST-1119

This PR adds the `bson::to_raw_document_buf` convenience function. I originally set out to also add `bson::to_raw_bson` as well (RUST-1110), but it looked like it was going to be a lot of effort for functionality that might not be all that useful. For now, I've split off just this function (which definitely will be useful) and am putting the `to_raw_bson` work on the backburner. Let me know if that sounds okay.