### PR TITLE
RUST-426 Fix Decimal128 human-readable serialization

### DIFF
--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -17,7 +17,6 @@ use crate::{
     serde_helpers::HUMAN_READABLE_NEWTYPE,
     spec::{BinarySubtype, ElementType},
     uuid::UUID_NEWTYPE_NAME,
-    Bson,
     DateTime,
     Decimal128,
     DeserializerOptions,
@@ -292,9 +291,8 @@ impl<'de> Deserializer<'de> {
                     )),
                     _ => {
                         let code = read_string(&mut self.bytes, utf8_lossy)?;
-                        let doc = Bson::JavaScriptCode(code).into_extended_document(false);
                         visitor.visit_map(MapDeserializer::new(
-                            doc,
+                            doc! { "$code": code },
                             #[allow(deprecated)]
                             DeserializerOptions::builder().human_readable(false).build(),
                         ))
@@ -350,9 +348,8 @@ impl<'de> Deserializer<'de> {
                     )),
                     _ => {
                         let symbol = read_string(&mut self.bytes, utf8_lossy)?;
-                        let doc = Bson::Symbol(symbol).into_extended_document(false);
                         visitor.visit_map(MapDeserializer::new(
-                            doc,
+                            doc! { "$symbol": symbol },
                             #[allow(deprecated)]
                             DeserializerOptions::builder().human_readable(false).build(),
                         ))

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -48,7 +48,7 @@ impl Decimal128 {
 
 impl fmt::Debug for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Decimal128(...)")
+        write!(f, "Decimal128({})", hex::encode(self.bytes))
     }
 }
 

--- a/src/ser/serde.rs
+++ b/src/ser/serde.rs
@@ -10,7 +10,6 @@ use serde::ser::{
     SerializeTupleStruct,
     SerializeTupleVariant,
 };
-use serde_bytes::Bytes;
 
 use crate::{
     bson::{Array, Bson, DbPointer, Document, JavaScriptCodeWithScope, Regex, Timestamp},

--- a/src/tests/spec/corpus.rs
+++ b/src/tests/spec/corpus.rs
@@ -267,12 +267,15 @@ fn run_test(test: TestFile) {
             description,
         );
 
-        assert_eq!(
-            hex::encode(documenttowriter_todocument_documentfromreader_cb).to_lowercase(),
-            valid.canonical_bson.to_lowercase(),
-            "{}",
-            description,
-        );
+        // bson::to_document(&Document) may be lossy due to round-tripping extjson
+        if valid.lossy != Some(true) {
+            assert_eq!(
+                hex::encode(documenttowriter_todocument_documentfromreader_cb).to_lowercase(),
+                valid.canonical_bson.to_lowercase(),
+                "{}",
+                description,
+            );
+        }
 
         assert_eq!(
             hex::encode(tovec_documentfromreader_cb).to_lowercase(),
@@ -313,11 +316,14 @@ fn run_test(test: TestFile) {
                 description
             );
 
-            assert_eq!(
-                documentfromreader_cb, todocument_documentfromreader_cb,
-                "{}",
-                description
-            );
+            // bson::to_document(&Document) may be lossy due to round-tripping extjson
+            if valid.lossy != Some(true) {
+                assert_eq!(
+                    documentfromreader_cb, todocument_documentfromreader_cb,
+                    "{}",
+                    description
+                );
+            }
 
             assert_eq!(
                 document_from_raw_document, documentfromreader_cb,


### PR DESCRIPTION
RUST-426

This is a bugfix tangential to working on RUST-426; it conveniently showcases the complexity of issues the current state of the codebase can cause.
* In the process of documenting serialization behavior, I noticed that `Decimal128` had both inline serialization code in `Bson::serialize` and its own `Serialize` implementation.
* The behavior between those two differed: `Decimal128::serialize` uses the proper extjson representation when the serializer is human-readable, whereas `Bson::serialize` would always use a non-human-readable format (a holdover from before we had proper support for Decimal128 values).
* Fixing that to always use `Decimal128::serialize` caused a corpus test to start failing.
 
It turns out that in the corpus tests, along with the spec-mandated comparisons, we also assert that various Rust-specific conversion identities hold.  The one failing in this case was:
```rust
let bytes: Vec[u8] = ...;  // from corpus
let inner = Document::from_reader(bytes);
let outer = bson::to_document(inner);
let mut new_bytes = Vec::new();
outer.to_writer(&mut new_bytes);
assert_eq!(bytes, new_bytes);
```

The bytes in the corpus deserialized to a doc with a `Decimal128` value of `-NaN`.  The failure occurs when calling `bson::to_document` on a value that is itself `Document`:
1. `bson::to_document` flags serialization as human-readable.
2. Serializing `Decimal128` to a human-readable destination causes it to emit an extjson representation (like the rest of our `Bson` types)`
3. The spec for bson decimal128 support gives the [string representation](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.md#to-string-representation) of `-NaN` as just `NaN`, so the extjson here is `{ $numberDecimal: NaN }`
4. In order to round-trip types, `bson::to_document` parses extjson representations in the serialized values, so it gets back a decimal128 that's non-negative.
5. That doesn't produce the same serialized bytes as the original 🙃 

More generally, what this means is that these three properties cannot all be true at once:
* The human-readable serialized form of bson types is extjson.
* `bson::to_document` is human-readable.
* `bson::to_document(Document)` is an identity function.

I believe the correct property to drop is the last one; the corpus already flags some of the tests (including the failing one here) as lossy, so there's clearly an acknowledgement there that extjson cannot always precisely correspond to the binary form.

We could work around that if there were some way for a serializer to flag to a data type that it should use special logic, but I can't find any way to do that in Serde 😞   There are various hacks to provide side-channel data in _other_ directions:
* Data types can wrap their serialized form in a specially-named newtype that will be special-cased by certain serializers
* Data types can request a specially-named newtype from deserializers, and those deserializers can trigger a different data format by calling different methods in the datatype's `Visitor` impl based on that.

... but I can't find any way for serialization format to change based on a serializer beyond the one-bit `is_human_readable` flag.