### PR TITLE
RUST-1677 Add duration_since methods to `DateTime`

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -389,6 +389,19 @@ impl crate::DateTime {
         })?;
         Ok(Self::from_time_0_3(odt))
     }
+
+    /// Computes `self - rhs`, returning the elapsed time as a [`Duration`] or `None` if the result is negative.
+    pub fn checked_sub(self, rhs: Self) -> Option<Duration> {
+        if rhs.0 > self.0 {
+            return None;
+        }
+        Some(Duration::from_millis((self.0 - rhs.0) as u64))
+    }
+
+/// Computes `self - rhs`, returning the elapsed time as a [`Duration`] or a [`Duration`] of zero if the result is negative.
+    pub fn saturating_sub(self, rhs: Self) -> Duration {
+        self.checked_sub(rhs).unwrap_or(Duration::ZERO)
+    }
 }
 
 impl fmt::Debug for crate::DateTime {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -390,17 +390,19 @@ impl crate::DateTime {
         Ok(Self::from_time_0_3(odt))
     }
 
-    /// Computes `self - rhs`, returning the elapsed time as a [`Duration`] or `None` if the result is negative.
-    pub fn checked_sub(self, rhs: Self) -> Option<Duration> {
-        if rhs.0 > self.0 {
+    /// Returns the time elapsed since `earlier`, or `None` if the given `DateTime` is later than
+    /// this one.
+    pub fn checked_duration_since(self, earlier: Self) -> Option<Duration> {
+        if earlier.0 > self.0 {
             return None;
         }
-        Some(Duration::from_millis((self.0 - rhs.0) as u64))
+        Some(Duration::from_millis((self.0 - earlier.0) as u64))
     }
 
-/// Computes `self - rhs`, returning the elapsed time as a [`Duration`] or a [`Duration`] of zero if the result is negative.
-    pub fn saturating_sub(self, rhs: Self) -> Duration {
-        self.checked_sub(rhs).unwrap_or(Duration::ZERO)
+    /// Returns the time elapsed since `earlier`, or a [`Duration`] of zero if the given `DateTime`
+    /// is later than this one.
+    pub fn saturating_duration_since(self, earlier: Self) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or(Duration::ZERO)
     }
 }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -402,7 +402,8 @@ impl crate::DateTime {
     /// Returns the time elapsed since `earlier`, or a [`Duration`] of zero if the given `DateTime`
     /// is later than this one.
     pub fn saturating_duration_since(self, earlier: Self) -> Duration {
-        self.checked_duration_since(earlier).unwrap_or(Duration::ZERO)
+        self.checked_duration_since(earlier)
+            .unwrap_or(Duration::ZERO)
     }
 }
 

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::tests::LOCK;
 
 #[test]
@@ -37,4 +39,17 @@ fn datetime_to_rfc3339() {
 #[test]
 fn invalid_datetime_to_rfc3339() {
     assert!(crate::DateTime::MAX.try_to_rfc3339_string().is_err());
+}
+
+#[test]
+fn subtraction() {
+    let _guard = LOCK.run_concurrently();
+
+    let date1 = crate::DateTime::from_millis(100);
+    let date2 = crate::DateTime::from_millis(1000);
+
+    assert_eq!(date2.checked_sub(date1), Some(Duration::from_millis(900)));
+    assert_eq!(date2.saturating_sub(date1), Duration::from_millis(900));
+    assert!(date1.checked_sub(date2).is_none());
+    assert_eq!(date1.saturating_sub(date2), Duration::ZERO);
 }

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -48,8 +48,14 @@ fn duration_since() {
     let date1 = crate::DateTime::from_millis(100);
     let date2 = crate::DateTime::from_millis(1000);
 
-    assert_eq!(date2.checked_duration_since(date1), Some(Duration::from_millis(900)));
-    assert_eq!(date2.saturating_duration_since(date1), Duration::from_millis(900));
+    assert_eq!(
+        date2.checked_duration_since(date1),
+        Some(Duration::from_millis(900))
+    );
+    assert_eq!(
+        date2.saturating_duration_since(date1),
+        Duration::from_millis(900)
+    );
     assert!(date1.checked_duration_since(date2).is_none());
     assert_eq!(date1.saturating_duration_since(date2), Duration::ZERO);
 }

--- a/src/tests/datetime.rs
+++ b/src/tests/datetime.rs
@@ -42,14 +42,14 @@ fn invalid_datetime_to_rfc3339() {
 }
 
 #[test]
-fn subtraction() {
+fn duration_since() {
     let _guard = LOCK.run_concurrently();
 
     let date1 = crate::DateTime::from_millis(100);
     let date2 = crate::DateTime::from_millis(1000);
 
-    assert_eq!(date2.checked_sub(date1), Some(Duration::from_millis(900)));
-    assert_eq!(date2.saturating_sub(date1), Duration::from_millis(900));
-    assert!(date1.checked_sub(date2).is_none());
-    assert_eq!(date1.saturating_sub(date2), Duration::ZERO);
+    assert_eq!(date2.checked_duration_since(date1), Some(Duration::from_millis(900)));
+    assert_eq!(date2.saturating_duration_since(date1), Duration::from_millis(900));
+    assert!(date1.checked_duration_since(date2).is_none());
+    assert_eq!(date1.saturating_duration_since(date2), Duration::ZERO);
 }


### PR DESCRIPTION
Adds `checked_duration_since` and `saturating_duration_since` methods to `crate::DateTime`. These are based off of the methods of the same name in `std::time::Instant`. I chose not to add any `Sub` implementation because we'd need to decide what to do when the result is negative (i.e. panic or return 0); I'd rather let users make this decision explicitly.