### PR TITLE
Fix links in the Feature Flags table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 
 #### Feature Flags
 
-| Feature      | Description                                                                                         | Extra dependencies | Default |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------|:--------|
-| `chrono-0_4` | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API.              | n/a                | no      |
-| `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API.                  | n/a                | no      |
-| `uuid-1`     | Enable support for v1.x of the [`uuid`](docs.rs/uuid/1.0) crate in the public API.                  | n/a                | no      |
-| `serde_with` | Enable [`serde_with`](docs.rs/serde_with/latest) integrations for `bson::DateTime` and `bson::Uuid` | serde_with         | no      |
+| Feature      | Description                                                                                                 | Extra dependencies | Default |
+| :----------- | :---------------------------------------------------------------------------------------------------------- | :----------------- | :------ |
+| `chrono-0_4` | Enable support for v0.4 of the [`chrono`](https://docs.rs/chrono/0.4) crate in the public API.              | n/a                | no      |
+| `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](https://docs.rs/uuid/0.8) crate in the public API.                  | n/a                | no      |
+| `uuid-1`     | Enable support for v1.x of the [`uuid`](https://docs.rs/uuid/1.0) crate in the public API.                  | n/a                | no      |
+| `serde_with` | Enable [`serde_with`](https://docs.rs/serde_with/latest) integrations for `bson::DateTime` and `bson::Uuid` | serde_with         | no      |
 
 ## Overview of the BSON Format
 


### PR DESCRIPTION
The links in the feature flags table in the README weren't absolute URLs, so they went to a GitHub 404 page.