### PR TITLE
RUST-1175 Introduce owned iterator for `RawArrayBuf`, `"unstable"` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,11 @@ uuid-0_8 = []
 # all optional dependencies.
 # serde_with
 
-# # private feature flag containing unstable functionality for special use in the
-# # mongodb crate. This feature flag should not be enabled by other users.
-# __private = []
+# feature flag containing unstable functionality for special use in the
+# mongodb crate. Any API exposed by using this feature flag is subject
+# to change at any time and should not be relied upon in stable
+# applications.
+unstable = []
 
 [lib]
 name = "bson"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ uuid-0_8 = []
 # all optional dependencies.
 # serde_with
 
+# # private feature flag containing unstable functionality for special use in the
+# # mongodb crate. This feature flag should not be enabled by other users.
+# __private = []
+
 [lib]
 name = "bson"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,10 @@ pub use self::{
     uuid::{Uuid, UuidRepresentation},
 };
 
+#[cfg(feature = "unstable")]
+#[doc(hidden)]
+pub use self::raw::RawArrayBufCopyingIter;
+
 #[macro_use]
 mod macros;
 mod bson;

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -270,6 +270,7 @@ pub struct RawArrayIter<'a> {
     inner: Iter<'a>,
 }
 
+#[cfg(feature = "unstable")]
 impl<'a> RawArrayIter<'a> {
     pub(crate) fn new_at(array: &'a RawArray, index: usize) -> Self {
         Self {

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -5,10 +5,21 @@ use serde::{ser::SerializeSeq, Deserialize, Serialize};
 use super::{
     error::{ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
     serde::OwnedOrBorrowedRawArray,
-    Error, Iter, RawBinaryRef, RawBsonRef, RawDocument, RawRegexRef, Result,
+    Error,
+    Iter,
+    RawBinaryRef,
+    RawBsonRef,
+    RawDocument,
+    RawRegexRef,
+    Result,
 };
 use crate::{
-    oid::ObjectId, raw::RAW_ARRAY_NEWTYPE, spec::ElementType, Bson, DateTime, RawArrayBuf,
+    oid::ObjectId,
+    raw::RAW_ARRAY_NEWTYPE,
+    spec::ElementType,
+    Bson,
+    DateTime,
+    RawArrayBuf,
     Timestamp,
 };
 
@@ -266,7 +277,7 @@ impl<'a> RawArrayIter<'a> {
         }
     }
 
-    pub fn offset(&self) -> usize {
+    pub(crate) fn offset(&self) -> usize {
         self.inner.offset()
     }
 }

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -5,21 +5,10 @@ use serde::{ser::SerializeSeq, Deserialize, Serialize};
 use super::{
     error::{ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
     serde::OwnedOrBorrowedRawArray,
-    Error,
-    Iter,
-    RawBinaryRef,
-    RawBsonRef,
-    RawDocument,
-    RawRegexRef,
-    Result,
+    Error, Iter, RawBinaryRef, RawBsonRef, RawDocument, RawRegexRef, Result,
 };
 use crate::{
-    oid::ObjectId,
-    raw::RAW_ARRAY_NEWTYPE,
-    spec::ElementType,
-    Bson,
-    DateTime,
-    RawArrayBuf,
+    oid::ObjectId, raw::RAW_ARRAY_NEWTYPE, spec::ElementType, Bson, DateTime, RawArrayBuf,
     Timestamp,
 };
 
@@ -268,6 +257,18 @@ impl<'a> IntoIterator for &'a RawArray {
 /// An iterator over borrowed raw BSON array values.
 pub struct RawArrayIter<'a> {
     inner: Iter<'a>,
+}
+
+impl<'a> RawArrayIter<'a> {
+    pub(crate) fn new_at(array: &'a RawArray, index: usize) -> Self {
+        Self {
+            inner: Iter::new_at(RawDocument::from_bytes(array.as_bytes()).unwrap(), index),
+        }
+    }
+
+    pub fn offset(&self) -> usize {
+        self.inner.offset()
+    }
 }
 
 impl<'a> Iterator for RawArrayIter<'a> {

--- a/src/raw/array_buf.rs
+++ b/src/raw/array_buf.rs
@@ -97,6 +97,10 @@ impl RawArrayBuf {
         self.len += 1;
     }
 
+    pub fn iter_at(&self, starting_at: usize) -> RawArrayIter<'_> {
+        RawArrayIter::new_at(self.as_ref(), starting_at)
+    }
+
     pub(crate) fn into_vec(self) -> Vec<u8> {
         self.inner.into_bytes()
     }

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -8,13 +8,22 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    de::MIN_BSON_DOCUMENT_SIZE, spec::BinarySubtype, Document, RawBinaryRef,
+    de::MIN_BSON_DOCUMENT_SIZE,
+    spec::BinarySubtype,
+    Document,
+    RawBinaryRef,
     RawJavaScriptCodeWithScopeRef,
 };
 
 use super::{
-    bson::RawBson, serde::OwnedOrBorrowedRawDocument, Error, ErrorKind, Iter, RawBsonRef,
-    RawDocument, Result,
+    bson::RawBson,
+    serde::OwnedOrBorrowedRawDocument,
+    Error,
+    ErrorKind,
+    Iter,
+    RawBsonRef,
+    RawDocument,
+    Result,
 };
 
 /// An owned BSON document (akin to [`std::path::PathBuf`]), backed by a buffer of raw BSON bytes.

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -21,6 +21,7 @@ use super::{
     Error,
     ErrorKind,
     Iter,
+    IntoIter,
     RawBsonRef,
     RawDocument,
     Result,
@@ -148,6 +149,10 @@ impl RawDocumentBuf {
     /// them to owned types yourself.
     pub fn iter(&self) -> Iter<'_> {
         self.into_iter()
+    }
+
+    pub(crate) fn iter_at(&self, starting_at: usize) -> Iter<'_> {
+       Iter::new_at(self.as_ref(), starting_at)
     }
 
     /// Return the contained data as a `Vec<u8>`
@@ -358,6 +363,15 @@ impl TryFrom<RawDocumentBuf> for Document {
 
     fn try_from(raw: RawDocumentBuf) -> Result<Document> {
         Document::try_from(raw.as_ref())
+    }
+}
+
+impl IntoIterator for RawDocumentBuf {
+    type IntoIter = IntoIter;
+    type Item = Result<(String, RawBson)>;
+
+    fn into_iter(self) -> IntoIter {
+        IntoIter::new(self)
     }
 }
 

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -8,23 +8,13 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    de::MIN_BSON_DOCUMENT_SIZE,
-    spec::BinarySubtype,
-    Document,
-    RawBinaryRef,
+    de::MIN_BSON_DOCUMENT_SIZE, spec::BinarySubtype, Document, RawBinaryRef,
     RawJavaScriptCodeWithScopeRef,
 };
 
 use super::{
-    bson::RawBson,
-    serde::OwnedOrBorrowedRawDocument,
-    Error,
-    ErrorKind,
-    Iter,
-    IntoIter,
-    RawBsonRef,
-    RawDocument,
-    Result,
+    bson::RawBson, serde::OwnedOrBorrowedRawDocument, Error, ErrorKind, Iter, RawBsonRef,
+    RawDocument, Result,
 };
 
 /// An owned BSON document (akin to [`std::path::PathBuf`]), backed by a buffer of raw BSON bytes.
@@ -149,10 +139,6 @@ impl RawDocumentBuf {
     /// them to owned types yourself.
     pub fn iter(&self) -> Iter<'_> {
         self.into_iter()
-    }
-
-    pub(crate) fn iter_at(&self, starting_at: usize) -> Iter<'_> {
-       Iter::new_at(self.as_ref(), starting_at)
     }
 
     /// Return the contained data as a `Vec<u8>`
@@ -363,15 +349,6 @@ impl TryFrom<RawDocumentBuf> for Document {
 
     fn try_from(raw: RawDocumentBuf) -> Result<Document> {
         Document::try_from(raw.as_ref())
-    }
-}
-
-impl IntoIterator for RawDocumentBuf {
-    type IntoIter = IntoIter;
-    type Item = Result<(String, RawBson)>;
-
-    fn into_iter(self) -> IntoIter {
-        IntoIter::new(self)
     }
 }
 

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -46,6 +46,18 @@ impl<'a> Iter<'a> {
         }
     }
 
+    pub(crate) fn new_at(doc: &'a RawDocument, index: usize) -> Self {
+        Self {
+            doc,
+            offset: index,
+            valid: true
+        }
+    }
+
+    pub(crate) fn offset(&self) -> usize {
+        self.offset
+    }
+
     fn verify_enough_bytes(&self, start: usize, num_bytes: usize) -> Result<()> {
         let end = checked_add(start, num_bytes)?;
         if self.doc.as_bytes().get(start..end).is_none() {

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -5,13 +5,26 @@ use crate::{
     oid::ObjectId,
     raw::{Error, ErrorKind, Result},
     spec::{BinarySubtype, ElementType},
-    DateTime, Decimal128, RawBson, RawDocumentBuf, Timestamp,
+    DateTime,
+    Decimal128,
+    Timestamp,
 };
 
 use super::{
-    bson_ref::RawDbPointerRef, checked_add, error::try_with_key, f64_from_slice, i32_from_slice,
-    i64_from_slice, read_lenencoded, read_nullterminated, RawArray, RawBinaryRef, RawBsonRef,
-    RawDocument, RawJavaScriptCodeWithScopeRef, RawRegexRef,
+    bson_ref::RawDbPointerRef,
+    checked_add,
+    error::try_with_key,
+    f64_from_slice,
+    i32_from_slice,
+    i64_from_slice,
+    read_lenencoded,
+    read_nullterminated,
+    RawArray,
+    RawBinaryRef,
+    RawBsonRef,
+    RawDocument,
+    RawJavaScriptCodeWithScopeRef,
+    RawRegexRef,
 };
 
 /// An iterator over the document's entries.
@@ -319,40 +332,40 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-pub struct IntoIter {
-    document: RawDocumentBuf,
-    offset: usize,
-}
+// pub struct IntoIter {
+//     document: RawDocumentBuf,
+//     offset: usize,
+// }
 
-impl IntoIter {
-    pub(crate) fn new(document: RawDocumentBuf) -> Self {
-        Self {
-            document,
-            offset: 4,
-        }
-    }
+// impl IntoIter {
+//     pub(crate) fn new(document: RawDocumentBuf) -> Self {
+//         Self {
+//             document,
+//             offset: 4,
+//         }
+//     }
 
-    pub fn advance(&mut self) {
-        let mut iter = self.document.iter_at(self.offset);
-        iter.next();
-        self.offset = iter.offset;
-    }
+//     pub fn advance(&mut self) {
+//         let mut iter = self.document.iter_at(self.offset);
+//         iter.next();
+//         self.offset = iter.offset;
+//     }
 
-    pub fn current(&self) -> Option<Result<(&str, RawBsonRef)>> {
-        let mut iter = self.document.iter_at(self.offset);
-        iter.next()
-    }
-}
+//     pub fn current(&self) -> Option<Result<(&str, RawBsonRef)>> {
+//         let mut iter = self.document.iter_at(self.offset);
+//         iter.next()
+//     }
+// }
 
-impl Iterator for IntoIter {
-    type Item = Result<(String, RawBson)>;
+// impl Iterator for IntoIter {
+//     type Item = Result<(String, RawBson)>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut iter = self.document.iter_at(self.offset);
-        let out = iter
-            .next()
-            .map(|r| r.map(|(k, v)| (k.to_string(), v.to_raw_bson())));
-        self.offset = iter.offset();
-        out
-    }
-}
+//     fn next(&mut self) -> Option<Self::Item> {
+//         let mut iter = self.document.iter_at(self.offset);
+//         let out = iter
+//             .next()
+//             .map(|r| r.map(|(k, v)| (k.to_string(), v.to_raw_bson())));
+//         self.offset = iter.offset();
+//         out
+//     }
+// }

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -46,6 +46,7 @@ impl<'a> Iter<'a> {
         }
     }
 
+    #[cfg(feature = "unstable")]
     pub(crate) fn new_at(doc: &'a RawDocument, index: usize) -> Self {
         Self {
             doc,
@@ -54,6 +55,7 @@ impl<'a> Iter<'a> {
         }
     }
 
+    #[cfg(feature = "unstable")]
     pub(crate) fn offset(&self) -> usize {
         self.offset
     }
@@ -331,41 +333,3 @@ impl<'a> Iterator for Iter<'a> {
         Some(kvp_result)
     }
 }
-
-// pub struct IntoIter {
-//     document: RawDocumentBuf,
-//     offset: usize,
-// }
-
-// impl IntoIter {
-//     pub(crate) fn new(document: RawDocumentBuf) -> Self {
-//         Self {
-//             document,
-//             offset: 4,
-//         }
-//     }
-
-//     pub fn advance(&mut self) {
-//         let mut iter = self.document.iter_at(self.offset);
-//         iter.next();
-//         self.offset = iter.offset;
-//     }
-
-//     pub fn current(&self) -> Option<Result<(&str, RawBsonRef)>> {
-//         let mut iter = self.document.iter_at(self.offset);
-//         iter.next()
-//     }
-// }
-
-// impl Iterator for IntoIter {
-//     type Item = Result<(String, RawBson)>;
-
-//     fn next(&mut self) -> Option<Self::Item> {
-//         let mut iter = self.document.iter_at(self.offset);
-//         let out = iter
-//             .next()
-//             .map(|r| r.map(|(k, v)| (k.to_string(), v.to_raw_bson())));
-//         self.offset = iter.offset();
-//         out
-//     }
-// }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -130,7 +130,7 @@ use crate::de::MIN_BSON_STRING_SIZE;
 
 pub use self::{
     array::{RawArray, RawArrayIter},
-    array_buf::{RawArrayBuf, RawArrayBufIntoIter},
+    array_buf::RawArrayBuf,
     bson::{RawBson, RawJavaScriptCodeWithScope},
     bson_ref::{
         RawBinaryRef,
@@ -144,6 +144,9 @@ pub use self::{
     error::{Error, ErrorKind, Result, ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
     iter::Iter,
 };
+
+#[cfg(feature = "unstable")]
+pub use self::array_buf::RawArrayBufCopyingIter;
 
 /// Special newtype name indicating that the type being (de)serialized is a raw BSON document.
 pub(crate) const RAW_DOCUMENT_NEWTYPE: &str = "$__private__bson_RawDocument";

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -130,7 +130,7 @@ use crate::de::MIN_BSON_STRING_SIZE;
 
 pub use self::{
     array::{RawArray, RawArrayIter},
-    array_buf::RawArrayBuf,
+    array_buf::{RawArrayBuf, RawArrayBufIntoIter},
     bson::{RawBson, RawJavaScriptCodeWithScope},
     bson_ref::{
         RawBinaryRef,
@@ -142,7 +142,7 @@ pub use self::{
     document::RawDocument,
     document_buf::RawDocumentBuf,
     error::{Error, ErrorKind, Result, ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
-    iter::Iter,
+    iter::{Iter, IntoIter},
 };
 
 /// Special newtype name indicating that the type being (de)serialized is a raw BSON document.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -142,7 +142,7 @@ pub use self::{
     document::RawDocument,
     document_buf::RawDocumentBuf,
     error::{Error, ErrorKind, Result, ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
-    iter::{Iter, IntoIter},
+    iter::Iter,
 };
 
 /// Special newtype name indicating that the type being (de)serialized is a raw BSON document.

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -3,8 +3,15 @@ mod props;
 
 use super::*;
 use crate::{
-    doc, oid::ObjectId, raw::error::ValueAccessErrorKind, spec::BinarySubtype, Binary, Bson,
-    DateTime, Regex, Timestamp,
+    doc,
+    oid::ObjectId,
+    raw::error::ValueAccessErrorKind,
+    spec::BinarySubtype,
+    Binary,
+    Bson,
+    DateTime,
+    Regex,
+    Timestamp,
 };
 use chrono::{TimeZone, Utc};
 
@@ -398,43 +405,36 @@ fn document_iteration() {
         .as_str()
         .expect("was not str");
     assert_eq!(end, "END");
-
-    // assert_eq!(
-    //     rawdoc
-    //         .clone()
-    //         .into_iter()
-    //         .collect::<Result<Vec<(String, _)>>>()
-    //         .expect("collecting iterated doc")
-    //         .len(),
-    //     17
-    // );
-
-    // let items = rawdoc.iter().collect::<Result<Vec<(&str, _)>>>();
-    // let items = items
-    //     .unwrap()
-    //     .into_iter()
-    //     .map(|(k, v)| (k.to_string(), v.to_raw_bson()))
-    //     .collect::<Vec<(String, RawBson)>>();
-
-    // let mut manual_items = Vec::new(); 
-    // let mut iter = rawdoc.into_iter();
-    // while let Some(kvp) = iter.current() {
-    //     let (k, v) = kvp.unwrap();
-    //     manual_items.push((k.to_string(), v.to_raw_bson()));
-    //     iter.advance();
-    // }
-    // assert_eq!(manual_items, items);
 }
 
-// #[test]
-// fn into_iter_advance() {
-//     let doc = rawdoc! {
-//         "x": 1
-//     };
+#[test]
+#[cfg(feature = "unstable")]
+fn into_copying_iter() {
+    let doc = rawdoc! {
+        "array": [
+            true,
+            1_i32,
+            "a string",
+            { "a": "document" },
+            [ "an", "array", true ]
+        ]
+    };
+    let array = doc.get_array("array").unwrap().to_owned();
 
-//     let mut iter = doc.into_iter();
+    let mut iter = array.into_copying_iter();
 
-// }
+    assert_eq!(iter.next(), Some(Ok(rawbson!(true))));
+    assert_eq!(iter.next(), Some(Ok(rawbson!(1_i32))));
+    assert_eq!(iter.next(), Some(Ok(rawbson!("a string"))));
+    assert_eq!(iter.next(), Some(Ok(rawbson!({ "a": "document" }))));
+    assert_eq!(iter.next(), Some(Ok(rawbson!(["an", "array", true]))));
+    assert_eq!(iter.next(), None);
+
+    // check for panics
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+}
 
 #[test]
 fn into_bson_conversion() {

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -3,15 +3,8 @@ mod props;
 
 use super::*;
 use crate::{
-    doc,
-    oid::ObjectId,
-    raw::error::ValueAccessErrorKind,
-    spec::BinarySubtype,
-    Binary,
-    Bson,
-    DateTime,
-    Regex,
-    Timestamp,
+    doc, oid::ObjectId, raw::error::ValueAccessErrorKind, spec::BinarySubtype, Binary, Bson,
+    DateTime, Regex, Timestamp,
 };
 use chrono::{TimeZone, Utc};
 
@@ -392,7 +385,7 @@ fn document_iteration() {
 
     assert_eq!(
         rawdoc
-            .into_iter()
+            .iter()
             .collect::<Result<Vec<(&str, _)>>>()
             .expect("collecting iterated doc")
             .len(),
@@ -405,7 +398,43 @@ fn document_iteration() {
         .as_str()
         .expect("was not str");
     assert_eq!(end, "END");
+
+    // assert_eq!(
+    //     rawdoc
+    //         .clone()
+    //         .into_iter()
+    //         .collect::<Result<Vec<(String, _)>>>()
+    //         .expect("collecting iterated doc")
+    //         .len(),
+    //     17
+    // );
+
+    // let items = rawdoc.iter().collect::<Result<Vec<(&str, _)>>>();
+    // let items = items
+    //     .unwrap()
+    //     .into_iter()
+    //     .map(|(k, v)| (k.to_string(), v.to_raw_bson()))
+    //     .collect::<Vec<(String, RawBson)>>();
+
+    // let mut manual_items = Vec::new(); 
+    // let mut iter = rawdoc.into_iter();
+    // while let Some(kvp) = iter.current() {
+    //     let (k, v) = kvp.unwrap();
+    //     manual_items.push((k.to_string(), v.to_raw_bson()));
+    //     iter.advance();
+    // }
+    // assert_eq!(manual_items, items);
 }
+
+// #[test]
+// fn into_iter_advance() {
+//     let doc = rawdoc! {
+//         "x": 1
+//     };
+
+//     let mut iter = doc.into_iter();
+
+// }
 
 #[test]
 fn into_bson_conversion() {


### PR DESCRIPTION
RUST-1175

This PR introduces an iterator type that owns the underlying `RawArrayBuf` for use in cursors in the driver. The main advantage of this type over the existing, borrowed iterators is that by owning the underlying data, it can be paused and resumed in between polls of the cursor.

My first idea was simply to implement `IntoIterator` on `RawArrayBuf` and have it return this type, but that seemed like possibly a bad idea, since this iterator needs to copy out each element, despite owning the underlying data. This would make it really easy for users to do something like:

``` rust
for i in doc {
    println!("{:?}", i);
}
```
and not realizing they're making needless copies. To that end, I introduced an `into_copying_iter()` method on `RawArrayBuf`, which does the same thing but prevents users from accidentally making extra copies. Since this didn't seem like generally useful API, I gated it behind an "unstable" feature flag, with the warning that its API is not stable. A slight wrinkle in that is we need it in the driver, and since Cargo unions all the feature flags for a given dependency, all users of the driver will have the `"unstable"` flag enabled for them, which sort of defeats it's purpose.

I don't think we have any great options here for introducing private BSON functionality. IMO, the `IntoIterator` stuff bleeds into the actual user's interface a bit too much, hence why I went this route, but I also see the flaws in this approach too. Not exactly sure what's the best path here, so would appreciate any opinions.