### PR TITLE
RUST-1850 Fix a fuzzer failure

### DIFF
--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -1316,14 +1316,14 @@ impl<'de, 'a> CodeWithScopeDeserializer<'de, 'a> {
         F: FnOnce(&mut Self) -> Result<O>,
     {
         let start_bytes = self.root_deserializer.bytes.bytes_read();
-        let out = f(self);
+        let out = f(self)?;
         let bytes_read = self.root_deserializer.bytes.bytes_read() - start_bytes;
         self.length_remaining -= bytes_read as i32;
 
         if self.length_remaining < 0 {
             return Err(Error::custom("length of CodeWithScope too short"));
         }
-        out
+        Ok(out)
     }
 }
 


### PR DESCRIPTION
RUST-1850

This is the same issue that caused RUST-1564, with the same fix: don't assume deserializer state is in any way valid after an error.  I looked for other instances of this pattern that would have the same problem but didn't find any.