### PR TITLE
RUST-1129 Make the dependency on `chrono` optional and provide equivalent `time` interop

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -181,9 +181,9 @@ axes:
   - id: "extra-rust-versions"
     values:
       - id: "min"
-        display_name: "1.51 (minimum supported version)"
+        display_name: "1.53 (minimum supported version)"
         variables:
-          RUST_VERSION: "1.51.0"
+          RUST_VERSION: "1.53.0"
       - id: "nightly"
         display_name: "nightly"
         variables:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -181,9 +181,9 @@ axes:
   - id: "extra-rust-versions"
     values:
       - id: "min"
-        display_name: "1.48 (minimum supported version)"
+        display_name: "1.51 (minimum supported version)"
         variables:
-          RUST_VERSION: "1.48.0"
+          RUST_VERSION: "1.51.0"
       - id: "nightly"
         display_name: "nightly"
         variables:

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 . ~/.cargo/env
 RUST_BACKTRACE=1 cargo test
-RUST_BACKTRACE=1 cargo test --features chrono-0_4,uuid-0_8,time-0_3,serde_with
+RUST_BACKTRACE=1 cargo test --all-features
 
 cd serde-tests
 RUST_BACKTRACE=1 cargo test

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 . ~/.cargo/env
 RUST_BACKTRACE=1 cargo test
-RUST_BACKTRACE=1 cargo test --features chrono-0_4,uuid-0_8
+RUST_BACKTRACE=1 cargo test --features chrono-0_4,uuid-0_8,time-0_3,serde_with
 
 cd serde-tests
 RUST_BACKTRACE=1 cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,9 @@ lazy_static = "1.4.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
-time = { version = "0.3.9", features = ["formatting", "parsing", "macros"] }
+# TODO RUST-1256 Update time to latest and remove time-macros.
+time = { version = "=0.3.5", features = ["formatting", "parsing", "macros"] }
+time-macros = "=0.2.3"
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
 # TODO RUST-1256 Update time to latest and remove time-macros.
-time = { version = "=0.3.5", features = ["formatting", "parsing", "macros"] }
+time = { version = "=0.3.5", features = ["formatting", "parsing", "macros", "large-dates"] }
 time-macros = "=0.2.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,7 @@ lazy_static = "1.4.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
-# TODO RUST-1256 Update time to latest and remove time-macros.
-time = { version = "=0.3.5", features = ["formatting", "parsing", "macros", "large-dates"] }
-time-macros = "=0.2.3"
+time = { version = "0.3.9", features = ["formatting", "parsing", "macros", "large-dates"] }
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,11 @@ exclude = [
 [features]
 default = []
 # if enabled, include API for interfacing with chrono 0.4
-chrono-0_4 = []
+chrono-0_4 = ["chrono"]
 # if enabled, include API for interfacing with uuid 0.8
 uuid-0_8 = []
+# if enabled, include API for interfacing with time 0.3
+time-0_3 = []
 # if enabled, include serde_with interop.
 # should be used in conjunction with chrono-0_4 or uuid-0_8.
 # it's commented out here because Cargo implicitly adds a feature flag for
@@ -47,7 +49,7 @@ name = "bson"
 
 [dependencies]
 ahash = "0.7.2"
-chrono = { version = "0.4.15", features = ["std"], default-features = false }
+chrono = { version = "0.4.15", features = ["std"], default-features = false, optional = true }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
@@ -58,6 +60,7 @@ lazy_static = "1.4.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
+time = { version = "0.3.9", features = ["formatting", "parsing"] }
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ lazy_static = "1.4.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
-time = { version = "0.3.9", features = ["formatting", "parsing"] }
+time = { version = "0.3.9", features = ["formatting", "parsing", "macros"] }
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -437,9 +437,10 @@ impl Bson {
                 })
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 99999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 9999 => {
                 json!({
-                    "$date": v.to_rfc3339_string(),
+                    // Unwrap safety: timestamps in the guarded range can always be formatted.
+                    "$date": v.try_to_rfc3339_string().unwrap(),
                 })
             }
             Bson::DateTime(v) => json!({
@@ -601,7 +602,8 @@ impl Bson {
             },
             Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 9999 => {
                 doc! {
-                    "$date": v.to_rfc3339_string(),
+                    // Unwrap safety: timestamps in the guarded range can always be formatted.
+                    "$date": v.try_to_rfc3339_string().unwrap(),
                 }
             }
             Bson::DateTime(v) => doc! {

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -32,8 +32,9 @@ pub use crate::document::Document;
 use crate::{
     oid::{self, ObjectId},
     spec::{BinarySubtype, ElementType},
+    DateTime,
     Decimal128,
-    RawBinaryRef, DateTime,
+    RawBinaryRef,
 };
 
 /// Possible BSON value types.
@@ -437,8 +438,7 @@ impl Bson {
                 })
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
-            Bson::DateTime(v) if dt_use_rfc3339(&v) =>
-            {
+            Bson::DateTime(v) if dt_use_rfc3339(&v) => {
                 json!({
                     "$date": v.to_rfc3339_string(),
                 })
@@ -600,8 +600,7 @@ impl Bson {
             Bson::DateTime(v) if rawbson => doc! {
                 "$date": v.timestamp_millis(),
             },
-            Bson::DateTime(v) if dt_use_rfc3339(&v) =>
-            {
+            Bson::DateTime(v) if dt_use_rfc3339(&v) => {
                 doc! {
                     "$date": v.to_rfc3339_string(),
                 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -599,7 +599,7 @@ impl Bson {
             Bson::DateTime(v) if rawbson => doc! {
                 "$date": v.timestamp_millis(),
             },
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 9999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.timestamp_millis() <= 253402300799999 => {
                 doc! {
                     "$date": v.to_rfc3339_string(),
                 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -26,7 +26,6 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
 };
 
-use chrono::Datelike;
 use serde_json::{json, Value};
 
 pub use crate::document::Document;
@@ -430,7 +429,7 @@ impl Bson {
                 })
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 99999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 99999 => {
                 json!({
                     "$date": v.to_rfc3339_string(),
                 })
@@ -592,7 +591,7 @@ impl Bson {
             Bson::DateTime(v) if rawbson => doc! {
                 "$date": v.timestamp_millis(),
             },
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_chrono().year() <= 9999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 9999 => {
                 doc! {
                     "$date": v.to_rfc3339_string(),
                 }
@@ -776,8 +775,8 @@ impl Bson {
                 }
 
                 if let Ok(date) = doc.get_str("$date") {
-                    if let Ok(date) = chrono::DateTime::parse_from_rfc3339(date) {
-                        return Bson::DateTime(crate::DateTime::from_chrono(date));
+                    if let Ok(dt) = crate::DateTime::parse_rfc3339_str(date) {
+                        return Bson::DateTime(dt);
                     }
                 }
             }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -599,7 +599,9 @@ impl Bson {
             Bson::DateTime(v) if rawbson => doc! {
                 "$date": v.timestamp_millis(),
             },
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.timestamp_millis() <= 253402300799999 => {
+            Bson::DateTime(v)
+                if v.timestamp_millis() >= 0 && v.timestamp_millis() <= 253402300799999 =>
+            {
                 doc! {
                     "$date": v.to_rfc3339_string(),
                 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -437,7 +437,7 @@ impl Bson {
                 })
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 9999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time_0_3().year() <= 9999 => {
                 json!({
                     // Unwrap safety: timestamps in the guarded range can always be formatted.
                     "$date": v.try_to_rfc3339_string().unwrap(),
@@ -600,7 +600,7 @@ impl Bson {
             Bson::DateTime(v) if rawbson => doc! {
                 "$date": v.timestamp_millis(),
             },
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 9999 => {
+            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time_0_3().year() <= 9999 => {
                 doc! {
                     // Unwrap safety: timestamps in the guarded range can always be formatted.
                     "$date": v.try_to_rfc3339_string().unwrap(),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -371,6 +371,9 @@ impl From<Bson> for Value {
     }
 }
 
+// 9999-12-31 23:59:59.999
+const MAX_RFC3339_TIMESTAMP: i64 = 253402300799999;
+
 impl Bson {
     /// Converts the Bson value into its [relaxed extended JSON representation](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
     ///
@@ -437,7 +440,9 @@ impl Bson {
                 })
             }
             Bson::ObjectId(v) => json!({"$oid": v.to_hex()}),
-            Bson::DateTime(v) if v.timestamp_millis() >= 0 && v.to_time().year() <= 99999 => {
+            Bson::DateTime(v)
+                if v.timestamp_millis() >= 0 && v.timestamp_millis() <= MAX_RFC3339_TIMESTAMP =>
+            {
                 json!({
                     "$date": v.to_rfc3339_string(),
                 })
@@ -600,7 +605,7 @@ impl Bson {
                 "$date": v.timestamp_millis(),
             },
             Bson::DateTime(v)
-                if v.timestamp_millis() >= 0 && v.timestamp_millis() <= 253402300799999 =>
+                if v.timestamp_millis() >= 0 && v.timestamp_millis() <= MAX_RFC3339_TIMESTAMP =>
             {
                 doc! {
                     "$date": v.to_rfc3339_string(),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -310,6 +310,14 @@ impl From<oid::ObjectId> for Bson {
     }
 }
 
+#[cfg(feature = "time-0_3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time-0_3")))]
+impl From<time::OffsetDateTime> for Bson {
+    fn from(a: time::OffsetDateTime) -> Bson {
+        Bson::DateTime(crate::DateTime::from(a))
+    }
+}
+
 #[cfg(feature = "chrono-0_4")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono-0_4")))]
 impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for Bson {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -194,16 +194,10 @@ impl crate::DateTime {
     fn to_time_private(self) -> time::OffsetDateTime {
         match self.to_time_opt() {
             Some(dt) => dt,
-            // TODO RUST-1256 use time::PrimitiveDateTime::{MIN, MAX} here.
             None => if self.0 < 0 {
-                time::PrimitiveDateTime::new(time::Date::MIN, time::Time::MIDNIGHT)
+                time::PrimitiveDateTime::MIN
             } else {
-                // unwrap safety: the constants here are within the representable range of
-                // `time::Time`.
-                time::PrimitiveDateTime::new(
-                    time::Date::MAX,
-                    time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap(),
-                )
+                time::PrimitiveDateTime::MAX
             }
             .assume_utc(),
         }
@@ -222,7 +216,7 @@ impl crate::DateTime {
     /// Convert this [`DateTime`] to a [`time::OffsetDateTime`].
     ///
     /// Note: Not every BSON datetime can be represented as a [`time::OffsetDateTime`]. For such
-    /// dates, the minimum or maximum representable `time::OffsetDateTime` will be
+    /// dates, [`time::PrimitiveDateTime::MIN`] or [`time::PrimitiveDateTime::MAX`] will be
     /// returned, whichever is closer.
     ///
     /// ```
@@ -232,7 +226,7 @@ impl crate::DateTime {
     ///
     /// let big = bson::DateTime::from_millis(i64::MIN);
     /// let time_big = big.to_time();
-    /// assert_eq!(time_big, time::PrimitiveDateTime::new(time::Date::MIN, time::Time::MIDNIGHT).assume_utc())
+    /// assert_eq!(time_big, time::PrimitiveDateTime::MIN.assume_utc())
     /// ```
     #[cfg(feature = "time-0_3")]
     #[cfg_attr(docsrs, doc(cfg(feature = "time-0_3")))]

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -203,7 +203,7 @@ impl crate::DateTime {
         }
     }
 
-    fn to_time_opt(self) -> Option<time::OffsetDateTime> {
+    pub(crate) fn to_time_opt(self) -> Option<time::OffsetDateTime> {
         time::OffsetDateTime::UNIX_EPOCH.checked_add(time::Duration::milliseconds(self.0))
     }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -198,8 +198,12 @@ impl crate::DateTime {
             None => if self.0 < 0 {
                 time::PrimitiveDateTime::new(time::Date::MIN, time::Time::MIDNIGHT)
             } else {
-                // unwrap safety: the constants here are within the representable range of `time::Time`.
-                time::PrimitiveDateTime::new(time::Date::MAX, time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap())
+                // unwrap safety: the constants here are within the representable range of
+                // `time::Time`.
+                time::PrimitiveDateTime::new(
+                    time::Date::MAX,
+                    time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap(),
+                )
             }
             .assume_utc(),
         }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -213,7 +213,7 @@ impl crate::DateTime {
     /// ```
     /// let bson_dt = bson::DateTime::now();
     /// let time_dt = bson_dt.to_time();
-    /// assert_eq!(bson_dt.timestamp_millis() / 1000, time_dt.timestamp());
+    /// assert_eq!(bson_dt.timestamp_millis() / 1000, time_dt.unix_timestamp());
     ///
     /// let big = bson::DateTime::from_millis(i64::MAX);
     /// let time_big = big.to_time();

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -176,7 +176,7 @@ impl crate::DateTime {
 
     #[cfg(not(feature = "time-0_3"))]
     #[allow(unused)]
-    pub(crate) fn from_time(dt: time::OffsetDateTime) -> Self {
+    pub(crate) fn from_time_0_3(dt: time::OffsetDateTime) -> Self {
         Self::from_time_private(dt)
     }
 
@@ -187,7 +187,7 @@ impl crate::DateTime {
     /// by a BSON datetime, either [`DateTime::MAX`] or [`DateTime::MIN`] will be
     /// returned, whichever is closer.
     #[cfg(feature = "time-0_3")]
-    pub fn from_time(dt: time::OffsetDateTime) -> Self {
+    pub fn from_time_0_3(dt: time::OffsetDateTime) -> Self {
         Self::from_time_private(dt)
     }
 
@@ -209,7 +209,7 @@ impl crate::DateTime {
 
     #[cfg(not(feature = "time-0_3"))]
     #[allow(unused)]
-    pub(crate) fn to_time(self) -> time::OffsetDateTime {
+    pub(crate) fn to_time_0_3(self) -> time::OffsetDateTime {
         self.to_time_private()
     }
 
@@ -221,16 +221,16 @@ impl crate::DateTime {
     ///
     /// ```
     /// let bson_dt = bson::DateTime::now();
-    /// let time_dt = bson_dt.to_time();
+    /// let time_dt = bson_dt.to_time_0_3();
     /// assert_eq!(bson_dt.timestamp_millis() / 1000, time_dt.unix_timestamp());
     ///
     /// let big = bson::DateTime::from_millis(i64::MIN);
-    /// let time_big = big.to_time();
+    /// let time_big = big.to_time_0_3();
     /// assert_eq!(time_big, time::PrimitiveDateTime::MIN.assume_utc())
     /// ```
     #[cfg(feature = "time-0_3")]
     #[cfg_attr(docsrs, doc(cfg(feature = "time-0_3")))]
-    pub fn to_time(self) -> time::OffsetDateTime {
+    pub fn to_time_0_3(self) -> time::OffsetDateTime {
         self.to_time_private()
     }
 
@@ -285,7 +285,7 @@ impl crate::DateTime {
 
     /// Convert this [`DateTime`] to an RFC 3339 formatted string.
     pub fn try_to_rfc3339_string(self) -> Result<String> {
-        self.to_time()
+        self.to_time_0_3()
             .format(&Rfc3339)
             .map_err(|e| Error::CannotFormat {
                 message: e.to_string(),
@@ -300,7 +300,7 @@ impl crate::DateTime {
                 message: e.to_string(),
             }
         })?;
-        Ok(Self::from_time(odt))
+        Ok(Self::from_time_0_3(odt))
     }
 }
 
@@ -383,7 +383,7 @@ impl SerializeAs<chrono::DateTime<Utc>> for crate::DateTime {
 #[cfg_attr(docsrs, doc(cfg(feature = "time-0_3")))]
 impl From<crate::DateTime> for time::OffsetDateTime {
     fn from(bson_dt: DateTime) -> Self {
-        bson_dt.to_time()
+        bson_dt.to_time_0_3()
     }
 }
 
@@ -391,7 +391,7 @@ impl From<crate::DateTime> for time::OffsetDateTime {
 #[cfg_attr(docsrs, doc(cfg(feature = "time-0_3")))]
 impl From<time::OffsetDateTime> for crate::DateTime {
     fn from(x: time::OffsetDateTime) -> Self {
-        Self::from_time(x)
+        Self::from_time_0_3(x)
     }
 }
 
@@ -403,7 +403,7 @@ impl<'de> DeserializeAs<'de, time::OffsetDateTime> for crate::DateTime {
         D: Deserializer<'de>,
     {
         let dt = DateTime::deserialize(deserializer)?;
-        Ok(dt.to_time())
+        Ok(dt.to_time_0_3())
     }
 }
 
@@ -417,7 +417,7 @@ impl SerializeAs<time::OffsetDateTime> for crate::DateTime {
     where
         S: serde::Serializer,
     {
-        let dt = DateTime::from_time(*source);
+        let dt = DateTime::from_time_0_3(*source);
         dt.serialize(serializer)
     }
 }

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -1,6 +1,5 @@
 //! A module defining serde models for the extended JSON representations of the various BSON types.
 
-use chrono::Utc;
 use serde::{
     de::{Error, Unexpected},
     Deserialize,
@@ -256,8 +255,8 @@ impl DateTime {
                 Ok(crate::DateTime::from_millis(date))
             }
             DateTimeBody::Relaxed(date) => {
-                let datetime: chrono::DateTime<Utc> =
-                    chrono::DateTime::parse_from_rfc3339(date.as_str())
+                let datetime =
+                    crate::DateTime::parse_rfc3339_str(date.as_str())
                         .map_err(|_| {
                             extjson::de::Error::invalid_value(
                                 Unexpected::Str(date.as_str()),
@@ -265,7 +264,7 @@ impl DateTime {
                             )
                         })?
                         .into();
-                Ok(crate::DateTime::from_chrono(datetime))
+                Ok(datetime)
             }
         }
     }

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -255,15 +255,14 @@ impl DateTime {
                 Ok(crate::DateTime::from_millis(date))
             }
             DateTimeBody::Relaxed(date) => {
-                let datetime =
-                    crate::DateTime::parse_rfc3339_str(date.as_str())
-                        .map_err(|_| {
-                            extjson::de::Error::invalid_value(
-                                Unexpected::Str(date.as_str()),
-                                &"rfc3339 formatted utc datetime",
-                            )
-                        })?
-                        .into();
+                let datetime = crate::DateTime::parse_rfc3339_str(date.as_str())
+                    .map_err(|_| {
+                        extjson::de::Error::invalid_value(
+                            Unexpected::Str(date.as_str()),
+                            &"rfc3339 formatted utc datetime",
+                        )
+                    })?
+                    .into();
                 Ok(datetime)
             }
         }

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -255,13 +255,12 @@ impl DateTime {
                 Ok(crate::DateTime::from_millis(date))
             }
             DateTimeBody::Relaxed(date) => {
-                let datetime = crate::DateTime::parse_rfc3339_str(date.as_str())
-                    .map_err(|_| {
-                        extjson::de::Error::invalid_value(
-                            Unexpected::Str(date.as_str()),
-                            &"rfc3339 formatted utc datetime",
-                        )
-                    })?;
+                let datetime = crate::DateTime::parse_rfc3339_str(date.as_str()).map_err(|_| {
+                    extjson::de::Error::invalid_value(
+                        Unexpected::Str(date.as_str()),
+                        &"rfc3339 formatted utc datetime",
+                    )
+                })?;
                 Ok(datetime)
             }
         }

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -261,8 +261,7 @@ impl DateTime {
                             Unexpected::Str(date.as_str()),
                             &"rfc3339 formatted utc datetime",
                         )
-                    })?
-                    .into();
+                    })?;
                 Ok(datetime)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ## Installation
 //! ### Requirements
-//! - Rust 1.51+
+//! - Rust 1.53+
 //!
 //! ### Importing
 //! This crate is available on [crates.io](https://crates.io/crates/bson). To use it in your application,
@@ -260,7 +260,7 @@
 //!
 //! ## Minimum supported Rust version (MSRV)
 //!
-//! The MSRV for this crate is currently 1.51.0. This will be rarely be increased, and if it ever is,
+//! The MSRV for this crate is currently 1.53.0. This will be rarely be increased, and if it ever is,
 //! it will only happen in a minor or major version release.
 
 #![allow(clippy::cognitive_complexity)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ## Installation
 //! ### Requirements
-//! - Rust 1.48+
+//! - Rust 1.51+
 //!
 //! ### Importing
 //! This crate is available on [crates.io](https://crates.io/crates/bson). To use it in your application,
@@ -260,7 +260,7 @@
 //!
 //! ## Minimum supported Rust version (MSRV)
 //!
-//! The MSRV for this crate is currently 1.48.0. This will be rarely be increased, and if it ever is,
+//! The MSRV for this crate is currently 1.51.0. This will be rarely be increased, and if it ever is,
 //! it will only happen in a minor or major version release.
 
 #![allow(clippy::cognitive_complexity)]

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -310,30 +310,18 @@ mod test {
     fn test_timestamp() {
         let id = super::ObjectId::parse_str("000000000000000000000000").unwrap();
         // "Jan 1st, 1970 00:00:00 UTC"
-        assert_eq!(
-            datetime!(1970-01-01 0:00 UTC),
-            id.timestamp().to_time()
-        );
+        assert_eq!(datetime!(1970-01-01 0:00 UTC), id.timestamp().to_time());
 
         let id = super::ObjectId::parse_str("7FFFFFFF0000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:07 UTC"
-        assert_eq!(
-            datetime!(2038-01-19 3:14:07 UTC),
-            id.timestamp().to_time()
-        );
+        assert_eq!(datetime!(2038-01-19 3:14:07 UTC), id.timestamp().to_time());
 
         let id = super::ObjectId::parse_str("800000000000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:08 UTC"
-        assert_eq!(
-            datetime!(2038-01-19 3:14:08 UTC),
-            id.timestamp().to_time()
-        );
+        assert_eq!(datetime!(2038-01-19 3:14:08 UTC), id.timestamp().to_time());
 
         let id = super::ObjectId::parse_str("FFFFFFFF0000000000000000").unwrap();
         // "Feb 7th, 2106 06:28:15 UTC"
-        assert_eq!(
-            datetime!(2106-02-07 6:28:15 UTC),
-            id.timestamp().to_time()
-        );
+        assert_eq!(datetime!(2106-02-07 6:28:15 UTC), id.timestamp().to_time());
     }
 }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -314,14 +314,23 @@ mod test {
 
         let id = super::ObjectId::parse_str("7FFFFFFF0000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:07 UTC"
-        assert_eq!(datetime!(2038-01-19 3:14:07 UTC), id.timestamp().to_time_0_3());
+        assert_eq!(
+            datetime!(2038-01-19 3:14:07 UTC),
+            id.timestamp().to_time_0_3()
+        );
 
         let id = super::ObjectId::parse_str("800000000000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:08 UTC"
-        assert_eq!(datetime!(2038-01-19 3:14:08 UTC), id.timestamp().to_time_0_3());
+        assert_eq!(
+            datetime!(2038-01-19 3:14:08 UTC),
+            id.timestamp().to_time_0_3()
+        );
 
         let id = super::ObjectId::parse_str("FFFFFFFF0000000000000000").unwrap();
         // "Feb 7th, 2106 06:28:15 UTC"
-        assert_eq!(datetime!(2106-02-07 6:28:15 UTC), id.timestamp().to_time_0_3());
+        assert_eq!(
+            datetime!(2106-02-07 6:28:15 UTC),
+            id.timestamp().to_time_0_3()
+        );
     }
 }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -283,7 +283,7 @@ fn test_counter_overflow_usize_max() {
 
 #[cfg(test)]
 mod test {
-    use chrono::{offset::TimeZone, Utc};
+    use time::macros::datetime;
 
     #[test]
     fn test_display() {
@@ -311,29 +311,29 @@ mod test {
         let id = super::ObjectId::parse_str("000000000000000000000000").unwrap();
         // "Jan 1st, 1970 00:00:00 UTC"
         assert_eq!(
-            Utc.ymd(1970, 1, 1).and_hms(0, 0, 0),
-            id.timestamp().to_chrono()
+            datetime!(1970-01-01 0:00 UTC),
+            id.timestamp().to_time()
         );
 
         let id = super::ObjectId::parse_str("7FFFFFFF0000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:07 UTC"
         assert_eq!(
-            Utc.ymd(2038, 1, 19).and_hms(3, 14, 7),
-            id.timestamp().to_chrono()
+            datetime!(2038-01-19 3:14:07 UTC),
+            id.timestamp().to_time()
         );
 
         let id = super::ObjectId::parse_str("800000000000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:08 UTC"
         assert_eq!(
-            Utc.ymd(2038, 1, 19).and_hms(3, 14, 8),
-            id.timestamp().to_chrono()
+            datetime!(2038-01-19 3:14:08 UTC),
+            id.timestamp().to_time()
         );
 
         let id = super::ObjectId::parse_str("FFFFFFFF0000000000000000").unwrap();
         // "Feb 7th, 2106 06:28:15 UTC"
         assert_eq!(
-            Utc.ymd(2106, 2, 7).and_hms(6, 28, 15),
-            id.timestamp().to_chrono()
+            datetime!(2106-02-07 6:28:15 UTC),
+            id.timestamp().to_time()
         );
     }
 }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -310,18 +310,18 @@ mod test {
     fn test_timestamp() {
         let id = super::ObjectId::parse_str("000000000000000000000000").unwrap();
         // "Jan 1st, 1970 00:00:00 UTC"
-        assert_eq!(datetime!(1970-01-01 0:00 UTC), id.timestamp().to_time());
+        assert_eq!(datetime!(1970-01-01 0:00 UTC), id.timestamp().to_time_0_3());
 
         let id = super::ObjectId::parse_str("7FFFFFFF0000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:07 UTC"
-        assert_eq!(datetime!(2038-01-19 3:14:07 UTC), id.timestamp().to_time());
+        assert_eq!(datetime!(2038-01-19 3:14:07 UTC), id.timestamp().to_time_0_3());
 
         let id = super::ObjectId::parse_str("800000000000000000000000").unwrap();
         // "Jan 19th, 2038 03:14:08 UTC"
-        assert_eq!(datetime!(2038-01-19 3:14:08 UTC), id.timestamp().to_time());
+        assert_eq!(datetime!(2038-01-19 3:14:08 UTC), id.timestamp().to_time_0_3());
 
         let id = super::ObjectId::parse_str("FFFFFFFF0000000000000000").unwrap();
         // "Feb 7th, 2106 06:28:15 UTC"
-        assert_eq!(datetime!(2106-02-07 6:28:15 UTC), id.timestamp().to_time());
+        assert_eq!(datetime!(2106-02-07 6:28:15 UTC), id.timestamp().to_time_0_3());
     }
 }

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -238,7 +238,10 @@ fn datetime() {
         .expect("no key datetime")
         .as_datetime()
         .expect("result was not datetime");
-    assert_eq!(datetime.to_rfc3339_string(), "2000-10-31T12:30:45Z");
+    assert_eq!(
+        datetime.try_to_rfc3339_string().unwrap(),
+        "2000-10-31T12:30:45Z"
+    );
 }
 
 #[test]

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -230,7 +230,7 @@ fn datetime() {
 
     let rawdoc = rawdoc! {
         "boolean": true,
-        "datetime": DateTime::from_time(datetime!(2000-10-31 12:30:45 UTC)),
+        "datetime": DateTime::from_time_0_3(datetime!(2000-10-31 12:30:45 UTC)),
     };
     let datetime = rawdoc
         .get("datetime")

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     Regex,
     Timestamp,
 };
-use chrono::{TimeZone, Utc};
 
 #[test]
 fn string_from_document() {
@@ -227,9 +226,11 @@ fn boolean() {
 
 #[test]
 fn datetime() {
+    use time::macros::datetime;
+
     let rawdoc = rawdoc! {
         "boolean": true,
-        "datetime": DateTime::from_chrono(Utc.ymd(2000,10,31).and_hms(12, 30, 45)),
+        "datetime": DateTime::from_time(datetime!(2000-10-31 12:30:45 UTC)),
     };
     let datetime = rawdoc
         .get("datetime")

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -17,12 +17,6 @@ pub use chrono_datetime_as_bson_datetime::{
     deserialize as deserialize_chrono_datetime_from_bson_datetime,
     serialize as serialize_chrono_datetime_as_bson_datetime,
 };
-#[cfg(feature = "time-0_3")]
-#[doc(inline)]
-pub use time_offsetdatetime_as_bson_datetime::{
-    deserialize as deserialize_time_offsetdatetime_from_bson_datetime,
-    serialize as serialize_time_offsetdatetime_as_bson_datetime,
-};
 #[doc(inline)]
 pub use hex_string_as_object_id::{
     deserialize as deserialize_hex_string_from_object_id,
@@ -32,6 +26,12 @@ pub use hex_string_as_object_id::{
 pub use rfc3339_string_as_bson_datetime::{
     deserialize as deserialize_rfc3339_string_from_bson_datetime,
     serialize as serialize_rfc3339_string_as_bson_datetime,
+};
+#[cfg(feature = "time-0_3")]
+#[doc(inline)]
+pub use time_offsetdatetime_as_bson_datetime::{
+    deserialize as deserialize_time_offsetdatetime_from_bson_datetime,
+    serialize as serialize_time_offsetdatetime_as_bson_datetime,
 };
 #[doc(inline)]
 pub use timestamp_as_u32::{
@@ -191,8 +191,8 @@ pub mod u64_as_f64 {
     }
 }
 
-/// Contains functions to serialize a [`time::OffsetDateTime`] as a [`crate::DateTime`] and deserialize
-/// a [`time::OffsetDateTime`] from a [`crate::DateTime`].
+/// Contains functions to serialize a [`time::OffsetDateTime`] as a [`crate::DateTime`] and
+/// deserialize a [`time::OffsetDateTime`] from a [`crate::DateTime`].
 ///
 /// ```rust
 /// # #[cfg(feature = "chrono-0_4")]
@@ -306,9 +306,8 @@ pub mod rfc3339_string_as_bson_datetime {
 
     /// Serializes an ISO string as a DateTime.
     pub fn serialize<S: Serializer>(val: &str, serializer: S) -> Result<S::Ok, S::Error> {
-        let date = crate::DateTime::parse_rfc3339_str(val).map_err(|_| {
-                ser::Error::custom(format!("cannot convert {} to DateTime", val))
-            })?;
+        let date = crate::DateTime::parse_rfc3339_str(val)
+            .map_err(|_| ser::Error::custom(format!("cannot convert {} to DateTime", val)))?;
         Bson::DateTime(date).serialize(serializer)
     }
 }
@@ -336,10 +335,9 @@ pub mod bson_datetime_as_rfc3339_string {
         D: Deserializer<'de>,
     {
         let iso = String::deserialize(deserializer)?;
-        let date =
-            crate::DateTime::parse_rfc3339_str(&iso).map_err(|_| {
-                de::Error::custom(format!("cannot parse RFC 3339 datetime from \"{}\"", iso))
-            })?;
+        let date = crate::DateTime::parse_rfc3339_str(&iso).map_err(|_| {
+            de::Error::custom(format!("cannot parse RFC 3339 datetime from \"{}\"", iso))
+        })?;
         Ok(date)
     }
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -29,9 +29,9 @@ pub use rfc3339_string_as_bson_datetime::{
 };
 #[cfg(feature = "time-0_3")]
 #[doc(inline)]
-pub use time_offsetdatetime_as_bson_datetime::{
-    deserialize as deserialize_time_offsetdatetime_from_bson_datetime,
-    serialize as serialize_time_offsetdatetime_as_bson_datetime,
+pub use time_0_3_offsetdatetime_as_bson_datetime::{
+    deserialize as deserialize_time_0_3_offsetdatetime_from_bson_datetime,
+    serialize as serialize_time_0_3_offsetdatetime_as_bson_datetime,
 };
 #[doc(inline)]
 pub use timestamp_as_u32::{
@@ -195,20 +195,20 @@ pub mod u64_as_f64 {
 /// deserialize a [`time::OffsetDateTime`] from a [`crate::DateTime`].
 ///
 /// ```rust
-/// # #[cfg(feature = "chrono-0_4")]
+/// # #[cfg(feature = "time-0_3")]
 /// # {
 /// # use serde::{Serialize, Deserialize};
-/// # use bson::serde_helpers::time_offsetdatetime_as_bson_datetime;
+/// # use bson::serde_helpers::time_0_3_offsetdatetime_as_bson_datetime;
 /// #[derive(Serialize, Deserialize)]
 /// struct Event {
-///     #[serde(with = "time_offsetdatetime_as_bson_datetime")]
+///     #[serde(with = "time_0_3_offsetdatetime_as_bson_datetime")]
 ///     pub date: time::OffsetDateTime,
 /// }
 /// # }
 /// ```
 #[cfg(feature = "time-0_3")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time-0_3")))]
-pub mod time_offsetdatetime_as_bson_datetime {
+pub mod time_0_3_offsetdatetime_as_bson_datetime {
     use crate::DateTime;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::result::Result;

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -220,7 +220,7 @@ pub mod time_0_3_offsetdatetime_as_bson_datetime {
         D: Deserializer<'de>,
     {
         let datetime = DateTime::deserialize(deserializer)?;
-        Ok(datetime.to_time())
+        Ok(datetime.to_time_0_3())
     }
 
     /// Serializes a [`time::OffsetDateTime`] as a [`crate::DateTime`].
@@ -229,7 +229,7 @@ pub mod time_0_3_offsetdatetime_as_bson_datetime {
         val: &time::OffsetDateTime,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        let datetime = DateTime::from_time(val.to_owned());
+        let datetime = DateTime::from_time_0_3(val.to_owned());
         datetime.serialize(serializer)
     }
 }

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -5,7 +5,8 @@ fn rfc3339_to_datetime() {
     let _guard = LOCK.run_concurrently();
 
     let rfc = "2020-06-09T10:58:07.095Z";
-    let date = time::OffsetDateTime::parse(rfc, &time::format_description::well_known::Rfc3339).unwrap();
+    let date =
+        time::OffsetDateTime::parse(rfc, &time::format_description::well_known::Rfc3339).unwrap();
     let parsed = crate::DateTime::parse_rfc3339_str(rfc).unwrap();
     assert_eq!(parsed, crate::DateTime::from_time(date));
     assert_eq!(crate::DateTime::to_rfc3339_string(parsed), rfc);

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -1,14 +1,13 @@
 use crate::tests::LOCK;
-use std::str::FromStr;
 
 #[test]
 fn rfc3339_to_datetime() {
     let _guard = LOCK.run_concurrently();
 
     let rfc = "2020-06-09T10:58:07.095Z";
-    let date = chrono::DateTime::<chrono::Utc>::from_str(rfc).unwrap();
+    let date = time::OffsetDateTime::parse(rfc, &time::format_description::well_known::Rfc3339).unwrap();
     let parsed = crate::DateTime::parse_rfc3339_str(rfc).unwrap();
-    assert_eq!(parsed, crate::DateTime::from_chrono(date));
+    assert_eq!(parsed, crate::DateTime::from_time(date));
     assert_eq!(crate::DateTime::to_rfc3339_string(parsed), rfc);
 }
 

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -9,7 +9,7 @@ fn rfc3339_to_datetime() {
         time::OffsetDateTime::parse(rfc, &time::format_description::well_known::Rfc3339).unwrap();
     let parsed = crate::DateTime::parse_rfc3339_str(rfc).unwrap();
     assert_eq!(parsed, crate::DateTime::from_time(date));
-    assert_eq!(crate::DateTime::to_rfc3339_string(parsed), rfc);
+    assert_eq!(crate::DateTime::try_to_rfc3339_string(parsed).unwrap(), rfc);
 }
 
 #[test]
@@ -22,4 +22,19 @@ fn invalid_rfc3339_to_datetime() {
     assert!(crate::DateTime::parse_rfc3339_str(a).is_err());
     assert!(crate::DateTime::parse_rfc3339_str(b).is_err());
     assert!(crate::DateTime::parse_rfc3339_str(c).is_err());
+}
+
+#[test]
+fn datetime_to_rfc3339() {
+    assert_eq!(
+        crate::DateTime::from_millis(0)
+            .try_to_rfc3339_string()
+            .unwrap(),
+        "1970-01-01T00:00:00Z"
+    );
+}
+
+#[test]
+fn invalid_datetime_to_rfc3339() {
+    assert!(crate::DateTime::MAX.try_to_rfc3339_string().is_err());
 }

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -8,7 +8,7 @@ fn rfc3339_to_datetime() {
     let date =
         time::OffsetDateTime::parse(rfc, &time::format_description::well_known::Rfc3339).unwrap();
     let parsed = crate::DateTime::parse_rfc3339_str(rfc).unwrap();
-    assert_eq!(parsed, crate::DateTime::from_time(date));
+    assert_eq!(parsed, crate::DateTime::from_time_0_3(date));
     assert_eq!(crate::DateTime::try_to_rfc3339_string(parsed).unwrap(), rfc);
 }
 

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -237,14 +237,14 @@ fn from_external_datetime() {
     let _guard = LOCK.run_concurrently();
 
     fn assert_millisecond_precision(dt: DateTime) {
-        assert!(dt.to_time().microsecond() % 1000 == 0);
+        assert!(dt.to_time_0_3().microsecond() % 1000 == 0);
     }
     fn assert_subsec_millis(dt: DateTime, millis: u32) {
-        assert_eq!(dt.to_time().millisecond() as u32, millis)
+        assert_eq!(dt.to_time_0_3().millisecond() as u32, millis)
     }
 
     let now = time::OffsetDateTime::now_utc();
-    let dt = DateTime::from_time(now);
+    let dt = DateTime::from_time_0_3(now);
     assert_millisecond_precision(dt);
 
     #[cfg(feature = "time-0_3")]
@@ -266,7 +266,7 @@ fn from_external_datetime() {
     }
 
     let no_subsec_millis = datetime!(2014-11-28 12:00:09 UTC);
-    let dt = DateTime::from_time(no_subsec_millis);
+    let dt = DateTime::from_time_0_3(no_subsec_millis);
     assert_millisecond_precision(dt);
     assert_subsec_millis(dt, 0);
 
@@ -296,7 +296,7 @@ fn from_external_datetime() {
     ] {
         let time_dt =
             time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).unwrap();
-        let dt = DateTime::from_time(time_dt);
+        let dt = DateTime::from_time_0_3(time_dt);
         assert_millisecond_precision(dt);
         assert_subsec_millis(dt, 123);
 
@@ -324,22 +324,22 @@ fn from_external_datetime() {
         let max = time::PrimitiveDateTime::MAX.assume_utc();
         let bdt = DateTime::from(max);
         assert_eq!(
-            bdt.to_time().unix_timestamp_nanos() / 1_000_000, // truncate to millis
+            bdt.to_time_0_3().unix_timestamp_nanos() / 1_000_000, // truncate to millis
             max.unix_timestamp_nanos() / 1_000_000
         );
 
         let min = time::PrimitiveDateTime::MIN.assume_utc();
         let bdt = DateTime::from(min);
         assert_eq!(
-            bdt.to_time().unix_timestamp_nanos() / 1_000_000,
+            bdt.to_time_0_3().unix_timestamp_nanos() / 1_000_000,
             min.unix_timestamp_nanos() / 1_000_000
         );
 
         let bdt = DateTime::MAX;
-        assert_eq!(bdt.to_time(), max);
+        assert_eq!(bdt.to_time_0_3(), max);
 
         let bdt = DateTime::MIN;
-        assert_eq!(bdt.to_time(), min);
+        assert_eq!(bdt.to_time_0_3(), min);
     }
     #[cfg(feature = "chrono-0_4")]
     {

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -321,17 +321,17 @@ fn from_external_datetime() {
 
     #[cfg(feature = "time-0_3")]
     {
-        let max = time::PrimitiveDateTime::MAX.assume_utc();
+        // TODO RUST-1256 use time::PrimitiveDateTime::{MIN, MAX} here.
+        let max = time::PrimitiveDateTime::new(time::Date::MAX, time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap()).assume_utc();
         let bdt = DateTime::from(max);
         assert_eq!(
             bdt.to_time().unix_timestamp_nanos() / 1_000_000, // truncate to millis
-            time::PrimitiveDateTime::MAX
-                .assume_utc()
+            max
                 .unix_timestamp_nanos()
                 / 1_000_000
         );
 
-        let min = time::PrimitiveDateTime::MIN.assume_utc();
+        let min = time::PrimitiveDateTime::new(time::Date::MIN, time::Time::MIDNIGHT).assume_utc();
         let bdt = DateTime::from(min);
         assert_eq!(
             bdt.to_time().unix_timestamp_nanos() / 1_000_000,

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -322,13 +322,15 @@ fn from_external_datetime() {
     #[cfg(feature = "time-0_3")]
     {
         // TODO RUST-1256 use time::PrimitiveDateTime::{MIN, MAX} here.
-        let max = time::PrimitiveDateTime::new(time::Date::MAX, time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap()).assume_utc();
+        let max = time::PrimitiveDateTime::new(
+            time::Date::MAX,
+            time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap(),
+        )
+        .assume_utc();
         let bdt = DateTime::from(max);
         assert_eq!(
             bdt.to_time().unix_timestamp_nanos() / 1_000_000, // truncate to millis
-            max
-                .unix_timestamp_nanos()
-                / 1_000_000
+            max.unix_timestamp_nanos() / 1_000_000
         );
 
         let min = time::PrimitiveDateTime::new(time::Date::MIN, time::Time::MIDNIGHT).assume_utc();

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -278,7 +278,8 @@ fn from_external_datetime() {
     }
     #[cfg(feature = "chrono-0_4")]
     {
-        let no_subsec_millis: chrono::DateTime<chrono::Utc> = "2014-11-28T12:00:09Z".parse().unwrap();
+        let no_subsec_millis: chrono::DateTime<chrono::Utc> =
+            "2014-11-28T12:00:09Z".parse().unwrap();
         let dt = DateTime::from(no_subsec_millis);
         assert_millisecond_precision(dt);
         assert_subsec_millis(dt, 0);
@@ -293,7 +294,8 @@ fn from_external_datetime() {
         "2014-11-28T12:00:09.123456Z",
         "2014-11-28T12:00:09.123456789Z",
     ] {
-        let time_dt = time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).unwrap();
+        let time_dt =
+            time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).unwrap();
         let dt = DateTime::from_time(time_dt);
         assert_millisecond_precision(dt);
         assert_subsec_millis(dt, 123);
@@ -322,8 +324,11 @@ fn from_external_datetime() {
         let max = time::PrimitiveDateTime::MAX.assume_utc();
         let bdt = DateTime::from(max);
         assert_eq!(
-            bdt.to_time().unix_timestamp_nanos() / 1_000_000,  // truncate to millis
-            time::PrimitiveDateTime::MAX.assume_utc().unix_timestamp_nanos() / 1_000_000
+            bdt.to_time().unix_timestamp_nanos() / 1_000_000, // truncate to millis
+            time::PrimitiveDateTime::MAX
+                .assume_utc()
+                .unix_timestamp_nanos()
+                / 1_000_000
         );
 
         let min = time::PrimitiveDateTime::MIN.assume_utc();

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -231,22 +231,33 @@ fn timestamp_ordering() {
 }
 
 #[test]
-fn from_chrono_datetime() {
+fn from_external_datetime() {
+    use time::macros::datetime;
+
     let _guard = LOCK.run_concurrently();
 
     fn assert_millisecond_precision(dt: DateTime) {
-        assert!(dt.to_chrono().timestamp_subsec_micros() % 1000 == 0);
+        assert!(dt.to_time().microsecond() % 1000 == 0);
     }
     fn assert_subsec_millis(dt: DateTime, millis: u32) {
-        assert_eq!(dt.to_chrono().timestamp_subsec_millis(), millis)
+        assert_eq!(dt.to_time().millisecond() as u32, millis)
     }
 
-    let now = chrono::Utc::now();
-    let dt = DateTime::from_chrono(now);
+    let now = time::OffsetDateTime::now_utc();
+    let dt = DateTime::from_time(now);
     assert_millisecond_precision(dt);
 
+    #[cfg(feature = "time-0_3")]
+    {
+        let bson = Bson::from(now);
+        assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
+
+        let from_time = DateTime::from(now);
+        assert_millisecond_precision(from_time);
+    }
     #[cfg(feature = "chrono-0_4")]
     {
+        let now = chrono::Utc::now();
         let bson = Bson::from(now);
         assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
 
@@ -254,13 +265,20 @@ fn from_chrono_datetime() {
         assert_millisecond_precision(from_chrono);
     }
 
-    let no_subsec_millis: chrono::DateTime<chrono::Utc> = "2014-11-28T12:00:09Z".parse().unwrap();
-    let dt = DateTime::from_chrono(no_subsec_millis);
+    let no_subsec_millis = datetime!(2014-11-28 12:00:09 UTC);
+    let dt = DateTime::from_time(no_subsec_millis);
     assert_millisecond_precision(dt);
     assert_subsec_millis(dt, 0);
 
+    #[cfg(feature = "time-0_3")]
+    {
+        let bson = Bson::from(dt);
+        assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
+        assert_subsec_millis(bson.as_datetime().unwrap().to_owned(), 0);
+    }
     #[cfg(feature = "chrono-0_4")]
     {
+        let no_subsec_millis: chrono::DateTime<chrono::Utc> = "2014-11-28T12:00:09Z".parse().unwrap();
         let dt = DateTime::from(no_subsec_millis);
         assert_millisecond_precision(dt);
         assert_subsec_millis(dt, 0);
@@ -275,13 +293,20 @@ fn from_chrono_datetime() {
         "2014-11-28T12:00:09.123456Z",
         "2014-11-28T12:00:09.123456789Z",
     ] {
-        let chrono_dt: chrono::DateTime<chrono::Utc> = s.parse().unwrap();
-        let dt = DateTime::from_chrono(chrono_dt);
+        let time_dt = time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).unwrap();
+        let dt = DateTime::from_time(time_dt);
         assert_millisecond_precision(dt);
         assert_subsec_millis(dt, 123);
 
+        #[cfg(feature = "time-0_3")]
+        {
+            let bson = Bson::from(time_dt);
+            assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
+            assert_subsec_millis(bson.as_datetime().unwrap().to_owned(), 123);
+        }
         #[cfg(feature = "chrono-0_4")]
         {
+            let chrono_dt: chrono::DateTime<chrono::Utc> = s.parse().unwrap();
             let dt = DateTime::from(chrono_dt);
             assert_millisecond_precision(dt);
             assert_subsec_millis(dt, 123);
@@ -292,6 +317,28 @@ fn from_chrono_datetime() {
         }
     }
 
+    #[cfg(feature = "time-0_3")]
+    {
+        let max = time::PrimitiveDateTime::MAX.assume_utc();
+        let bdt = DateTime::from(max);
+        assert_eq!(
+            bdt.to_time().unix_timestamp_nanos() / 1_000_000,  // truncate to millis
+            time::PrimitiveDateTime::MAX.assume_utc().unix_timestamp_nanos() / 1_000_000
+        );
+
+        let min = time::PrimitiveDateTime::MIN.assume_utc();
+        let bdt = DateTime::from(min);
+        assert_eq!(
+            bdt.to_time().unix_timestamp_nanos() / 1_000_000,
+            min.unix_timestamp_nanos() / 1_000_000
+        );
+
+        let bdt = DateTime::MAX;
+        assert_eq!(bdt.to_time(), max);
+
+        let bdt = DateTime::MIN;
+        assert_eq!(bdt.to_time(), min);
+    }
     #[cfg(feature = "chrono-0_4")]
     {
         let bdt = DateTime::from(chrono::MAX_DATETIME);

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -321,19 +321,14 @@ fn from_external_datetime() {
 
     #[cfg(feature = "time-0_3")]
     {
-        // TODO RUST-1256 use time::PrimitiveDateTime::{MIN, MAX} here.
-        let max = time::PrimitiveDateTime::new(
-            time::Date::MAX,
-            time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap(),
-        )
-        .assume_utc();
+        let max = time::PrimitiveDateTime::MAX.assume_utc();
         let bdt = DateTime::from(max);
         assert_eq!(
             bdt.to_time().unix_timestamp_nanos() / 1_000_000, // truncate to millis
             max.unix_timestamp_nanos() / 1_000_000
         );
 
-        let min = time::PrimitiveDateTime::new(time::Date::MIN, time::Time::MIDNIGHT).assume_utc();
+        let min = time::PrimitiveDateTime::MIN.assume_utc();
         let bdt = DateTime::from(min);
         assert_eq!(
             bdt.to_time().unix_timestamp_nanos() / 1_000_000,

--- a/src/tests/modules/document.rs
+++ b/src/tests/modules/document.rs
@@ -51,7 +51,7 @@ fn ordered_insert_shorthand() {
 fn test_getters() {
     let _guard = LOCK.run_concurrently();
     let datetime = OffsetDateTime::now_utc();
-    let cloned_dt = crate::DateTime::from_time(datetime);
+    let cloned_dt = crate::DateTime::from_time_0_3(datetime);
     let binary = vec![0, 1, 2, 3, 4];
     let mut doc = doc! {
         "floating_point": 10.0,
@@ -125,7 +125,7 @@ fn test_getters() {
         doc.get_timestamp("timestamp")
     );
 
-    let dt = crate::DateTime::from_time(datetime);
+    let dt = crate::DateTime::from_time_0_3(datetime);
     assert_eq!(Some(&Bson::DateTime(dt)), doc.get("datetime"));
     assert_eq!(Ok(&dt), doc.get_datetime("datetime"));
 

--- a/src/tests/modules/document.rs
+++ b/src/tests/modules/document.rs
@@ -9,7 +9,7 @@ use crate::{
     Document,
     Timestamp,
 };
-use chrono::Utc;
+use time::OffsetDateTime;
 
 #[test]
 fn ordered_insert() {
@@ -50,8 +50,8 @@ fn ordered_insert_shorthand() {
 #[test]
 fn test_getters() {
     let _guard = LOCK.run_concurrently();
-    let datetime = Utc::now();
-    let cloned_dt = crate::DateTime::from_chrono(datetime);
+    let datetime = OffsetDateTime::now_utc();
+    let cloned_dt = crate::DateTime::from_time(datetime);
     let binary = vec![0, 1, 2, 3, 4];
     let mut doc = doc! {
         "floating_point": 10.0,
@@ -125,7 +125,7 @@ fn test_getters() {
         doc.get_timestamp("timestamp")
     );
 
-    let dt = crate::DateTime::from_chrono(datetime);
+    let dt = crate::DateTime::from_time(datetime);
     assert_eq!(Some(&Bson::DateTime(dt)), doc.get("datetime"));
     assert_eq!(Ok(&dt), doc.get_datetime("datetime"));
 

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -81,7 +81,7 @@ fn standard_format() {
         base64::encode("thingies"),
         base64::encode("secret"),
         hex::encode(id_string),
-        format!("{}", date_trunc),
+        date_trunc,
     );
 
     assert_eq!(expected, format!("{}", doc));

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -68,7 +68,9 @@ fn standard_format() {
         "date": crate::DateTime::from_time(date),
     };
 
-    let date_trunc = date.replace_microsecond(date.microsecond() - (date.microsecond() % 1000)).unwrap();
+    let date_trunc = date
+        .replace_microsecond(date.microsecond() - (date.microsecond() % 1000))
+        .unwrap();
     let expected = format!(
         "{{ \"float\": 2.4, \"string\": \"hello\", \"array\": [\"testing\", 1, true, [1, 2]], \
          \"doc\": {{ \"fish\": \"in\", \"a\": \"barrel\", \"!\": 1 }}, \"bool\": true, \"null\": \

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -68,9 +68,9 @@ fn standard_format() {
         "date": crate::DateTime::from_time(date),
     };
 
-    let date_trunc = date
-        .replace_microsecond(date.microsecond() - (date.microsecond() % 1000))
-        .unwrap();
+    let ts_nanos = date.unix_timestamp_nanos();
+    let ts_millis = ts_nanos - (ts_nanos % 1_000_000);
+    let date_trunc = time::OffsetDateTime::from_unix_timestamp_nanos(ts_millis).unwrap();
     let expected = format!(
         "{{ \"float\": 2.4, \"string\": \"hello\", \"array\": [\"testing\", 1, true, [1, 2]], \
          \"doc\": {{ \"fish\": \"in\", \"a\": \"barrel\", \"!\": 1 }}, \"bool\": true, \"null\": \

--- a/src/tests/modules/macros.rs
+++ b/src/tests/modules/macros.rs
@@ -42,7 +42,7 @@ fn standard_format() {
         "binary": Binary { subtype: BinarySubtype::Md5, bytes: "thingies".to_owned().into_bytes() },
         "encrypted": Binary { subtype: BinarySubtype::Encrypted, bytes: "secret".to_owned().into_bytes() },
         "_id": id,
-        "date": Bson::DateTime(crate::DateTime::from_time(date)),
+        "date": Bson::DateTime(crate::DateTime::from_time_0_3(date)),
     };
 
     let rawdoc = rawdoc! {
@@ -65,7 +65,7 @@ fn standard_format() {
         "binary": Binary { subtype: BinarySubtype::Md5, bytes: "thingies".to_owned().into_bytes() },
         "encrypted": Binary { subtype: BinarySubtype::Encrypted, bytes: "secret".to_owned().into_bytes() },
         "_id": id,
-        "date": crate::DateTime::from_time(date),
+        "date": crate::DateTime::from_time_0_3(date),
     };
 
     let ts_nanos = date.unix_timestamp_nanos();

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -315,7 +315,7 @@ fn test_serialize_utc_date_time() {
     use chrono::offset::TimeZone;
     let _guard = LOCK.run_concurrently();
     #[cfg(not(any(feature = "chrono-0_4", feature = "time-0_3")))]
-    let src = crate::DateTime::from_time(
+    let src = crate::DateTime::from_time_0_3(
         time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap(),
     );
     #[cfg(feature = "time-0_3")]
@@ -373,7 +373,7 @@ fn test_deserialize_utc_date_time_overflows() {
 
     let deserialized = Document::from_reader(&mut Cursor::new(raw)).unwrap();
 
-    let expected = doc! { "A": crate::DateTime::from_time(time::OffsetDateTime::from_unix_timestamp(1_530_492_218).unwrap() + time::Duration::nanoseconds(999 * 1_000_000))};
+    let expected = doc! { "A": crate::DateTime::from_time_0_3(time::OffsetDateTime::from_unix_timestamp(1_530_492_218).unwrap() + time::Duration::nanoseconds(999 * 1_000_000))};
     assert_eq!(deserialized, expected);
 }
 

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -311,13 +311,15 @@ fn test_serialize_deserialize_object_id() {
 
 #[test]
 fn test_serialize_utc_date_time() {
+    #[cfg(feature = "chrono-0_4")]
+    use chrono::offset::TimeZone;
     let _guard = LOCK.run_concurrently();
     #[cfg(not(any(feature = "chrono-0_4", feature = "time-0_3")))]
     let src = crate::DateTime::from_time(time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap());
     #[cfg(feature = "time-0_3")]
     let src = time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap();
     #[cfg(feature = "chrono-0_4")]
-    let src = Utc.timestamp(1_286_705_410, 0);
+    let src = chrono::Utc.timestamp(1_286_705_410, 0);
     let dst = vec![
         18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0,
     ];

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -315,7 +315,9 @@ fn test_serialize_utc_date_time() {
     use chrono::offset::TimeZone;
     let _guard = LOCK.run_concurrently();
     #[cfg(not(any(feature = "chrono-0_4", feature = "time-0_3")))]
-    let src = crate::DateTime::from_time(time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap());
+    let src = crate::DateTime::from_time(
+        time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap(),
+    );
     #[cfg(feature = "time-0_3")]
     let src = time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap();
     #[cfg(feature = "chrono-0_4")]
@@ -370,8 +372,7 @@ fn test_deserialize_utc_date_time_overflows() {
 
     let deserialized = Document::from_reader(&mut Cursor::new(raw)).unwrap();
 
-    let expected =
-        doc! { "A": crate::DateTime::from_time(time::OffsetDateTime::from_unix_timestamp(1_530_492_218).unwrap() + time::Duration::nanoseconds(999 * 1_000_000))};
+    let expected = doc! { "A": crate::DateTime::from_time(time::OffsetDateTime::from_unix_timestamp(1_530_492_218).unwrap() + time::Duration::nanoseconds(999 * 1_000_000))};
     assert_eq!(deserialized, expected);
 }
 

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -319,6 +319,7 @@ fn test_serialize_utc_date_time() {
         time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap(),
     );
     #[cfg(feature = "time-0_3")]
+    #[allow(unused)]
     let src = time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap();
     #[cfg(feature = "chrono-0_4")]
     let src = chrono::Utc.timestamp(1_286_705_410, 0);

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -776,6 +776,7 @@ fn test_datetime_helpers() {
 
     #[cfg(feature = "chrono-0_4")]
     {
+        use std::str::FromStr;
         #[derive(Deserialize, Serialize)]
         struct B {
             #[serde(with = "serde_helpers::chrono_datetime_as_bson_datetime")]

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -752,7 +752,7 @@ fn test_datetime_helpers() {
 
         #[derive(Deserialize, Serialize)]
         struct B {
-            #[serde(with = "serde_helpers::time_offsetdatetime_as_bson_datetime")]
+            #[serde(with = "serde_helpers::time_0_3_offsetdatetime_as_bson_datetime")]
             pub date: time::OffsetDateTime,
         }
 

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -739,12 +739,12 @@ fn test_datetime_helpers() {
     let iso = "1996-12-20T00:39:57Z";
     let date = OffsetDateTime::parse(iso, &Rfc3339).unwrap();
     let a = A {
-        date: crate::DateTime::from_time(date),
+        date: crate::DateTime::from_time_0_3(date),
     };
     let doc = to_document(&a).unwrap();
     assert_eq!(doc.get_str("date").unwrap(), iso);
     let a: A = from_document(doc).unwrap();
-    assert_eq!(a.date.to_time(), date);
+    assert_eq!(a.date.to_time_0_3(), date);
 
     #[cfg(feature = "time-0_3")]
     {
@@ -769,7 +769,7 @@ fn test_datetime_helpers() {
         let expected = datetime!(2020-06-09 10:58:07.095 UTC);
         assert_eq!(b.date, expected);
         let doc = to_document(&b).unwrap();
-        assert_eq!(doc.get_datetime("date").unwrap().to_time(), expected);
+        assert_eq!(doc.get_datetime("date").unwrap().to_time_0_3(), expected);
         let b: B = from_document(doc).unwrap();
         assert_eq!(b.date, expected);
     }

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -726,7 +726,7 @@ fn test_unsigned_helpers() {
 
 #[test]
 fn test_datetime_helpers() {
-    use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+    use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
     let _guard = LOCK.run_concurrently();
 

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -216,7 +216,6 @@ fn run_test(test: TestFile) {
                 let from_value_value_doc = doc! {
                     test_key: bson_field,
                 };
-                dbg!(&from_value_value_doc);
 
                 // deserialize the field from a Bson into a RawBson
                 let deserializer_value_raw =

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -216,6 +216,7 @@ fn run_test(test: TestFile) {
                 let from_value_value_doc = doc! {
                     test_key: bson_field,
                 };
+                dbg!(&from_value_value_doc);
 
                 // deserialize the field from a Bson into a RawBson
                 let deserializer_value_raw =


### PR DESCRIPTION
RUST-1129

This PR swaps out the internal operations that used `chrono` for equivalent ones using `time`, makes the `chrono` dependency optional, and adds optional interop methods for `time` structs.