### PR TITLE
RUST-1130 Check that the bson crate compiles to wasm

### DIFF
--- a/.evergreen/check-wasm.sh
+++ b/.evergreen/check-wasm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+
+. ~/.cargo/env
+
+rustup target add wasm32-unknown-unknown
+cd $(dirname $0)/../wasm-test
+cargo build --target wasm32-unknown-unknown

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -133,6 +133,16 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/check-rustdoc.sh
 
+  "check wasm compilation":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          .evergreen/check-wasm.sh
+
   "init test-results":
     - command: shell.exec
       params:
@@ -177,6 +187,10 @@ tasks:
     commands:
       - func: "run fuzzer"
 
+  - name: "wasm-compilation"
+    commands:
+      - func: "check wasm compilation"
+
 axes:
   - id: "extra-rust-versions"
     values:
@@ -207,6 +221,7 @@ buildvariants:
     - ubuntu1804-test
   tasks:
     - name: "compile-only"
+
 -
   name: "lint"
   display_name: "Lint"
@@ -224,3 +239,11 @@ buildvariants:
     - ubuntu1804-test
   tasks:
     - name: "run-fuzzer"
+
+-
+  name: "wasm"
+  display_name: "WASM"
+  run_on:
+    - ubuntu1804-test
+  tasks:
+    - name: "wasm-compilation"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bson-wasm-test"
+version = "0.1.0"
+authors = ["Abraham Egnor <abe.egnor@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+bson = { path = ".." }
+getrandom = { version = "0.2", features = ["js"] }

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -1,0 +1,1 @@
+pub use bson;


### PR DESCRIPTION
RUST-1130

This adds a small test crate rather than testing directly against the bson crate - one of the leaf dependencies requires an extra `js` feature to be set, and recommends that libraries not do so themselves.