### PR TITLE
RUST-1773 Merge duplicate extjson map parsing between OwnedOrBorrowedRawBsonVisitor and SeededVisitor

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -406,7 +406,7 @@ impl crate::DateTime {
             .unwrap_or(Duration::ZERO)
     }
 
-    pub(crate) fn to_le_bytes(&self) -> [u8; 8] {
+    pub(crate) fn as_le_bytes(&self) -> [u8; 8] {
         self.0.to_le_bytes()
     }
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -405,6 +405,10 @@ impl crate::DateTime {
         self.checked_duration_since(earlier)
             .unwrap_or(Duration::ZERO)
     }
+
+    pub(crate) fn to_le_bytes(&self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
 }
 
 impl fmt::Debug for crate::DateTime {

--- a/src/raw/serde.rs
+++ b/src/raw/serde.rs
@@ -33,6 +33,18 @@ pub(crate) enum OwnedOrBorrowedRawBson<'a> {
     Borrowed(RawBsonRef<'a>),
 }
 
+impl<'a> OwnedOrBorrowedRawBson<'a> {
+    pub(crate) fn as_ref<'b>(&'b self) -> RawBsonRef<'b>
+    where
+        'a: 'b,
+    {
+        match self {
+            Self::Borrowed(r) => *r,
+            Self::Owned(bson) => bson.as_raw_bson_ref(),
+        }
+    }
+}
+
 impl<'a, 'de: 'a> Deserialize<'de> for OwnedOrBorrowedRawBson<'a> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/raw/serde/seeded_visitor.rs
+++ b/src/raw/serde/seeded_visitor.rs
@@ -308,7 +308,7 @@ impl<'a, 'de> Visitor<'de> for SeededVisitor<'a, 'de> {
                             }
                             RawBsonRef::Undefined => Ok(ElementType::Undefined),
                             RawBsonRef::DateTime(dt) => {
-                                self.buffer.append_bytes(&dt.to_le_bytes());
+                                self.buffer.append_bytes(&dt.as_le_bytes());
                                 Ok(ElementType::DateTime)
                             }
                             RawBsonRef::Timestamp(ts) => {


### PR DESCRIPTION
RUST-1773

This puts responsibility for turning a Serde map into bson values squarely on `OwnedOrBorrowedRawBsonVisitor`; `SeededVisitor`'s job is now to efficiently buffer those values.

In my plan for the 🎆Glorious Future🎆, `OwnedOrBorrowedRawBsonVisitor` will also be taking over for the other places that parse extjson (`BsonVisitor`, `TryFrom<serde_json::Value>`, `crate::extjson::models`) and will necessarily be getting more liberal in the forms it accepts, so this means that doesn't need to be mirrored in `SeededVisitor` as well.

With this, I think the separation of logic is clear enough that there's no need to further merge; the reasoning from your original work on why that would involve quite a bit of complication is still very valid.