### PR TITLE
RUST-1240 Fix potential underflow in length counting

### DIFF
--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -1405,3 +1405,8 @@ fn non_human_readable() {
     assert_eq!(human_readable, expected);
     assert_eq!(human_readable, non_human_readable);
 }
+
+#[test]
+fn fuzz_regression() {
+    assert!(bson::from_slice::<Document>(&[4, 0, 0, 128, 0, 87]).is_err());
+}

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -171,9 +171,11 @@ impl<'de> Deserializer<'de> {
     where
         F: FnOnce(DocumentAccess<'_, 'de>) -> Result<O>,
     {
-        let mut length_remaining = read_i32(&mut self.bytes)?
-            .checked_sub(4)
-            .ok_or_else(|| Error::custom("invalid length, less than min document size"))?;
+        let mut length_remaining = read_i32(&mut self.bytes)?;
+        if length_remaining < 4 {
+            return Err(Error::custom("invalid length, less than min document size"));
+        }
+        length_remaining -= 4;
         let out = f(DocumentAccess {
             root_deserializer: self,
             length_remaining: &mut length_remaining,


### PR DESCRIPTION
RUST-1240

Because `length_remaining` is an `i32`, the `checked_sub` call would allow (invalid) negative values; this was caught by the fuzzer because this particular fuzz input happened to create a value negative enough that further subtraction elsewhere underflowed.

As far as I can tell this doesn't have safety implications; the underlying buffer is accessed through a safe slice, so this would have caused a panic or at worst garbage parsed data.