### PR TITLE
RUST-1933: Support deserializing $uuid extended JSON syntax

### DIFF
--- a/src/de/serde.rs
+++ b/src/de/serde.rs
@@ -381,6 +381,14 @@ impl<'de> Visitor<'de> for BsonVisitor {
                     ));
                 }
 
+                "$uuid" => {
+                    let v: String = visitor.next_value()?;
+                    let uuid = extjson::models::Uuid { value: v }
+                        .parse()
+                        .map_err(Error::custom)?;
+                    return Ok(Bson::Binary(uuid));
+                }
+
                 "$code" => {
                     let code = visitor.next_value::<String>()?;
                     if let Some(key) = visitor.next_key::<String>()? {

--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -188,7 +188,7 @@ impl Binary {
 #[serde(deny_unknown_fields)]
 pub(crate) struct Uuid {
     #[serde(rename = "$uuid")]
-    value: String,
+    pub(crate) value: String,
 }
 
 impl Uuid {

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -651,6 +651,21 @@ fn test_serde_legacy_uuid_1() {
 }
 
 #[test]
+fn test_de_uuid_extjson_string() {
+    let _guard = LOCK.run_concurrently();
+
+    let uuid_bson_bytes =
+        hex::decode("1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400").unwrap();
+    let uuid_document = Document::from_reader(uuid_bson_bytes.as_slice()).unwrap();
+    let expected_uuid_bson = Bson::from_extended_document(uuid_document);
+
+    let ext_json_uuid = "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}";
+    let actual_uuid_bson: Bson = serde_json::from_str(ext_json_uuid).unwrap();
+
+    assert_eq!(actual_uuid_bson, expected_uuid_bson);
+}
+
+#[test]
 fn test_de_oid_string() {
     let _guard = LOCK.run_concurrently();
 


### PR DESCRIPTION
This PR updates the extended JSON deserializer to support the `$uuid` documented [here](https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#special-rules-for-parsing-uuid-fields). As noted in the ticket, this behavior now required for the Atlas SQL team. I confirmed locally that this change works for our purposes.

Looking through the code, it seems `$uuid` _is_ supported in several other places but not for direct `serde_json::from_str::<bson::Bson>` parsing. I assume this was an accidental omission and not a deliberate choice.

I was unsure exactly where/how to test this. I spent a lot of time looking through the test files but I never quite figured out how/where/if you are testing this specific behavior (parsing extended json strings directly into `Bson` values), so I added a single, simple unit test to cover this. Let me know if testing should be done elsewhere or another way.

Edit: To be clear, our actual use case is using `serde_yaml` to parse yaml files that contain extended json values. The files are parsed into structs that have nested `Bson` fields, which is why this change is relevant and why we can't conveniently use the workaround of parsing into a `serde_json::Value` and then using `TryFrom<serde_json::Value> for Bson`. I updated the description to be a bit more lax to make this clear.