### PR TITLE
RUST-1524 use `to_bson` instead of `Bson::from` in `bson!`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -178,10 +178,10 @@ macro_rules! bson {
         $crate::Bson::Document($crate::doc!{$($tt)+})
     };
 
-    // Any Into<Bson> type.
+    // Any Serialize type.
     // Must be below every other rule.
     ($other:expr) => {
-        $crate::Bson::from($other)
+        $crate::to_bson(&$other).unwrap()
     };
 }
 


### PR DESCRIPTION
* prevents `bson!` and `doc!` from taking ownership of variables passed without reference
* prevents `bson!` and `doc!` requiring variables passed by reference to implement  `Clone`

NOTE: not sure if this project follows semver, but wanted to note that this change is not semver-compatible