### PR TITLE
Double canonical extended json fraction fails round trip on Deserialize from_slice

### DIFF
--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -360,7 +360,7 @@ impl<'de> Visitor<'de> for BsonVisitor {
                         "Infinity" => Bson::Double(std::f64::INFINITY),
                         "-Infinity" => Bson::Double(std::f64::NEG_INFINITY),
                         "NaN" => Bson::Double(std::f64::NAN),
-                        _ => Bson::Int64(string.parse().map_err(|_| {
+                        _ => Bson::Double(string.parse().map_err(|_| {
                             V::Error::invalid_value(
                                 Unexpected::Str(&string),
                                 &"64-bit signed integer as a string",


### PR DESCRIPTION
I believe this was a bug as try_from has this functionality--while from_slice had functionality that failed on fractions.  Either this is the proper decode fix, or the encoding needs fixed where .fract() adds ".0" to string.