### PR TITLE
RUST-939 Run BSON fuzzer in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -120,6 +120,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          .evergreen/install-fuzzer.sh
           .evergreen/run-fuzzer.sh
 
   "check rustdoc":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -112,6 +112,16 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/check-clippy.sh
 
+  "run fuzzer":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          .evergreen/run-fuzzer.sh
+
   "check rustdoc":
     - command: shell.exec
       type: test
@@ -162,6 +172,10 @@ tasks:
     commands:
       - func: "check rustdoc"
 
+  - name: "run-fuzzer"
+    commands:
+      - func: "run fuzzer"
+
 axes:
   - id: "extra-rust-versions"
     values:
@@ -200,3 +214,11 @@ buildvariants:
     - name: "check-clippy"
     - name: "check-rustfmt"
     - name: "check-rustdoc"
+
+-
+  name: "fuzz"
+  display_name: "Raw BSON Fuzzer"
+  run_on:
+    - ubuntu1804-test
+  tasks:
+    - name: "run-fuzzer"

--- a/.evergreen/install-fuzzer.sh
+++ b/.evergreen/install-fuzzer.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+
+. ~/.cargo/env
+
+cargo install cargo-fuzz

--- a/.evergreen/run-fuzzer.sh
+++ b/.evergreen/run-fuzzer.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -o errexit
+
+. ~/.cargo/env
+
+cd fuzz
+
+# each runs for a minute
+cargo +nightly fuzz run deserialize -- -rss_limit_mb=4096 -max_total_time=60
+cargo +nightly fuzz run raw_deserialize -- -rss_limit_mb=4096 -max_total_time=60
+cargo +nightly fuzz run iterate -- -rss_limit_mb=4096 -max_total_time=60

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,16 +11,20 @@ cargo-fuzz = true
 [dependencies.bson]
 path = ".."
 [dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+version = "0.4.0"
 
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
 
 [[bin]]
-name = "fuzz_target_1"
-path = "fuzz_targets/fuzz_target_1.rs"
-
-[[bin]]
 name = "deserialize"
 path = "fuzz_targets/deserialize.rs"
+
+[[bin]]
+name = "iterate"
+path = "fuzz_targets/iterate.rs"
+
+[[bin]]
+name = "raw_deserialize"
+path = "fuzz_targets/raw_deserialize.rs"

--- a/fuzz/fuzz_targets/iterate.rs
+++ b/fuzz/fuzz_targets/iterate.rs
@@ -1,0 +1,10 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate bson;
+use bson::RawDocument;
+
+fuzz_target!(|buf: &[u8]| {
+    if let Ok(doc) = RawDocument::from_bytes(buf) {
+        for _ in doc {}
+    }
+});

--- a/fuzz/fuzz_targets/raw_deserialize.rs
+++ b/fuzz/fuzz_targets/raw_deserialize.rs
@@ -1,0 +1,8 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate bson;
+use bson::Document;
+
+fuzz_target!(|buf: &[u8]| {
+    let _ = bson::from_slice::<Document>(buf);
+});

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -171,7 +171,9 @@ impl<'de> Deserializer<'de> {
     where
         F: FnOnce(DocumentAccess<'_, 'de>) -> Result<O>,
     {
-        let mut length_remaining = read_i32(&mut self.bytes)? - 4;
+        let mut length_remaining = read_i32(&mut self.bytes)?
+            .checked_sub(4)
+            .ok_or_else(|| Error::custom("invalid length, less than min document size"))?;
         let out = f(DocumentAccess {
             root_deserializer: self,
             length_remaining: &mut length_remaining,

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -175,7 +175,14 @@ impl<'a> Iterator for Iter<'a> {
                 ElementType::Binary => {
                     let len = i32_from_slice(&self.doc.as_bytes()[valueoffset..])? as usize;
                     let data_start = valueoffset + 4 + 1;
-                    self.verify_enough_bytes(valueoffset, len)?;
+
+                    if len >= i32::MAX as usize {
+                        return Err(Error::new_without_key(ErrorKind::MalformedValue {
+                            message: format!("binary length exceeds maximum: {}", len),
+                        }));
+                    }
+
+                    self.verify_enough_bytes(valueoffset + 4, len + 1)?;
                     let subtype = BinarySubtype::from(self.doc.as_bytes()[valueoffset + 4]);
                     let data = match subtype {
                         BinarySubtype::BinaryOld => {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -171,7 +171,7 @@ fn f64_from_slice(val: &[u8]) -> Result<f64> {
 /// Given a u8 slice, return an i32 calculated from the first four bytes in
 /// little endian order.
 fn i32_from_slice(val: &[u8]) -> Result<i32> {
-    let arr = val
+    let arr: [u8; 4] = val
         .get(0..4)
         .and_then(|s| s.try_into().ok())
         .ok_or_else(|| {
@@ -213,6 +213,15 @@ fn read_nullterminated(buf: &[u8]) -> Result<&str> {
 }
 
 fn read_lenencoded(buf: &[u8]) -> Result<&str> {
+    if buf.len() < 4 {
+        return Err(Error::new_without_key(ErrorKind::MalformedValue {
+            message: format!(
+                "expected buffer with string to contain at least 4 bytes, but it only has {}",
+                buf.len()
+            ),
+        }));
+    }
+
     let length = i32_from_slice(&buf[..4])?;
     let end = checked_add(usize_try_from_i32(length)?, 4)?;
 


### PR DESCRIPTION
RUST-939

This PR begins running the existing fuzzer in evergreen, and it also runs some new fuzzing targets intended for the new raw BSON API. As part of that, it found some crashes which have also been fixed in this PR.