### PR TITLE
RUST-1716 Add BSON Binary Data subtype Sensitive

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -54,6 +54,7 @@ const BINARY_SUBTYPE_UUID: u8 = 0x04;
 const BINARY_SUBTYPE_MD5: u8 = 0x05;
 const BINARY_SUBTYPE_ENCRYPTED: u8 = 0x06;
 const BINARY_SUBTYPE_COLUMN: u8 = 0x07;
+const BINARY_SUBTYPE_SENSITIVE: u8 = 0x08;
 const BINARY_SUBTYPE_USER_DEFINED: u8 = 0x80;
 
 /// All available BSON element types.
@@ -153,6 +154,7 @@ pub enum BinarySubtype {
     Md5,
     Encrypted,
     Column,
+    Sensitive,
     UserDefined(u8),
     Reserved(u8),
 }
@@ -169,6 +171,7 @@ impl From<BinarySubtype> for u8 {
             BinarySubtype::Md5 => BINARY_SUBTYPE_MD5,
             BinarySubtype::Encrypted => BINARY_SUBTYPE_ENCRYPTED,
             BinarySubtype::Column => BINARY_SUBTYPE_COLUMN,
+            BinarySubtype::Sensitive => BINARY_SUBTYPE_SENSITIVE,
             BinarySubtype::UserDefined(x) => x,
             BinarySubtype::Reserved(x) => x,
         }
@@ -187,6 +190,7 @@ impl From<u8> for BinarySubtype {
             BINARY_SUBTYPE_MD5 => BinarySubtype::Md5,
             BINARY_SUBTYPE_ENCRYPTED => BinarySubtype::Encrypted,
             BINARY_SUBTYPE_COLUMN => BinarySubtype::Column,
+            BINARY_SUBTYPE_SENSITIVE => BinarySubtype::Sensitive,
             _ if t < BINARY_SUBTYPE_USER_DEFINED => BinarySubtype::Reserved(t),
             _ => BinarySubtype::UserDefined(t),
         }

--- a/src/tests/binary_subtype.rs
+++ b/src/tests/binary_subtype.rs
@@ -7,6 +7,7 @@ fn from_u8() {
     assert_eq!(BinarySubtype::from(0x00), BinarySubtype::Generic);
     assert_eq!(BinarySubtype::from(0x06), BinarySubtype::Encrypted);
     assert_eq!(BinarySubtype::from(0x07), BinarySubtype::Column);
+    assert_eq!(BinarySubtype::from(0x08), BinarySubtype::Sensitive);
     assert_eq!(BinarySubtype::from(0x7F), BinarySubtype::Reserved(0x7F));
     assert_eq!(BinarySubtype::from(0x80), BinarySubtype::UserDefined(0x80));
     assert_eq!(BinarySubtype::from(0xFF), BinarySubtype::UserDefined(0xFF));

--- a/src/tests/spec/json/bson-corpus/binary.json
+++ b/src/tests/spec/json/bson-corpus/binary.json
@@ -56,6 +56,11 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"07\"}}}"
         },
         {
+            "description": "subtype 0x08",
+            "canonical_bson": "1D000000057800100000000873FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"08\"}}}"
+        },
+        {
             "description": "subtype 0x80",
             "canonical_bson": "0F0000000578000200000080FFFF00",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"


### PR DESCRIPTION
- Sync BSON corpus test
- Implement and test BinarySubtype::Sensitive which maps to 0x08