### PR TITLE
minor: minor raw BSON perf and API improvements

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1050,7 +1050,10 @@ impl Display for Regex {
 /// Represents a BSON code with scope value.
 #[derive(Debug, Clone, PartialEq)]
 pub struct JavaScriptCodeWithScope {
+    /// The JavaScript code.
     pub code: String,
+
+    /// The scope document containing variable bindings.
     pub scope: Document,
 }
 

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -212,6 +212,11 @@ impl RawArray {
     pub fn as_bytes(&self) -> &[u8] {
         self.doc.as_bytes()
     }
+
+    /// Whether this array contains any elements or not.
+    pub fn is_empty(&self) -> bool {
+        self.doc.is_empty()
+    }
 }
 
 impl std::fmt::Debug for RawArray {

--- a/src/raw/bson_ref.rs
+++ b/src/raw/bson_ref.rs
@@ -533,20 +533,17 @@ impl<'a> From<&'a Binary> for RawBsonRef<'a> {
 /// A BSON regex referencing raw bytes stored elsewhere.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RawRegexRef<'a> {
-    pub(crate) pattern: &'a str,
-    pub(crate) options: &'a str,
-}
+    /// The regex pattern to match.
+    pub pattern: &'a str,
 
-impl<'a> RawRegexRef<'a> {
-    /// Gets the pattern portion of the regex.
-    pub fn pattern(self) -> &'a str {
-        self.pattern
-    }
-
-    /// Gets the options portion of the regex.
-    pub fn options(self) -> &'a str {
-        self.options
-    }
+    /// The options for the regex.
+    ///
+    /// Options are identified by characters, which must be stored in
+    /// alphabetical order. Valid options are 'i' for case insensitive matching, 'm' for
+    /// multiline matching, 'x' for verbose mode, 'l' to make \w, \W, etc. locale dependent,
+    /// 's' for dotall mode ('.' matches everything), and 'u' to make \w, \W, etc. match
+    /// unicode.
+    pub options: &'a str,
 }
 
 impl<'de: 'a, 'a> Deserialize<'de> for RawRegexRef<'a> {
@@ -594,22 +591,14 @@ impl<'a> From<RawRegexRef<'a>> for RawBsonRef<'a> {
 /// A BSON "code with scope" value referencing raw bytes stored elsewhere.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RawJavaScriptCodeWithScopeRef<'a> {
-    pub(crate) code: &'a str,
+    /// The JavaScript code.
+    pub code: &'a str,
 
-    pub(crate) scope: &'a RawDocument,
+    /// The scope document containing variable bindings.
+    pub scope: &'a RawDocument,
 }
 
 impl<'a> RawJavaScriptCodeWithScopeRef<'a> {
-    /// Gets the code in the value.
-    pub fn code(self) -> &'a str {
-        self.code
-    }
-
-    /// Gets the scope in the value.
-    pub fn scope(self) -> &'a RawDocument {
-        self.scope
-    }
-
     pub(crate) fn len(self) -> i32 {
         4 + 4 + self.code.len() as i32 + 1 + self.scope.as_bytes().len() as i32
     }

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -6,6 +6,7 @@ use std::{
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 
 use crate::{
+    de::MIN_BSON_DOCUMENT_SIZE,
     raw::{error::ErrorKind, serde::OwnedOrBorrowedRawDocument, RAW_DOCUMENT_NEWTYPE},
     DateTime,
     Timestamp,
@@ -485,6 +486,11 @@ impl RawDocument {
     /// ```
     pub fn as_bytes(&self) -> &[u8] {
         &self.data
+    }
+
+    /// Returns whether this document contains any elements or not.
+    pub fn is_empty(&self) -> bool {
+        self.as_bytes().len() == MIN_BSON_DOCUMENT_SIZE as usize
     }
 }
 

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -398,8 +398,8 @@ impl RawDocument {
     ///     "bool": true,
     /// };
     ///
-    /// assert_eq!(doc.get_regex("regex")?.pattern(), r"end\s*$");
-    /// assert_eq!(doc.get_regex("regex")?.options(), "i");
+    /// assert_eq!(doc.get_regex("regex")?.pattern, r"end\s*$");
+    /// assert_eq!(doc.get_regex("regex")?.options, "i");
     /// assert!(matches!(doc.get_regex("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
     /// assert!(matches!(doc.get_regex("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
     /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/raw/serde.rs
+++ b/src/raw/serde.rs
@@ -349,8 +349,8 @@ impl<'de> Visitor<'de> for OwnedOrBorrowedRawBsonVisitor {
             let v: RawBson = map.next_value()?;
             doc.append(first_key, v);
 
-            while let Some((k, v)) = map.next_entry::<String, RawBson>()? {
-                doc.append(k, v);
+            while let Some((k, v)) = map.next_entry::<CowStr, RawBson>()? {
+                doc.append(k.0, v);
             }
 
             Ok(RawBson::Document(doc).into())

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -310,9 +310,9 @@ fn javascript_with_scope() {
         .expect("no key javascript_with_scope")
         .as_javascript_with_scope()
         .expect("was not javascript with scope");
-    assert_eq!(js_with_scope.code(), "console.log(msg);");
+    assert_eq!(js_with_scope.code, "console.log(msg);");
     let (scope_key, scope_value_bson) = js_with_scope
-        .scope()
+        .scope
         .into_iter()
         .next()
         .expect("no next value in scope")

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -97,8 +97,8 @@ impl Serializer {
     /// Replace an i32 value at the given index with the given value.
     #[inline]
     fn replace_i32(&mut self, at: usize, with: i32) {
-        self.bytes
-            .splice(at..at + 4, with.to_le_bytes().iter().cloned());
+        let portion = &mut self.bytes[at..at + 4];
+        portion.copy_from_slice(&with.to_le_bytes());
     }
 }
 


### PR DESCRIPTION
This PR implements a few minor performance and API improvements to the raw BSON API that I noticed while benchmarking it / using it in the driver.

- `RawDocumentBuf::append` accepts and `impl AsRef<str>` for the key instead of an `impl Into<String>`
  - this allows us to avoid an allocation when we have string reference types
  - we can't really move a string into our buffer anyways, so for owned strings there isn't any perf penalty here
  - this also applies to the `FromIterator` implementation for `RawDocumentBuf`
- exposed all fields of `RawJavaScriptCodeWithScopeRef` and `RawRegexRef`
  - this is in line with other similar types
  - the getters were removed as part of this