### PR TITLE
RUST-1062 More efficiently serialize array indexes

### DIFF
--- a/src/ser/raw/document_serializer.rs
+++ b/src/ser/raw/document_serializer.rs
@@ -63,7 +63,8 @@ impl<'a> serde::ser::SerializeSeq for DocumentSerializer<'a> {
     where
         T: serde::Serialize,
     {
-        self.serialize_doc_key(&self.num_keys_serialized.to_string())?;
+        let index = self.num_keys_serialized;
+        self.serialize_doc_key(&index)?;
         value.serialize(&mut *self.root_serializer)
     }
 
@@ -224,14 +225,9 @@ impl<'a> serde::Serializer for KeySerializer<'a> {
     }
 
     #[inline]
-    fn serialize_u64(self, mut v: u64) -> Result<Self::Ok> {
-        loop {
-            self.root_serializer.bytes.push((v % 10) as u8 + b'0');
-            if v < 10 {
-                break;
-            }
-            v /= 10;
-        }
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok> {
+        use std::io::Write;
+        write!(&mut self.root_serializer.bytes, "{}", v)?;
         self.root_serializer.bytes.push(0);
         Ok(())
     }

--- a/src/ser/raw/document_serializer.rs
+++ b/src/ser/raw/document_serializer.rs
@@ -224,8 +224,16 @@ impl<'a> serde::Serializer for KeySerializer<'a> {
     }
 
     #[inline]
-    fn serialize_u64(self, v: u64) -> Result<Self::Ok> {
-        Err(Self::invalid_key(v))
+    fn serialize_u64(self, mut v: u64) -> Result<Self::Ok> {
+        loop {
+            self.root_serializer.bytes.push((v % 10) as u8 + b'0');
+            if v < 10 {
+                break;
+            }
+            v /= 10;
+        }
+        self.root_serializer.bytes.push(0);
+        Ok(())
     }
 
     #[inline]


### PR DESCRIPTION
RUST-1062

This PR updates the array serialization logic in the raw document serializer to avoid unnecessary heap allocations, resulting in an ~8% improvement in performance in a simple benchmark I'm using.

The solution used here is a bit different than the originally proposed one to just push bytes directly onto the buffer, but it was necessary in order to preserve the expected byte order (pushing them would result in a backwards string). As a result, the performance improvements were not as significant as originally envisioned unfortunately.