### PR TITLE
RUST-1540 Rename `i64_as_datetime` to `i64_as_bson_datetime`

### DIFF
--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -23,9 +23,9 @@ pub use hex_string_as_object_id::{
     serialize as serialize_hex_string_as_object_id,
 };
 #[doc(inline)]
-pub use i64_as_datetime::{
-    deserialize as deserialize_i64_from_datetime,
-    serialize as serialize_i64_as_datetime,
+pub use i64_as_bson_datetime::{
+    deserialize as deserialize_i64_from_bson_datetime,
+    serialize as serialize_i64_as_bson_datetime,
 };
 #[doc(inline)]
 pub use rfc3339_string_as_bson_datetime::{
@@ -424,14 +424,14 @@ pub mod hex_string_as_object_id {
 ///
 /// ```rust
 /// # use serde::{Serialize, Deserialize};
-/// # use bson::serde_helpers::i64_as_datetime;
+/// # use bson::serde_helpers::i64_as_bson_datetime;
 /// #[derive(Serialize, Deserialize)]
 /// struct Item {
-///     #[serde(with = "i64_as_datetime")]
+///     #[serde(with = "i64_as_bson_datetime")]
 ///     pub now: i64,
 /// }
 /// ```
-pub mod i64_as_datetime {
+pub mod i64_as_bson_datetime {
     use crate::DateTime;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -10,7 +10,7 @@ use crate::{
     serde_helpers::{
         bson_datetime_as_rfc3339_string,
         hex_string_as_object_id,
-        i64_as_datetime,
+        i64_as_bson_datetime,
         rfc3339_string_as_bson_datetime,
         serialize_object_id_as_hex_string,
         timestamp_as_u32,
@@ -888,12 +888,12 @@ fn test_oid_helpers() {
 }
 
 #[test]
-fn test_i64_as_datetime() {
+fn test_i64_as_bson_datetime() {
     let _guard = LOCK.run_concurrently();
 
     #[derive(Serialize, Deserialize)]
     struct A {
-        #[serde(with = "i64_as_datetime")]
+        #[serde(with = "i64_as_bson_datetime")]
         now: i64,
     }
 


### PR DESCRIPTION
This is a follow on PR to #381 which renames the new `i64_as_datetime` helper to `i64_as_bson_datetime`, which more closely matches our existing helpers. The "bson" portion helps differentiate between different datetime types that we have support for, such as those from `chrono`.