### PR TITLE
RUST-504 Use js timestamps when generating objectids

### DIFF
--- a/.evergreen/check-wasm.sh
+++ b/.evergreen/check-wasm.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-
-. ~/.cargo/env
-
-rustup target add wasm32-unknown-unknown
-cd $(dirname $0)/../wasm-test
-cargo build --target wasm32-unknown-unknown

--- a/.evergreen/check-wasm.sh
+++ b/.evergreen/check-wasm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+
+. ~/.cargo/env
+
+rustup target add wasm32-unknown-unknown
+cd $(dirname $0)/../wasm-test
+cargo build --target wasm32-unknown-unknown

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -133,6 +133,16 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/check-rustdoc.sh
 
+  "check wasm compilation":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          .evergreen/check-wasm.sh
+
   "init test-results":
     - command: shell.exec
       params:
@@ -177,6 +187,10 @@ tasks:
     commands:
       - func: "run fuzzer"
 
+  - name: "wasm-compilation"
+    commands:
+      - func: "check wasm compilation"
+
 axes:
   - id: "extra-rust-versions"
     values:
@@ -207,6 +221,7 @@ buildvariants:
     - ubuntu1804-test
   tasks:
     - name: "compile-only"
+
 -
   name: "lint"
   display_name: "Lint"
@@ -224,3 +239,11 @@ buildvariants:
     - ubuntu1804-test
   tasks:
     - name: "run-fuzzer"
+
+-
+  name: "wasm"
+  display_name: "WASM"
+  run_on:
+    - ubuntu1804-test
+  tasks:
+    - name: "wasm-compilation"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -133,7 +133,7 @@ functions:
           ${PREPARE_SHELL}
           .evergreen/check-rustdoc.sh
 
-  "check wasm compilation":
+  "run wasm tests":
     - command: shell.exec
       type: test
       params:
@@ -141,7 +141,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          .evergreen/check-wasm.sh
+          .evergreen/run-wasm-tests.sh
 
   "init test-results":
     - command: shell.exec
@@ -187,9 +187,9 @@ tasks:
     commands:
       - func: "run fuzzer"
 
-  - name: "wasm-compilation"
+  - name: "wasm-test"
     commands:
-      - func: "check wasm compilation"
+      - func: "run wasm tests"
 
 axes:
   - id: "extra-rust-versions"
@@ -246,4 +246,4 @@ buildvariants:
   run_on:
     - ubuntu1804-test
   tasks:
-    - name: "wasm-compilation"
+    - name: "wasm-test"

--- a/.evergreen/run-wasm-tests.sh
+++ b/.evergreen/run-wasm-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+
+. ~/.cargo/env
+
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+cd $(dirname $0)/../wasm-test
+wasm-pack test --node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ serde_bytes = "0.11.5"
 serde_with = { version = "1", optional = true }
 time = { version = "0.3.9", features = ["formatting", "parsing", "macros", "large-dates"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+
 [dev-dependencies]
 assert_matches = "1.2"
 criterion = "0.3.0"

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -2,14 +2,15 @@
 //! For more information, see the documentation for the [`ObjectId`] type.
 
 use std::{
-    convert::TryInto,
     error,
     fmt,
     result,
     str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
-    time::SystemTime,
 };
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::{convert::TryInto, time::SystemTime};
 
 use hex::{self, FromHexError};
 use rand::{thread_rng, Rng};
@@ -240,6 +241,9 @@ impl ObjectId {
     /// Generates a new timestamp representing the current seconds since epoch.
     /// Represented in Big Endian.
     fn gen_timestamp() -> [u8; 4] {
+        #[cfg(target_arch = "wasm32")]
+        let timestamp: u32 = (js_sys::Date::now() / 1000.0) as u32;
+        #[cfg(not(target_arch = "wasm32"))]
         let timestamp: u32 = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("system clock is before 1970")

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bson = { path = ".." }
 getrandom = { version = "0.2", features = ["js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.0"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bson-wasm-test"
+version = "0.1.0"
+authors = ["Abraham Egnor <abe.egnor@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+bson = { path = ".." }
+getrandom = { version = "0.2", features = ["js"] }

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -1,1 +1,2 @@
-pub use bson;
+#[cfg(test)]
+mod test;

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -1,0 +1,1 @@
+pub use bson;

--- a/wasm-test/src/test.rs
+++ b/wasm-test/src/test.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[wasm_bindgen_test]
+fn objectid_new() {
+    let _ = bson::oid::ObjectId::new();
+}


### PR DESCRIPTION
RUST-504 / RUST-1130

This adds support for using the Javascript environment timestamp when constructing an `ObjectId` when compiled to wasm, and a simple test case and the supporting machinery.  This supersedes #405.