### PR TITLE
RUST-1243 Handle enum keys when deserializing a map from binary

### DIFF
--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -410,7 +410,7 @@ fn hashmap_enum_key() {
     };
     let doc = doc! {
         "map": {
-            "Baz": "2",  
+            "Baz": "2",
         },
     };
     run_test(&obj, &doc, "hashmap_enum_key");

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -14,7 +14,7 @@ use serde::{
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     iter::FromIterator,
 };
 
@@ -391,6 +391,29 @@ fn hashmap() {
         "set": ["a"]
     };
     run_test(&v, &doc, "hashmap");
+}
+
+#[test]
+fn hashmap_enum_key() {
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct Foo {
+        map: HashMap<Bar, String>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+    enum Bar {
+        Baz,
+    }
+
+    let obj = Foo {
+        map: HashMap::from_iter([(Bar::Baz, "1".to_owned()), (Bar::Baz, "2".to_owned())]),
+    };
+    let doc = doc! {
+        "map": {
+            "Baz": "2",  
+        },
+    };
+    run_test(&obj, &doc, "hashmap_enum_key");
 }
 
 #[test]

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -14,7 +14,7 @@ use serde::{
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     iter::FromIterator,
 };
 
@@ -397,16 +397,16 @@ fn hashmap() {
 fn hashmap_enum_key() {
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     struct Foo {
-        map: HashMap<Bar, String>,
+        map: BTreeMap<Bar, String>,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, PartialOrd, Ord)]
     enum Bar {
         Baz,
     }
 
     let obj = Foo {
-        map: HashMap::from_iter([(Bar::Baz, "1".to_owned()), (Bar::Baz, "2".to_owned())]),
+        map: BTreeMap::from_iter([(Bar::Baz, "2".to_owned())]),
     };
     let doc = doc! {
         "map": {

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -651,7 +651,11 @@ impl<'d, 'de> serde::de::Deserializer<'de> for DocumentKeyDeserializer<'d, 'de> 
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_enum(self.root_deserializer.deserialize_cstr()?.into_deserializer())
+        visitor.visit_enum(
+            self.root_deserializer
+                .deserialize_cstr()?
+                .into_deserializer(),
+        )
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -642,6 +642,18 @@ impl<'d, 'de> serde::de::Deserializer<'de> for DocumentKeyDeserializer<'d, 'de> 
         }
     }
 
+    fn deserialize_enum<V>(
+        self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_enum(self.root_deserializer.deserialize_cstr()?.into_deserializer())
+    }
+
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'de>,
@@ -655,7 +667,7 @@ impl<'d, 'de> serde::de::Deserializer<'de> for DocumentKeyDeserializer<'d, 'de> 
 
     forward_to_deserialize_any! {
         bool char str bytes byte_buf option unit unit_struct string
-        identifier seq tuple tuple_struct struct map enum
+        identifier seq tuple tuple_struct struct map
         ignored_any i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
     }
 }


### PR DESCRIPTION
RUST-1243

Prior to this PR, all keys were treated as strings, so the deserialization would fail with "invalid type: string \"Key\", expected enum Enum".  This bug doesn't occur when deserializing from the parsed Bson types because that one uses the main deserializer to parse the key (which knows how to handle enum values) rather than a specialized one.