### PR TITLE
fix: export RawElement type

### DIFF
--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -145,6 +145,10 @@ impl<'a> TryInto<Bson> for RawElement<'a> {
 }
 
 impl<'a> RawElement<'a> {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn len(&self) -> usize {
         self.size
     }

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -145,11 +145,7 @@ impl<'a> TryInto<Bson> for RawElement<'a> {
 }
 
 impl<'a> RawElement<'a> {
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn len(&self) -> usize {
+    pub fn size(&self) -> usize {
         self.size
     }
 

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -144,11 +144,8 @@ impl<'a> TryInto<Bson> for RawElement<'a> {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<'a> RawElement<'a> {
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn len(&self) -> usize {
         self.size
     }

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -145,7 +145,11 @@ impl<'a> TryInto<Bson> for RawElement<'a> {
 }
 
 impl<'a> RawElement<'a> {
-    pub fn size(&self) -> usize {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
         self.size
     }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -142,7 +142,7 @@ pub use self::{
     document::RawDocument,
     document_buf::RawDocumentBuf,
     error::{Error, ErrorKind, Result, ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
-    iter::RawIter,
+    iter::{RawElement, RawIter},
 };
 
 /// Special newtype name indicating that the type being (de)serialized is a raw BSON document.


### PR DESCRIPTION
Missed that exports had to be explicitly re-exported in #449. 