### PR TITLE
RUST-1111 Support deserializing `RawBson` from `Bson`

### DIFF
--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -39,6 +39,7 @@ use bson::{
     RawDbPointerRef,
     RawDocument,
     RawDocumentBuf,
+    RawJavaScriptCodeWithScope,
     RawJavaScriptCodeWithScopeRef,
     RawRegexRef,
     Regex,
@@ -52,9 +53,9 @@ use bson::{
 ///     - serializing the `expected_value` to a `Document` matches the `expected_doc`
 ///     - deserializing from the serialized document produces `expected_value`
 ///   - round trip through raw BSON:
-///     - deserializing a `T` from the raw BSON version of `expected_doc` produces `expected_value`
-///     - deserializing a `Document` from the raw BSON version of `expected_doc` produces
-///       `expected_doc`
+///     - serializering `expected_value` to BSON bytes matches the raw BSON bytes of `expected_doc`
+///     - deserializing a `T` from the serialized bytes produces `expected_value`
+///     - deserializing a `Document` from the serialized bytes produces `expected_doc`
 ///   - `bson::to_writer` and `Document::to_writer` produce the same result given the same input
 fn run_test<T>(expected_value: &T, expected_doc: &Document, description: &str)
 where
@@ -1244,17 +1245,34 @@ fn owned_raw_types() {
 
     let oid = ObjectId::new();
     let dt = DateTime::now();
+    let d128 = Decimal128::from_bytes([1; 16]);
+
+    let raw_code_w_scope = RawJavaScriptCodeWithScope {
+        code: "code".to_string(),
+        scope: RawDocumentBuf::new(),
+    };
+    let code_w_scope = JavaScriptCodeWithScope {
+        code: "code".to_string(),
+        scope: doc! {},
+    };
 
     let f = Foo {
         subdoc: RawDocumentBuf::from_iter([
             ("a key", RawBson::String("a value".to_string())),
             ("an objectid", RawBson::ObjectId(oid)),
             ("a date", RawBson::DateTime(dt)),
+            (
+                "code_w_scope",
+                RawBson::JavaScriptCodeWithScope(raw_code_w_scope.clone()),
+            ),
+            ("decimal128", RawBson::Decimal128(d128)),
         ]),
         array: RawArrayBuf::from_iter([
             RawBson::String("a string".to_string()),
             RawBson::ObjectId(oid),
             RawBson::DateTime(dt),
+            RawBson::JavaScriptCodeWithScope(raw_code_w_scope),
+            RawBson::Decimal128(d128),
         ]),
     };
 
@@ -1263,28 +1281,19 @@ fn owned_raw_types() {
             "a key": "a value",
             "an objectid": oid,
             "a date": dt,
+            "code_w_scope": code_w_scope.clone(),
+            "decimal128": d128,
         },
         "array": [
             "a string",
             oid,
-            dt
+            dt,
+            code_w_scope,
+            d128,
         ]
     };
 
-    // TODO: RUST-1111
-    // can't use run_test here because deserializing RawDocumentBuf and RawArrayBuf
-    // from Bson or Document currently don't work.
-
-    let bytes = bson::to_vec(&expected).unwrap();
-
-    let deserialized: Foo = bson::from_slice(bytes.as_slice()).unwrap();
-    assert_eq!(deserialized, f);
-
-    let serialized = bson::to_document(&deserialized).unwrap();
-    assert_eq!(serialized, expected);
-
-    let serialized_bytes = bson::to_vec(&deserialized).unwrap();
-    assert_eq!(serialized_bytes, bytes);
+    run_test(&f, &expected, "owned_raw_types");
 }
 
 #[test]

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -53,7 +53,7 @@ use bson::{
 ///     - serializing the `expected_value` to a `Document` matches the `expected_doc`
 ///     - deserializing from the serialized document produces `expected_value`
 ///   - round trip through raw BSON:
-///     - serializering `expected_value` to BSON bytes matches the raw BSON bytes of `expected_doc`
+///     - serializing `expected_value` to BSON bytes matches the raw BSON bytes of `expected_doc`
 ///     - deserializing a `T` from the serialized bytes produces `expected_value`
 ///     - deserializing a `Document` from the serialized bytes produces `expected_doc`
 ///   - `bson::to_writer` and `Document::to_writer` produce the same result given the same input

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -56,6 +56,22 @@ pub(crate) const MIN_BSON_DOCUMENT_SIZE: i32 = 4 + 1; // 4 bytes for length, one
 pub(crate) const MIN_BSON_STRING_SIZE: i32 = 4 + 1; // 4 bytes for length, one byte for null terminator
 pub(crate) const MIN_CODE_WITH_SCOPE_SIZE: i32 = 4 + MIN_BSON_STRING_SIZE + MIN_BSON_DOCUMENT_SIZE;
 
+/// Hint provided to the deserializer via `deserialize_newtype_struct` as to the type of thing
+/// being deserialized.
+#[derive(Debug, Clone, Copy)]
+enum DeserializerHint {
+    /// No hint provided, deserialize normally.
+    None,
+
+    /// The type being deserialized expects the BSON to contain a binary value with the provided
+    /// subtype. This is currently used to deserialize `bson::Uuid` values.
+    BinarySubtype(BinarySubtype),
+
+    /// The type being deserialized is raw BSON, meaning no allocations should occur as part of
+    /// deserializing and everything should be visited via borrowing or `Copy` if possible.
+    RawBson,
+}
+
 /// Run the provided closure, ensuring that over the course of its execution, exactly `length` bytes
 /// were read from the reader.
 pub(crate) fn ensure_read_exactly<F, R>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ pub use self::{
     decimal128::Decimal128,
     raw::{
         RawArray, RawArrayBuf, RawBinaryRef, RawBson, RawBsonRef, RawDbPointerRef, RawDocument,
-        RawDocumentBuf, RawJavaScriptCodeWithScopeRef, RawRegexRef,
+        RawDocumentBuf, RawJavaScriptCodeWithScope, RawJavaScriptCodeWithScopeRef, RawRegexRef,
     },
     ser::{
         to_bson, to_bson_with_options, to_document, to_document_with_options, to_raw_document_buf,

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -217,16 +217,28 @@ fn run_test(test: TestFile) {
                     test_key: bson_field,
                 };
 
+                // deserialize the field from a Bson into a RawBson
+                let deserializer_value_raw =
+                    crate::Deserializer::new(Bson::Document(documentfromreader_cb.clone()));
+                let raw_bson_field = deserializer_value_raw
+                    .deserialize_any(FieldVisitor(test_key.as_str(), PhantomData::<RawBson>))
+                    .expect(&description);
+                let from_value_raw_doc = doc! {
+                    test_key: Bson::try_from(raw_bson_field).expect(&description),
+                };
+
                 // convert back into raw BSON for comparison with canonical BSON
                 let from_raw_vec = crate::to_vec(&from_raw_doc).expect(&description);
                 let from_slice_value_vec =
                     crate::to_vec(&from_slice_value_doc).expect(&description);
                 let from_bson_value_vec = crate::to_vec(&from_value_value_doc).expect(&description);
+                let from_value_raw_vec = crate::to_vec(&from_value_raw_doc).expect(&description);
 
                 assert_eq!(from_raw_vec, canonical_bson, "{}", description);
                 assert_eq!(from_slice_value_vec, canonical_bson, "{}", description);
                 assert_eq!(from_bson_value_vec, canonical_bson, "{}", description);
                 assert_eq!(from_slice_owned_vec, canonical_bson, "{}", description);
+                assert_eq!(from_value_raw_vec, canonical_bson, "{}", description);
             }
         }
 


### PR DESCRIPTION
RUST-1111

This PR adds support to the `Bson`-based deserializer (used in `bson::from_bson` and `bson::from_document`) for deserializing the owned raw BSON types, namely `RawBson`, `RawDocumentBuf`, and `RawArrayBuf`.