### PR TITLE
RUST-1681 Add deserialize_object_id_from_hex_string

### DIFF
--- a/serde-tests/json.rs
+++ b/serde-tests/json.rs
@@ -130,3 +130,24 @@ fn owned_raw_bson() {
     let round_trip = serde_json::to_value(&f).unwrap();
     assert_eq!(round_trip, json);
 }
+
+#[test]
+fn objectid_hex_json() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Foo {
+        #[serde(with = "bson::serde_helpers::object_id_as_hex_string")]
+        object_id: bson::oid::ObjectId,
+    }
+
+    let expected = bson::oid::ObjectId::new();
+
+    let json = json!({
+        "object_id": expected.to_hex()
+    });
+
+    let f: Foo = serde_json::from_value(json.clone()).unwrap();
+    assert_eq!(f.object_id, expected);
+
+    let round_trip = serde_json::to_value(&f).unwrap();
+    assert_eq!(round_trip, json);
+}

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -23,6 +23,11 @@ pub use hex_string_as_object_id::{
     serialize as serialize_hex_string_as_object_id,
 };
 #[doc(inline)]
+pub use object_id_as_hex_string::{
+    deserialize as deserialize_object_id_from_hex_string,
+    serialize as serialize_object_id_as_hex_string,
+};
+#[doc(inline)]
 pub use i64_as_bson_datetime::{
     deserialize as deserialize_i64_from_bson_datetime,
     serialize as serialize_i64_as_bson_datetime,
@@ -129,14 +134,6 @@ pub fn serialize_u64_as_i64<S: Serializer>(val: &u64, serializer: S) -> Result<S
         Ok(val) => serializer.serialize_i64(val),
         Err(_) => Err(ser::Error::custom(format!("cannot convert {} to i64", val))),
     }
-}
-
-/// Serializes an [`ObjectId`] as a hex string.
-pub fn serialize_object_id_as_hex_string<S: Serializer>(
-    val: &ObjectId,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    val.to_hex().serialize(serializer)
 }
 
 /// Contains functions to serialize a u32 as an f64 (BSON double) and deserialize a
@@ -414,6 +411,37 @@ pub mod hex_string_as_object_id {
                 val
             ))),
         }
+    }
+}
+
+/// Contains functions to serialize a hex string as an ObjectId and deserialize a
+/// hex string from an ObjectId
+///
+/// ```rust
+/// # use serde::{Serialize, Deserialize};
+/// # use bson::oid::ObjectId;
+/// # use bson::serde_helpers::object_id_as_hex_string;
+/// #[derive(Serialize, Deserialize)]
+/// struct Item {
+///     #[serde(with = "object_id_as_hex_string")]
+///     pub id: ObjectId,
+/// }
+/// ```
+pub mod object_id_as_hex_string {
+    use crate::oid::ObjectId;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Deserializes an [`ObjectId`] from a hex string.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ObjectId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        ObjectId::deserialize(deserializer)
+    }
+
+    /// Serializes an [`ObjectId`] as a hex string.
+    pub fn serialize<S: Serializer>(val: &ObjectId, serializer: S) -> Result<S::Ok, S::Error> {
+        val.to_hex().serialize(serializer)
     }
 }
 


### PR DESCRIPTION
This implements [RUST-1681](https://jira.mongodb.org/browse/RUST-1681) `bson::serde_helpers::deserialize_object_id_from_hex_string` (#418).

I rearranged the already existing `serialize_object_id_as_hex_string` function into a `object_id_as_hex_string` module similar to the way `hex_string_as_object_id` was implemented.