### PR TITLE
RUST-1764 Add `HumanReadable` convenience wrapper

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,6 @@ combine_control_expr = false
 comment_width = 100
 condense_wildcard_suffixes = true
 format_strings = true
-normalize_comments = true
 use_try_shorthand = true
 wrap_comments = true
 imports_layout = "HorizontalVertical"

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -295,6 +295,7 @@ impl<'de> Deserializer<'de> {
                         let doc = Bson::JavaScriptCode(code).into_extended_document(false);
                         visitor.visit_map(MapDeserializer::new(
                             doc,
+                            #[allow(deprecated)]
                             DeserializerOptions::builder().human_readable(false).build(),
                         ))
                     }
@@ -352,6 +353,7 @@ impl<'de> Deserializer<'de> {
                         let doc = Bson::Symbol(symbol).into_extended_document(false);
                         visitor.visit_map(MapDeserializer::new(
                             doc,
+                            #[allow(deprecated)]
                             DeserializerOptions::builder().human_readable(false).build(),
                         ))
                     }

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -14,6 +14,7 @@ use serde::{
 use crate::{
     oid::ObjectId,
     raw::{RawBinaryRef, RAW_ARRAY_NEWTYPE, RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
+    serde_helpers::HUMAN_READABLE_NEWTYPE,
     spec::{BinarySubtype, ElementType},
     uuid::UUID_NEWTYPE_NAME,
     Bson,
@@ -51,6 +52,8 @@ pub(crate) struct Deserializer<'de> {
     /// but given that there's no difference between deserializing an embedded document and a
     /// top level one, the distinction isn't necessary.
     current_type: ElementType,
+
+    human_readable: bool,
 }
 
 /// Enum used to determine what the type of document being deserialized is in
@@ -65,6 +68,7 @@ impl<'de> Deserializer<'de> {
         Self {
             bytes: BsonBuf::new(buf, utf8_lossy),
             current_type: ElementType::EmbeddedDocument,
+            human_readable: false,
         }
     }
 
@@ -454,12 +458,16 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
                 self.deserialize_next(visitor, DeserializerHint::RawBson)
             }
+            HUMAN_READABLE_NEWTYPE => {
+                self.human_readable = true;
+                visitor.visit_newtype_struct(self)
+            }
             _ => visitor.visit_newtype_struct(self),
         }
     }
 
     fn is_human_readable(&self) -> bool {
-        false
+        self.human_readable
     }
 
     forward_to_deserialize_any! {

--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -459,8 +459,11 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 self.deserialize_next(visitor, DeserializerHint::RawBson)
             }
             HUMAN_READABLE_NEWTYPE => {
+                let old = self.human_readable;
                 self.human_readable = true;
-                visitor.visit_newtype_struct(self)
+                let result = visitor.visit_newtype_struct(&mut *self);
+                self.human_readable = old;
+                result
             }
             _ => visitor.visit_newtype_struct(self),
         }

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -579,6 +579,7 @@ pub struct Deserializer {
 pub struct DeserializerOptions {
     /// Whether the [`Deserializer`] should present itself as human readable or not.
     /// The default is true.
+    #[deprecated = "use bson::serde_helpers::HumanReadable"]
     pub human_readable: Option<bool>,
 }
 
@@ -598,6 +599,8 @@ pub struct DeserializerOptionsBuilder {
 
 impl DeserializerOptionsBuilder {
     /// Set the value for [`DeserializerOptions::human_readable`].
+    #[deprecated = "use bson::serde_helpers::HumanReadable"]
+    #[allow(deprecated)]
     pub fn human_readable(mut self, val: impl Into<Option<bool>>) -> Self {
         self.options.human_readable = val.into();
         self
@@ -717,6 +720,7 @@ macro_rules! forward_to_deserialize {
 impl<'de> de::Deserializer<'de> for Deserializer {
     type Error = crate::de::Error;
 
+    #[allow(deprecated)]
     fn is_human_readable(&self) -> bool {
         self.options.human_readable.unwrap_or(true)
     }
@@ -849,6 +853,7 @@ impl<'de> de::Deserializer<'de> for Deserializer {
 
                 self.deserialize_next(visitor, DeserializerHint::RawBson)
             }
+            #[allow(deprecated)]
             HUMAN_READABLE_NEWTYPE => {
                 self.options.human_readable = Some(true);
                 visitor.visit_newtype_struct(self)

--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -26,6 +26,7 @@ use crate::{
     document::{Document, IntoIter},
     oid::ObjectId,
     raw::{RawBsonRef, RAW_ARRAY_NEWTYPE, RAW_BSON_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
+    serde_helpers::HUMAN_READABLE_NEWTYPE,
     spec::BinarySubtype,
     uuid::UUID_NEWTYPE_NAME,
     Binary,
@@ -815,7 +816,7 @@ impl<'de> de::Deserializer<'de> for Deserializer {
 
     #[inline]
     fn deserialize_newtype_struct<V>(
-        self,
+        mut self,
         name: &'static str,
         visitor: V,
     ) -> crate::de::Result<V::Value>
@@ -847,6 +848,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
                 }
 
                 self.deserialize_next(visitor, DeserializerHint::RawBson)
+            }
+            HUMAN_READABLE_NEWTYPE => {
+                self.options.human_readable = Some(true);
+                visitor.visit_newtype_struct(self)
             }
             _ => visitor.visit_newtype_struct(self),
         }

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -14,6 +14,7 @@ use super::{write_binary, write_cstring, write_f64, write_i32, write_i64, write_
 use crate::{
     raw::{RAW_ARRAY_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
     ser::{Error, Result},
+    serde_helpers::HUMAN_READABLE_NEWTYPE,
     spec::{BinarySubtype, ElementType},
     uuid::UUID_NEWTYPE_NAME,
 };
@@ -30,6 +31,8 @@ pub(crate) struct Serializer {
 
     /// Hint provided by the type being serialized.
     hint: SerializerHint,
+
+    human_readable: bool,
 }
 
 /// Various bits of information that the serialized type can provide to the serializer to
@@ -60,6 +63,7 @@ impl Serializer {
             bytes: Vec::new(),
             type_index: 0,
             hint: SerializerHint::None,
+            human_readable: false,
         }
     }
 
@@ -115,7 +119,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     type SerializeStructVariant = VariantSerializer<'a>;
 
     fn is_human_readable(&self) -> bool {
-        false
+        self.human_readable
     }
 
     #[inline]
@@ -267,6 +271,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
             UUID_NEWTYPE_NAME => self.hint = SerializerHint::Uuid,
             RAW_DOCUMENT_NEWTYPE => self.hint = SerializerHint::RawDocument,
             RAW_ARRAY_NEWTYPE => self.hint = SerializerHint::RawArray,
+            HUMAN_READABLE_NEWTYPE => self.human_readable = true,
             _ => {}
         }
         value.serialize(self)

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -271,7 +271,13 @@ impl<'a> serde::Serializer for &'a mut Serializer {
             UUID_NEWTYPE_NAME => self.hint = SerializerHint::Uuid,
             RAW_DOCUMENT_NEWTYPE => self.hint = SerializerHint::RawDocument,
             RAW_ARRAY_NEWTYPE => self.hint = SerializerHint::RawArray,
-            HUMAN_READABLE_NEWTYPE => self.human_readable = true,
+            HUMAN_READABLE_NEWTYPE => {
+                let old = self.human_readable;
+                self.human_readable = true;
+                let result = value.serialize(&mut *self);
+                self.human_readable = old;
+                return result;
+            }
             _ => {}
         }
         value.serialize(self)

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -121,6 +121,7 @@ pub struct Serializer {
 pub struct SerializerOptions {
     /// Whether the [`Serializer`] should present itself as human readable or not.
     /// The default value is true.
+    #[deprecated = "use bson::serde_helpers::HumanReadable"]
     pub human_readable: Option<bool>,
 }
 
@@ -140,6 +141,8 @@ pub struct SerializerOptionsBuilder {
 
 impl SerializerOptionsBuilder {
     /// Set the value for [`SerializerOptions::is_human_readable`].
+    #[deprecated = "use bson::serde_helpers::HumanReadable"]
+    #[allow(deprecated)]
     pub fn human_readable(mut self, value: impl Into<Option<bool>>) -> Self {
         self.options.human_readable = value.into();
         self
@@ -349,6 +352,7 @@ impl ser::Serializer for Serializer {
                     b
                 ))),
             },
+            #[allow(deprecated)]
             HUMAN_READABLE_NEWTYPE => {
                 self.options.human_readable = Some(true);
                 value.serialize(self)
@@ -452,6 +456,7 @@ impl ser::Serializer for Serializer {
         })
     }
 
+    #[allow(deprecated)]
     fn is_human_readable(&self) -> bool {
         self.options.human_readable.unwrap_or(true)
     }

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -18,6 +18,7 @@ use crate::{
     extjson,
     oid::ObjectId,
     raw::{RawDbPointerRef, RawRegexRef, RAW_ARRAY_NEWTYPE, RAW_DOCUMENT_NEWTYPE},
+    serde_helpers::HUMAN_READABLE_NEWTYPE,
     spec::BinarySubtype,
     uuid::UUID_NEWTYPE_NAME,
     Binary,
@@ -296,7 +297,7 @@ impl ser::Serializer for Serializer {
 
     #[inline]
     fn serialize_newtype_struct<T: ?Sized>(
-        self,
+        mut self,
         name: &'static str,
         value: &T,
     ) -> crate::ser::Result<Bson>
@@ -348,6 +349,10 @@ impl ser::Serializer for Serializer {
                     b
                 ))),
             },
+            HUMAN_READABLE_NEWTYPE => {
+                self.options.human_readable = Some(true);
+                value.serialize(self)
+            }
             _ => value.serialize(self),
         }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod binary_subtype;
 mod datetime;
 mod modules;
 mod serde;
+mod serde_helpers;
 mod spec;
 
 use modules::TestLock;

--- a/src/tests/serde_helpers.rs
+++ b/src/tests/serde_helpers.rs
@@ -1,0 +1,125 @@
+use serde::{de::Visitor, Deserialize, Serialize};
+
+use crate::serde_helpers::HumanReadable;
+
+#[test]
+fn human_readable_wrapper() {
+    #[derive(PartialEq, Eq, Debug)]
+    struct Detector {
+        serialized_as: bool,
+        deserialized_as: bool,
+    }
+    impl Detector {
+        fn new() -> Self {
+            Detector {
+                serialized_as: false,
+                deserialized_as: false,
+            }
+        }
+    }
+    impl Serialize for Detector {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let s = if serializer.is_human_readable() {
+                "human readable"
+            } else {
+                "not human readable"
+            };
+            serializer.serialize_str(s)
+        }
+    }
+    impl<'de> Deserialize<'de> for Detector {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct V;
+            impl<'de> Visitor<'de> for V {
+                type Value = bool;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    formatter.write_str("Detector")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    match v {
+                        "human readable" => Ok(true),
+                        "not human readable" => Ok(false),
+                        _ => Err(E::custom(format!("invalid detector string {:?}", v))),
+                    }
+                }
+            }
+            let deserialized_as = deserializer.is_human_readable();
+            let serialized_as = deserializer.deserialize_str(V)?;
+            Ok(Detector {
+                serialized_as,
+                deserialized_as,
+            })
+        }
+    }
+    #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+    struct Data {
+        outer: Detector,
+        wrapped: HumanReadable<Detector>,
+        inner: HumanReadable<SubData>,
+    }
+    #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+    struct SubData {
+        value: Detector,
+    }
+    let bson = crate::to_bson_with_options(
+        &Data {
+            outer: Detector::new(),
+            wrapped: HumanReadable(Detector::new()),
+            inner: HumanReadable(SubData {
+                value: Detector::new(),
+            }),
+        },
+        crate::SerializerOptions::builder()
+            .human_readable(false)
+            .build(),
+    )
+    .unwrap();
+    assert_eq!(
+        bson.as_document().unwrap(),
+        &doc! {
+            "outer": "not human readable",
+            "wrapped": "human readable",
+            "inner": {
+                "value": "human readable",
+            }
+        }
+    );
+
+    let tripped: Data = crate::from_bson_with_options(
+        bson,
+        crate::DeserializerOptions::builder()
+            .human_readable(false)
+            .build(),
+    )
+    .unwrap();
+    assert_eq!(
+        tripped,
+        Data {
+            outer: Detector {
+                serialized_as: false,
+                deserialized_as: false
+            },
+            wrapped: HumanReadable(Detector {
+                serialized_as: true,
+                deserialized_as: true
+            }),
+            inner: HumanReadable(SubData {
+                value: Detector {
+                    serialized_as: true,
+                    deserialized_as: true
+                }
+            })
+        }
+    )
+}

--- a/src/tests/serde_helpers.rs
+++ b/src/tests/serde_helpers.rs
@@ -83,6 +83,7 @@ fn human_readable_wrapper() {
     };
     let bson = crate::to_bson_with_options(
         &data,
+        #[allow(deprecated)]
         crate::SerializerOptions::builder()
             .human_readable(false)
             .build(),
@@ -102,6 +103,7 @@ fn human_readable_wrapper() {
 
     let tripped: Data = crate::from_bson_with_options(
         bson,
+        #[allow(deprecated)]
         crate::DeserializerOptions::builder()
             .human_readable(false)
             .build(),

--- a/src/tests/serde_helpers.rs
+++ b/src/tests/serde_helpers.rs
@@ -64,6 +64,7 @@ fn human_readable_wrapper() {
     }
     #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
     struct Data {
+        first: HumanReadable<Detector>,
         outer: Detector,
         wrapped: HumanReadable<Detector>,
         inner: HumanReadable<SubData>,
@@ -73,6 +74,7 @@ fn human_readable_wrapper() {
         value: Detector,
     }
     let data = Data {
+        first: HumanReadable(Detector::new()),
         outer: Detector::new(),
         wrapped: HumanReadable(Detector::new()),
         inner: HumanReadable(SubData {
@@ -89,6 +91,7 @@ fn human_readable_wrapper() {
     assert_eq!(
         bson.as_document().unwrap(),
         &doc! {
+            "first": "human readable",
             "outer": "not human readable",
             "wrapped": "human readable",
             "inner": {
@@ -105,6 +108,10 @@ fn human_readable_wrapper() {
     )
     .unwrap();
     let expected = Data {
+        first: HumanReadable(Detector {
+            serialized_as: true,
+            deserialized_as: true,
+        }),
         outer: Detector {
             serialized_as: false,
             deserialized_as: false,


### PR DESCRIPTION
RUST-1764

This wrapper removes the need for the `human_readable_serialization` option for `Collection` and provides more granular control as well.  There could hypothetically also be a use for a corresponding `NonHumanReadable` wrapper but I'd prefer to wait on adding that until someone asks for it.