### PR TITLE
RUST-1385 Add binary/raw conversions

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -1130,7 +1130,8 @@ impl Binary {
         }
     }
 
-    pub(crate) fn as_raw_binary(&self) -> RawBinaryRef<'_> {
+    /// Borrow the contents as a `RawBinaryRef`.
+    pub fn as_raw_binary(&self) -> RawBinaryRef<'_> {
         RawBinaryRef {
             bytes: self.bytes.as_slice(),
             subtype: self.subtype,

--- a/src/raw/bson_ref.rs
+++ b/src/raw/bson_ref.rs
@@ -460,6 +460,14 @@ pub struct RawBinaryRef<'a> {
 }
 
 impl<'a> RawBinaryRef<'a> {
+    /// Copy the contents into a `Binary`.
+    pub fn to_binary(&self) -> Binary {
+        Binary {
+            subtype: self.subtype,
+            bytes: self.bytes.to_owned(),
+        }
+    }
+
     pub(crate) fn len(&self) -> i32 {
         match self.subtype {
             BinarySubtype::BinaryOld => self.bytes.len() as i32 + 4,


### PR DESCRIPTION
RUST-1385

This makes public the existing `Binary::as_raw_binary`, and adds the reciprocal `RawBinaryRef::to_binary`.  Tagging RUST-1385 because I noticed these didn't exist during implementation of that :)