### PR TITLE
minor: fix lifetime of RawElement::key

### DIFF
--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -150,7 +150,7 @@ impl<'a> RawElement<'a> {
         self.size
     }
 
-    pub fn key(&self) -> &str {
+    pub fn key(&self) -> &'a str {
         self.key
     }
 


### PR DESCRIPTION
Without the annotation it gets a lifetime bound to the `RawElement` struct, not the underlying data.