### PR TITLE
Updated uuid version, fixed clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ indexmap = "1.6.2"
 hex = "0.4.2"
 base64 = "0.13.0"
 lazy_static = "1.4.0"
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.1.1", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
 time = { version = "0.3.9", features = ["formatting", "parsing", "macros", "large-dates"] }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1023,7 +1023,7 @@ impl Timestamp {
 }
 
 /// Represents a BSON regular expression value.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Regex {
     /// The regex pattern to match.
     pub pattern: String,
@@ -1073,7 +1073,7 @@ impl Display for JavaScriptCodeWithScope {
 }
 
 /// Represents a BSON binary value.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binary {
     /// The subtype of the bytes.
     pub subtype: BinarySubtype,
@@ -1131,7 +1131,7 @@ impl Binary {
 }
 
 /// Represents a DBPointer. (Deprecated)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbPointer {
     pub(crate) namespace: String,
     pub(crate) id: oid::ObjectId,

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -267,7 +267,7 @@ impl crate::DateTime {
         } else {
             // need to convert to i128 before calculating absolute value since i64::MIN.abs()
             // overflows and panics.
-            SystemTime::UNIX_EPOCH - Duration::from_millis((self.0 as i128).abs() as u64)
+            SystemTime::UNIX_EPOCH - Duration::from_millis((self.0 as i128).unsigned_abs() as u64)
         }
     }
 

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -1673,7 +1673,7 @@ struct RawBsonDeserializer<'a> {
     value: BsonContent<'a>,
 }
 
-impl<'de, 'a> serde::de::Deserializer<'de> for RawBsonDeserializer<'de> {
+impl<'de> serde::de::Deserializer<'de> for RawBsonDeserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -6,7 +6,7 @@ use std::{convert::TryInto, fmt};
 ///
 /// Currently, this type can only be used to round-trip through BSON. See
 /// [RUST-36](https://jira.mongodb.org/browse/RUST-36) to track the progress towards a complete implementation.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Decimal128 {
     /// BSON bytes containing the decimal128. Stored for round tripping.
     pub(crate) bytes: [u8; 128 / 8],

--- a/src/document.rs
+++ b/src/document.rs
@@ -23,7 +23,7 @@ use crate::{
 
 /// Error to indicate that either a value was empty or it contained an unexpected
 /// type, for use with the direct getters.
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub enum ValueAccessError {
     /// Cannot find the expected field with the specified key
@@ -165,7 +165,7 @@ impl FromIterator<(String, Bson)> for Document {
     }
 }
 
-impl<'a> Iterator for IntoIter {
+impl Iterator for IntoIter {
     type Item = (String, Bson);
 
     fn next(&mut self) -> Option<(String, Bson)> {

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -72,7 +72,7 @@ use crate::{
 /// assert_eq!(rawarray.get_bool(1)?, true);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 #[repr(transparent)]
 pub struct RawArray {
     pub(crate) doc: RawDocument,

--- a/src/raw/array_buf.rs
+++ b/src/raw/array_buf.rs
@@ -41,7 +41,7 @@ use super::{bson::RawBson, serde::OwnedOrBorrowedRawArray, RawArrayIter};
 /// type-specific getters, such as [`RawArray::get_object_id`] or [`RawArray::get_str`]. Note
 /// that accessing elements is an O(N) operation, as it requires iterating through the document from
 /// the beginning to find the requested key.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RawArrayBuf {
     inner: RawDocumentBuf,
     len: usize,

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -447,7 +447,7 @@ impl Serialize for RawBson {
     }
 }
 
-impl<'a> TryFrom<RawBson> for Bson {
+impl TryFrom<RawBson> for Bson {
     type Error = Error;
 
     fn try_from(rawbson: RawBson) -> Result<Bson> {
@@ -483,7 +483,7 @@ impl<'a> TryFrom<RawBson> for Bson {
 }
 
 /// A BSON "code with scope" value backed by owned raw BSON.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RawJavaScriptCodeWithScope {
     /// The code value.
     pub code: String,

--- a/src/raw/bson_ref.rs
+++ b/src/raw/bson_ref.rs
@@ -450,7 +450,7 @@ impl<'a> From<Decimal128> for RawBsonRef<'a> {
 }
 
 /// A BSON binary value referencing raw bytes stored elsewhere.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RawBinaryRef<'a> {
     /// The subtype of the binary value.
     pub subtype: BinarySubtype,
@@ -531,7 +531,7 @@ impl<'a> From<&'a Binary> for RawBsonRef<'a> {
 }
 
 /// A BSON regex referencing raw bytes stored elsewhere.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RawRegexRef<'a> {
     /// The regex pattern to match.
     pub pattern: &'a str,
@@ -589,7 +589,7 @@ impl<'a> From<RawRegexRef<'a>> for RawBsonRef<'a> {
 }
 
 /// A BSON "code with scope" value referencing raw bytes stored elsewhere.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RawJavaScriptCodeWithScopeRef<'a> {
     /// The JavaScript code.
     pub code: &'a str,
@@ -638,7 +638,7 @@ impl<'a> From<RawJavaScriptCodeWithScopeRef<'a>> for RawBsonRef<'a> {
 }
 
 /// A BSON DB pointer value referencing raw bytes stored elesewhere.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RawDbPointerRef<'a> {
     pub(crate) namespace: &'a str,
     pub(crate) id: ObjectId,

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -64,7 +64,7 @@ use crate::{oid::ObjectId, spec::ElementType, Document};
 /// assert_eq!(doc.get_str("hi")?, "y'all");
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 #[repr(transparent)]
 pub struct RawDocument {
     data: [u8],

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -62,7 +62,7 @@ use super::{
 /// assert_eq!(doc.get_str("hi")?, "y'all");
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RawDocumentBuf {
     data: Vec<u8>,
 }

--- a/src/raw/error.rs
+++ b/src/raw/error.rs
@@ -3,7 +3,7 @@ use std::str::Utf8Error;
 use crate::spec::ElementType;
 
 /// An error that occurs when attempting to parse raw BSON bytes.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub struct Error {
     /// The type of error that was encountered.
@@ -37,7 +37,7 @@ impl Error {
 }
 
 /// The different categories of errors that can be returned when reading from raw BSON.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
     /// A BSON value did not fit the proper format.
@@ -80,7 +80,7 @@ pub type ValueAccessResult<T> = std::result::Result<T, ValueAccessError>;
 
 /// Error to indicate that either a value was empty or it contained an unexpected
 /// type, for use with the direct getters (e.g. [`crate::RawDocument::get_str`]).
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub struct ValueAccessError {
     /// The type of error that was encountered.
@@ -98,7 +98,7 @@ impl ValueAccessError {
 }
 
 /// The type of error encountered when using a direct getter (e.g. [`crate::RawDocument::get_str`]).
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub enum ValueAccessErrorKind {
     /// Cannot find the expected field with the specified key

--- a/src/uuid/mod.rs
+++ b/src/uuid/mod.rs
@@ -327,7 +327,7 @@ impl From<Uuid> for uuid::Uuid {
 /// # Ok::<(), Box::<dyn std::error::Error>>(())
 /// ```
 #[non_exhaustive]
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum UuidRepresentation {
     /// The canonical representation of UUIDs in BSON (binary with subtype 0x04)
     Standard,


### PR DESCRIPTION
I was needing to use this crate for a WASM target, but the version of `uuid`
in use does not have the `js` feature, while later ones do. I updated the dependency.
In the process, I had to fix clippy default lints to get my CI to work, so I've also
included that in this PR. I have run the test suite for all features and every test
still passes. The changes to the code are just adding `Eq` to derive macros and
in two places removing unused lifetime parameters from an `impl` block.
