### PR TITLE
RUST-1195 Add missing trait impls to `Uuid`

### DIFF
--- a/src/uuid/mod.rs
+++ b/src/uuid/mod.rs
@@ -162,7 +162,7 @@ pub(crate) const UUID_NEWTYPE_NAME: &str = "$__bson_private_uuid";
 /// will also allow deserialization from 16 byte + subtype 0 Binary values in BSON if part of a
 /// `#[serde(flatten)]` chain. This behavior shouldn't be relied upon as it may be fixed at some
 /// point in the future.
-#[derive(Clone, Copy, PartialEq, Hash)]
+#[derive(Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub struct Uuid {
     uuid: uuid::Uuid,
 }


### PR DESCRIPTION
Add traits that exist in `uuid::Uuid` but were missing in `bson::Uuid`.

This is particularly useful for usage in a `HashMap` where `Eq` is required for most methods.