### PR TITLE
RUST-1480 Add a TryFrom<Bson> impl for RawBson

### DIFF
--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -361,6 +361,14 @@ impl TryFrom<RawDocumentBuf> for Document {
     }
 }
 
+impl TryFrom<&Document> for RawDocumentBuf {
+    type Error = Error;
+
+    fn try_from(doc: &Document) -> Result<RawDocumentBuf> {
+        RawDocumentBuf::from_document(doc)
+    }
+}
+
 impl<'a> IntoIterator for &'a RawDocumentBuf {
     type IntoIter = Iter<'a>;
     type Item = Result<(&'a str, RawBsonRef<'a>)>;


### PR DESCRIPTION
RUST-1480

I also added a `TryFrom<&Document> for RawDocumentBuf` for symmetry; that functionality was already present, just not as the standard trait.