### PR TITLE
Fix compilation on `wasm32-wasi` target

### DIFF
--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -5,9 +5,14 @@ set -o errexit
 . ~/.cargo/env
 rustup update $RUST_VERSION
 
+if [ ! -z "$TARGET" ]; then
+    rustup target add $TARGET --toolchain $RUST_VERSION
+    TARGET="--target=$TARGET"
+fi
+
 # pin all dependencies when checking msrv compilation
-if [  "$MSRV" = "true" ]; then
+if [ "$MSRV" = "true" ]; then
     cp .evergreen/Cargo.lock.msrv Cargo.lock
 fi
 
-rustup run $RUST_VERSION cargo build
+rustup run $RUST_VERSION cargo build $TARGET

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -90,7 +90,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          RUST_VERSION=${RUST_VERSION} MSRV=${MSRV} .evergreen/compile-only.sh
+          RUST_VERSION=${RUST_VERSION} MSRV=${MSRV} TARGET=${TARGET} .evergreen/compile-only.sh
 
   "check rustfmt":
     - command: shell.exec
@@ -203,6 +203,18 @@ axes:
         display_name: "nightly"
         variables:
           RUST_VERSION: "nightly"
+  - id: "extra-targets"
+    values:
+      - id: "current"
+        display_name: "current target"
+      - id: "wasi"
+        display_name: "WASI"
+        variables:
+          TARGET: "wasm32-wasi"
+      - id: "wasm"
+        display_name: "WASM"
+        variables:
+          TARGET: "wasm32-unknown-unknown"
 
 buildvariants:
 -
@@ -216,6 +228,7 @@ buildvariants:
 - matrix_name: "compile only"
   matrix_spec:
     extra-rust-versions: "*"
+    extra-targets: "*"
   display_name: "Compile on Rust ${extra-rust-versions}"
   run_on:
     - ubuntu1804-test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ serde_with = { version = "1.3.1", optional = true }
 serde_with-3 = { package = "serde_with", version = "3.1.0", optional = true }
 time = { version = "0.3.9", features = ["formatting", "parsing", "macros", "large-dates"] }
 bitvec = "1.0.1"
-
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = "0.3"
+
 [dev-dependencies]
 assert_matches = "1.2"
 criterion = "0.3.0"
@@ -79,6 +79,8 @@ pretty_assertions = "0.6.1"
 proptest = "1.0.0"
 serde_bytes = "0.11"
 chrono = { version = "0.4", features = ["serde", "clock", "std"], default-features = false }
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -9,7 +9,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::{convert::TryInto, time::SystemTime};
 
 use hex::{self, FromHexError};


### PR DESCRIPTION
## Synopsis

See https://github.com/mongodb/bson-rust/pull/442#issuecomment-1851849879:
> This [broke the 2.8.0 release on `wasm32-wasi` targets](https://github.com/graphql-rust/juniper/actions/runs/7173028592/job/19531503717#step:4:171):
> 
> ```
>  error[E0433]: failed to resolve: use of undeclared type `SystemTime`
>    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bson-2.8.0/src/oid.rs:245:30
>     |
> 245 |         let timestamp: u32 = SystemTime::now()
>     |                              ^^^^^^^^^^ use of undeclared type `SystemTime`
>     |
> help: consider importing this struct
>     |
> 4   + use std::time::SystemTime;
>     |
> 
> error[E0433]: failed to resolve: use of undeclared type `SystemTime`
>    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bson-2.8.0/src/oid.rs:246:29
>     |
> 246 |             .duration_since(SystemTime::UNIX_EPOCH)
>     |                             ^^^^^^^^^^ use of undeclared type `SystemTime`
>     |
> help: consider importing this struct
>     |
> 4   + use std::time::SystemTime;
> ```
> 
> To reproduce, just run `cargo check -p bson --target wasm32-wasi`.


## Solution

- [x] Fix importing according to the new `cfg` rules for WASM targets.
- [x] Check compilation under WASM targets on CI.