### PR TITLE
RUST-1564 Fix a fuzzer-found failure

### DIFF
--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -519,7 +519,7 @@ impl<'d, 'de> DocumentAccess<'d, 'de> {
         if bytes_read > *self.length_remaining {
             return Err(Error::custom("length of document too short"));
         }
-        *self.length_remaining -= bytes_read as i32;
+        *self.length_remaining -= bytes_read;
         Ok(out)
     }
 

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -1042,3 +1042,9 @@ fn oid_as_hex_string() {
     let doc = to_document(&foo).unwrap();
     assert_eq!(doc.get_str("oid").unwrap(), oid.to_hex());
 }
+
+#[test]
+fn fuzz_regression_00() {
+    let buf: &[u8] = &[227, 0, 35, 4, 2, 0, 255, 255, 255, 127, 255, 255, 255, 47];
+    let _ = crate::from_slice::<Document>(buf);
+}


### PR DESCRIPTION
RUST-1564

This was found in prepping for the 2.5.0 release; it's unrelated to changes in that release but seemed good to fix before rolling that out.