### PR TITLE
RUST-1512 Provide a method to append a borrowed value

### DIFF
--- a/src/raw/array_buf.rs
+++ b/src/raw/array_buf.rs
@@ -96,10 +96,6 @@ impl RawArrayBuf {
         self.inner.append(self.len.to_string(), value);
         self.len += 1;
     }
-
-    pub(crate) fn into_vec(self) -> Vec<u8> {
-        self.inner.into_bytes()
-    }
 }
 
 impl Debug for RawArrayBuf {

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -371,7 +371,12 @@ impl RawDocumentBuf {
         })
     }
 
-    fn append_to_data(&mut self, key: impl AsRef<str>, element_type: ElementType, apply: impl FnOnce(&mut Vec<u8>)) {
+    fn append_to_data(
+        &mut self,
+        key: impl AsRef<str>,
+        element_type: ElementType,
+        apply: impl FnOnce(&mut Vec<u8>),
+    ) {
         let original_len = self.data.len();
 
         // write the key for the next value to the end
@@ -398,8 +403,7 @@ impl RawDocumentBuf {
 }
 
 fn append_string(data: &mut Vec<u8>, value: &str) {
-    data
-        .extend(((value.as_bytes().len() + 1) as i32).to_le_bytes());
+    data.extend(((value.as_bytes().len() + 1) as i32).to_le_bytes());
     data.extend(value.as_bytes());
     data.push(0);
 }


### PR DESCRIPTION
RUST-1512

This adds `RawDocumentBuf::append_ref`, providing a method equivalent to `append` for borrowed data.  This can be useful for avoiding the need for intermediate buffers when the source data is borrowed.