### PR TITLE
RUST-1592 Support decimal128 to/from human-readable strings

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -181,9 +181,9 @@ axes:
   - id: "extra-rust-versions"
     values:
       - id: "min"
-        display_name: "1.53 (minimum supported version)"
+        display_name: "1.56 (minimum supported version)"
         variables:
-          RUST_VERSION: "1.53.0"
+          RUST_VERSION: "1.56.0"
           MSRV: "true"
       - id: "nightly"
         display_name: "nightly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ uuid = { version = "1.1.2", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
 time = { version = "0.3.9", features = ["formatting", "parsing", "macros", "large-dates"] }
+bitvec = "1.0.1"
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/serde-tests/json.rs
+++ b/serde-tests/json.rs
@@ -48,7 +48,7 @@ fn all_types_json() {
         "undefined": { "$undefined": true },
         "code": { "$code": code },
         "code_w_scope": { "$code": code_w_scope.code, "$scope": scope_json },
-        "decimal": { "$numberDecimalBytes": v.decimal.bytes() },
+        "decimal": { "$numberDecimal": v.decimal.to_string() },
         "symbol": { "$symbol": "ok" },
         "min_key": { "$minKey": 1 },
         "max_key": { "$maxKey": 1 },

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -474,9 +474,6 @@ impl Bson {
     }
 
     /// Converts the Bson value into its [canonical extended JSON representation](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/).
-    ///
-    /// Note: extended json encoding for `Decimal128` values is not supported. If this method is
-    /// called on a case which contains a `Decimal128` value, it will panic.
     pub fn into_canonical_extjson(self) -> Value {
         match self {
             Bson::Int32(i) => json!({ "$numberInt": i.to_string() }),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -455,7 +455,7 @@ impl Bson {
                 "$date": { "$numberLong": v.timestamp_millis().to_string() },
             }),
             Bson::Symbol(v) => json!({ "$symbol": v }),
-            Bson::Decimal128(_) => panic!("Decimal128 extended JSON not implemented yet."),
+            Bson::Decimal128(v) => json!({ "$numberDecimal": v.to_string() }),
             Bson::Undefined => json!({ "$undefined": true }),
             Bson::MinKey => json!({ "$minKey": 1 }),
             Bson::MaxKey => json!({ "$maxKey": 1 }),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -702,6 +702,14 @@ impl Bson {
                 _ => {}
             },
 
+            ["$numberDecimal"] => {
+                if let Ok(d) = doc.get_str("$numberDecimal") {
+                    if let Ok(d) = d.parse() {
+                        return Bson::Decimal128(d);
+                    }
+                }
+            }
+
             ["$numberDecimalBytes"] => {
                 if let Ok(bytes) = doc.get_binary_generic("$numberDecimalBytes") {
                     if let Ok(b) = bytes.clone().try_into() {

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -467,12 +467,14 @@ impl<'de> Visitor<'de> for BsonVisitor {
 
                 "$numberDecimal" => {
                     let string: String = visitor.next_value()?;
-                    return Ok(Bson::Decimal128(string.parse::<Decimal128>().map_err(|_| {
-                        V::Error::invalid_value(
-                            Unexpected::Str(&string),
-                            &"decimal128 as a string",
-                        )
-                    })?));
+                    return Ok(Bson::Decimal128(string.parse::<Decimal128>().map_err(
+                        |_| {
+                            V::Error::invalid_value(
+                                Unexpected::Str(&string),
+                                &"decimal128 as a string",
+                            )
+                        },
+                    )?));
                 }
 
                 "$numberDecimalBytes" => {

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -466,10 +466,13 @@ impl<'de> Visitor<'de> for BsonVisitor {
                 }
 
                 "$numberDecimal" => {
-                    return Err(Error::custom(
-                        "deserializing decimal128 values from strings is not currently supported"
-                            .to_string(),
-                    ));
+                    let string: String = visitor.next_value()?;
+                    return Ok(Bson::Decimal128(string.parse::<Decimal128>().map_err(|_| {
+                        V::Error::invalid_value(
+                            Unexpected::Str(&string),
+                            &"decimal128 as a string",
+                        )
+                    })?));
                 }
 
                 "$numberDecimalBytes" => {

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -501,11 +501,27 @@ mod tests {
     }
 
     #[test]
+    fn finite_0_parse() {
+        let hex = "180000001364000000000000000000000000000000403000";
+        let parsed: ParsedDecimal128 = "0".parse().unwrap();
+        assert_eq!(finite_parts(&parsed), (0, 0));
+        assert_eq!(hex_from_dec(&parsed).to_ascii_lowercase(), hex.to_ascii_lowercase());
+    }
+
+    #[test]
     fn finite_0_1() {
         let hex = "1800000013640001000000000000000000000000003E3000";
         let parsed = dec_from_hex(hex);
         assert_eq!(parsed.to_string(), "0.1");
         assert!(!parsed.sign);
+        assert_eq!(finite_parts(&parsed), (-1, 1));
+        assert_eq!(hex_from_dec(&parsed).to_ascii_lowercase(), hex.to_ascii_lowercase());
+    }
+
+    #[test]
+    fn finite_0_1_parse() {
+        let hex = "1800000013640001000000000000000000000000003E3000";
+        let parsed: ParsedDecimal128 = "0.1".parse().unwrap();
         assert_eq!(finite_parts(&parsed), (-1, 1));
         assert_eq!(hex_from_dec(&parsed).to_ascii_lowercase(), hex.to_ascii_lowercase());
     }
@@ -537,6 +553,35 @@ mod tests {
         assert_eq!(parsed.to_string(), "-1.00E-8");
         assert!(parsed.sign);
         assert_eq!(finite_parts(&parsed), (-10, 100));
+        assert_eq!(hex_from_dec(&parsed).to_ascii_lowercase(), hex.to_ascii_lowercase());
+    }
+
+    #[test]
+    fn finite_largest() {
+        let hex = "18000000136400F2AF967ED05C82DE3297FF6FDE3C403000";
+        let parsed = dec_from_hex(hex);
+        assert_eq!(parsed.to_string(), "1234567890123456789012345678901234");
+        assert!(!parsed.sign);
+        assert_eq!(finite_parts(&parsed), (0, 1234567890123456789012345678901234));
+        assert_eq!(hex_from_dec(&parsed).to_ascii_lowercase(), hex.to_ascii_lowercase());
+    }
+
+    #[test]
+    fn finite_scientific_largest() {
+        let hex = "18000000136400FFFFFFFF638E8D37C087ADBE09EDFF5F00";
+        let parsed = dec_from_hex(hex);
+        assert_eq!(parsed.to_string(), "9.999999999999999999999999999999999E+6144");
+        assert!(!parsed.sign);
+        assert_eq!(finite_parts(&parsed), (6111, 9999999999999999999999999999999999));
+        assert_eq!(hex_from_dec(&parsed).to_ascii_lowercase(), hex.to_ascii_lowercase());
+    }
+
+    #[test]
+    fn finite_scientific_largest_parse() {
+        let hex = "18000000136400FFFFFFFF638E8D37C087ADBE09EDFF5F00";
+        let parsed: ParsedDecimal128 = "9.999999999999999999999999999999999E+6144".parse().unwrap();
+        assert!(!parsed.sign);
+        assert_eq!(finite_parts(&parsed), (6111, 9999999999999999999999999999999999));
         assert_eq!(hex_from_dec(&parsed).to_ascii_lowercase(), hex.to_ascii_lowercase());
     }
 }

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -335,7 +335,7 @@ impl std::str::FromStr for ParsedDecimal128 {
 
     fn from_str(mut s: &str) -> Result<Self, Self::Err> {
         let sign;
-        if let Some(rest) = s.strip_prefix(['-', '+']) {
+        if let Some(rest) = s.strip_prefix(&['-', '+']) {
             sign = s.starts_with('-');
             s = rest;
         } else {

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -335,7 +335,7 @@ impl std::str::FromStr for ParsedDecimal128 {
 
     fn from_str(mut s: &str) -> Result<Self, Self::Err> {
         let sign;
-        if let Some(rest) = s.strip_prefix(&['-', '+']) {
+        if let Some(rest) = s.strip_prefix(&['-', '+'][..]) {
             sign = s.starts_with('-');
             s = rest;
         } else {

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -75,11 +75,17 @@ enum Decimal128Kind {
 struct Exponent([u8; 2]);
 
 impl Exponent {
+    /// The exponent is stored as an unsigned value; `BIAS` is subtracted to get the actual value.
     const BIAS: i16 = 6176;
+    /// The minimum representable exponent.  This is distinct from the specifications "min" value,
+    /// which marks the point at which exponents are considered subnormal.
     const TINY: i16 = -6176;
+    /// The maximum representable exponent.
     const MAX: i16 = 6111;
 
+    /// The number of unused bits in the parsed representation.
     const UNUSED_BITS: usize = 2;
+    /// The total number of bits in the packed representation.
     const PACKED_WIDTH: usize = 14;
 
     fn from_bits(src_bits: &BitSlice<u8, Msb0>) -> Self {
@@ -111,8 +117,11 @@ impl Exponent {
 struct Coefficient([u8; 16]);
 
 impl Coefficient {
+    /// The number of unused bits in the parsed representation.
     const UNUSED_BITS: usize = 14;
+    /// The maximum number of digits allowed in a base-10 string representation of the coefficient.
     const MAX_DIGITS: usize = 34;
+    /// The maximum allowable value of a coefficient.
     const MAX_VALUE: u128 = 9_999_999_999_999_999_999_999_999_999_999_999;
 
     fn from_bits(

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -346,7 +346,7 @@ impl std::str::FromStr for ParsedDecimal128 {
                 // Split into parts
                 let mut decimal_str;
                 let exp_str;
-                match finite_str.split_once('E') {
+                match finite_str.split_once('e') {
                     None => {
                         decimal_str = finite_str;
                         exp_str = "0";
@@ -379,8 +379,8 @@ impl std::str::FromStr for ParsedDecimal128 {
 
                 // Check decimal precision
                 {
-                    let len = decimal_str.len();
-                    if len > Coefficient::MAX_DIGITS {
+                    let len = dbg!(dbg!(&decimal_str).len());
+                    if dbg!(len > Coefficient::MAX_DIGITS) {
                         let decimal_str = round_decimal_str(decimal_str, Coefficient::MAX_DIGITS)?;
                         let exp_adj = (len - decimal_str.len()).try_into().map_err(|_| ParseError::Overflow)?;
                         exp = exp.checked_add(exp_adj).ok_or(ParseError::Overflow)?;
@@ -388,7 +388,7 @@ impl std::str::FromStr for ParsedDecimal128 {
                 }
 
                 // Check exponent limits
-                if exp < Exponent::TINY {
+                if dbg!(exp < Exponent::TINY) {
                     let delta = (Exponent::TINY - exp).try_into().map_err(|_| ParseError::Overflow)?;
                     let new_precision = decimal_str.len().checked_sub(delta).ok_or(ParseError::Underflow)?;
                     decimal_str = round_decimal_str(decimal_str, new_precision)?;

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn zero() {
+    fn finite_0() {
         let parsed = dec_from_hex("180000001364000000000000000000000000000000403000");
         let (exp, sig) = if let Decimal128Kind::Finite { exponent, significand } = parsed.kind {
             (exponent, significand)
@@ -224,5 +224,17 @@ mod tests {
         };
         assert_eq!(sig.value(), 0);
         assert_eq!(exp.value(), 0);
+    }
+
+    #[test]
+    fn finite_0_1() {
+        let parsed = dec_from_hex("1800000013640001000000000000000000000000003E3000");
+        let (exp, sig) = if let Decimal128Kind::Finite { exponent, significand } = parsed.kind {
+            (exponent, significand)
+        } else {
+            panic!("expected finite, got {:?}", parsed);
+        };
+        assert_eq!(sig.value(), 1);
+        assert_eq!(exp.value(), -1);
     }
 }

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -99,7 +99,13 @@ macro_rules! pdbg {
 
 impl ParsedDecimal128 {
     fn new(source: &Decimal128) -> Self {
-        let tmp: Vec<_> = source.bytes.iter().copied().rev().collect();
+        let tmp: [u8; 16] = {
+            let mut tmp = [0u8; 16];
+            for i in 0..16 {
+                tmp[i] = source.bytes[15-i];
+            }
+            tmp
+        };
         let bits = tmp.view_bits::<Order>();
         pdbg!(&bits);
 

--- a/src/extjson/de.rs
+++ b/src/extjson/de.rs
@@ -112,6 +112,11 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for Bson {
             return Ok(Bson::Double(double.parse()?));
         }
 
+        if obj.contains_key("$numberDecimal") {
+            let decimal: models::Decimal128 = serde_json::from_value(obj.into())?;
+            return Ok(Bson::Decimal128(decimal.parse()?));
+        }
+
         if obj.contains_key("$binary") {
             let binary: models::Binary = serde_json::from_value(obj.into())?;
             return Ok(Bson::Binary(binary.parse()?));
@@ -157,10 +162,6 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for Bson {
         if obj.contains_key("$dbPointer") {
             let db_ptr: models::DbPointer = serde_json::from_value(obj.into())?;
             return Ok(db_ptr.parse()?.into());
-        }
-
-        if obj.contains_key("$numberDecimal") {
-            return Err(Error::custom("decimal128 extjson support not implemented"));
         }
 
         if obj.contains_key("$undefined") {

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -20,7 +20,7 @@ impl Int32 {
         let i: i32 = self.value.parse().map_err(|_| {
             extjson::de::Error::invalid_value(
                 Unexpected::Str(self.value.as_str()),
-                &"expected i32 as a string",
+                &"i32 as a string",
             )
         })?;
         Ok(i)
@@ -39,7 +39,7 @@ impl Int64 {
         let i: i64 = self.value.parse().map_err(|_| {
             extjson::de::Error::invalid_value(
                 Unexpected::Str(self.value.as_str()),
-                &"expected i64 as a string",
+                &"i64 as a string",
             )
         })?;
         Ok(i)
@@ -63,7 +63,7 @@ impl Double {
                 let d: f64 = other.parse().map_err(|_| {
                     extjson::de::Error::invalid_value(
                         Unexpected::Str(other),
-                        &"expected bson double as string",
+                        &"bson double as string",
                     )
                 })?;
                 Ok(d)
@@ -81,10 +81,11 @@ pub(crate) struct Decimal128 {
 
 impl Decimal128 {
     pub(crate) fn parse(self) -> extjson::de::Result<crate::Decimal128> {
-        self.value.parse().map_err(|_| {
+        self.value.parse().map_err(|err| {
+            dbg!(err);
             extjson::de::Error::invalid_value(
                 Unexpected::Str(&self.value),
-                &"expected bson decimal128 as string",
+                &"bson decimal128 as string",
             )
         })
     }

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -81,8 +81,7 @@ pub(crate) struct Decimal128 {
 
 impl Decimal128 {
     pub(crate) fn parse(self) -> extjson::de::Result<crate::Decimal128> {
-        self.value.parse().map_err(|err| {
-            dbg!(err);
+        self.value.parse().map_err(|_| {
             extjson::de::Error::invalid_value(
                 Unexpected::Str(&self.value),
                 &"bson decimal128 as string",

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -72,6 +72,24 @@ impl Double {
     }
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Decimal128 {
+    #[serde(rename = "$numberDecimal")]
+    value: String,
+}
+
+impl Decimal128 {
+    pub(crate) fn parse(self) -> extjson::de::Result<crate::Decimal128> {
+        self.value.parse().map_err(|_| {
+            extjson::de::Error::invalid_value(
+                Unexpected::Str(&self.value),
+                &"expected bson decimal128 as string",
+            )
+        })
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ObjectId {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ## Installation
 //! ### Requirements
-//! - Rust 1.53+
+//! - Rust 1.56+
 //!
 //! ### Importing
 //! This crate is available on [crates.io](https://crates.io/crates/bson). To use it in your application,
@@ -260,7 +260,7 @@
 //!
 //! ## Minimum supported Rust version (MSRV)
 //!
-//! The MSRV for this crate is currently 1.53.0. This will be rarely be increased, and if it ever is,
+//! The MSRV for this crate is currently 1.56.0. This will be rarely be increased, and if it ever is,
 //! it will only happen in a minor or major version release.
 
 #![allow(clippy::cognitive_complexity, clippy::derive_partial_eq_without_eq)]

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -695,9 +695,15 @@ impl Serialize for Decimal128 {
     where
         S: ser::Serializer,
     {
-        let mut state = serializer.serialize_struct("$numberDecimal", 1)?;
-        state.serialize_field("$numberDecimalBytes", serde_bytes::Bytes::new(&self.bytes))?;
-        state.end()
+        if serializer.is_human_readable() {
+            let mut state = serializer.serialize_map(Some(1))?;
+            state.serialize_entry("$numberDecimal", &self.to_string())?;
+            state.end()
+        } else {
+            let mut state = serializer.serialize_struct("$numberDecimal", 1)?;
+            state.serialize_field("$numberDecimalBytes", serde_bytes::Bytes::new(&self.bytes))?;
+            state.end()
+        }
     }
 }
 

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -387,12 +387,6 @@ fn run_test(test: TestFile) {
             }
         }
 
-        // TODO RUST-36: Enable decimal128 tests.
-        // extJSON not implemented for decimal128, so we must stop here.
-        if test.bson_type == "0x13" {
-            continue;
-        }
-
         let cej: serde_json::Value =
             serde_json::from_str(&valid.canonical_extjson).expect(&description);
 
@@ -422,15 +416,12 @@ fn run_test(test: TestFile) {
             }
         }
 
-        // TODO RUST-36: Enable decimal128 tests.
-        if test.bson_type != "0x13" {
-            assert_eq!(
-                Bson::Document(documentfromreader_cb.clone()).into_canonical_extjson(),
-                cej_updated_float,
-                "{}",
-                description
-            );
-        }
+        assert_eq!(
+            Bson::Document(documentfromreader_cb.clone()).into_canonical_extjson(),
+            cej_updated_float,
+            "{}",
+            description
+        );
 
         // native_to_relaxed_extended_json( bson_to_native(cB) ) = cEJ
 
@@ -468,15 +459,12 @@ fn run_test(test: TestFile) {
                 .to_writer(&mut native_to_bson_json_to_native_cej)
                 .unwrap();
 
-            // TODO RUST-36: Enable decimal128 tests.
-            if test.bson_type != "0x13" {
-                assert_eq!(
-                    hex::encode(native_to_bson_json_to_native_cej).to_lowercase(),
-                    valid.canonical_bson.to_lowercase(),
-                    "{}",
-                    description,
-                );
-            }
+            assert_eq!(
+                hex::encode(native_to_bson_json_to_native_cej).to_lowercase(),
+                valid.canonical_bson.to_lowercase(),
+                "{}",
+                description,
+            );
         }
 
         if let Some(ref degenerate_extjson) = valid.degenerate_extjson {
@@ -490,14 +478,11 @@ fn run_test(test: TestFile) {
             let native_to_canonical_extended_json_json_to_native_dej =
                 json_to_native_dej.clone().into_canonical_extjson();
 
-            // TODO RUST-36: Enable decimal128 tests.
-            if test.bson_type != "0x13" {
-                assert_eq!(
-                    native_to_canonical_extended_json_json_to_native_dej, cej,
-                    "{}",
-                    description,
-                );
-            }
+            assert_eq!(
+                native_to_canonical_extended_json_json_to_native_dej, cej,
+                "{}",
+                description,
+            );
 
             // native_to_bson( json_to_native(dEJ) ) = cB (unless lossy)
 
@@ -509,15 +494,12 @@ fn run_test(test: TestFile) {
                     .to_writer(&mut native_to_bson_json_to_native_dej)
                     .unwrap();
 
-                // TODO RUST-36: Enable decimal128 tests.
-                if test.bson_type != "0x13" {
-                    assert_eq!(
-                        hex::encode(native_to_bson_json_to_native_dej).to_lowercase(),
-                        valid.canonical_bson.to_lowercase(),
-                        "{}",
-                        description,
-                    );
-                }
+                assert_eq!(
+                    hex::encode(native_to_bson_json_to_native_dej).to_lowercase(),
+                    valid.canonical_bson.to_lowercase(),
+                    "{}",
+                    description,
+                );
             }
         }
 
@@ -571,18 +553,8 @@ fn run_test(test: TestFile) {
     }
 
     for parse_error in test.parse_errors {
-        // TODO RUST-36: Enable decimal128 tests.
-        if test.bson_type == "0x13" {
-            continue;
-        }
-
         // no special support for dbref convention
         if parse_error.description.contains("DBRef") {
-            continue;
-        }
-
-        // TODO RUST-36: Enable decimal128 tests.
-        if parse_error.description.contains("$numberDecimal") {
             continue;
         }
 

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -559,7 +559,6 @@ fn run_test(test: TestFile) {
         }
 
         let json: serde_json::Value = serde_json::Value::String(parse_error.string);
-            //serde_json::from_str(parse_error.string.as_str()).expect(&parse_error.description);
 
         if let Ok(bson) = Bson::try_from(json.clone()) {
             // if converting to bson succeeds, assert that translating that bson to bytes fails

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -558,8 +558,8 @@ fn run_test(test: TestFile) {
             continue;
         }
 
-        let json: serde_json::Value =
-            serde_json::from_str(parse_error.string.as_str()).expect(&parse_error.description);
+        let json: serde_json::Value = serde_json::Value::String(parse_error.string);
+            //serde_json::from_str(parse_error.string.as_str()).expect(&parse_error.description);
 
         if let Ok(bson) = Bson::try_from(json.clone()) {
             // if converting to bson succeeds, assert that translating that bson to bytes fails


### PR DESCRIPTION
RUST-1592

This adds support for the standard human-readable string traits (`Display` and `FromStr`) to `Decimal128` via an intermediate `ParsedDecimal128` struct, as well as using such in the extjson format.  While it's possible to generate/parse the strings directly from the packed binary representation, I opted for the intermediate struct because it's _way_ more readable and it'll be useful if we ever want to support more operations.