### PR TITLE
RUST-1992 Minor parsing cleanup

### DIFF
--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -58,6 +58,12 @@ impl From<string::FromUtf8Error> for Error {
     }
 }
 
+impl From<crate::raw::Error> for Error {
+    fn from(value: crate::raw::Error) -> Self {
+        Self::deserialization(value)
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -519,15 +519,11 @@ impl RawDocument {
         let buf = &self.as_bytes()[start_at..];
 
         let mut splits = buf.splitn(2, |x| *x == 0);
-        let value = splits
-            .next()
-            .ok_or_else(|| Error::new_without_key(ErrorKind::new_malformed("no value")))?;
+        let value = splits.next().ok_or_else(|| Error::malformed("no value"))?;
         if splits.next().is_some() {
             Ok(value)
         } else {
-            Err(Error::new_without_key(ErrorKind::new_malformed(
-                "expected null terminator",
-            )))
+            Err(Error::malformed("expected null terminator"))
         }
     }
 

--- a/src/raw/error.rs
+++ b/src/raw/error.rs
@@ -14,23 +14,18 @@ pub struct Error {
 }
 
 impl Error {
-    pub(crate) fn new_with_key(key: impl Into<String>, kind: ErrorKind) -> Self {
-        Self {
-            kind,
-            key: Some(key.into()),
-        }
-    }
-
-    pub(crate) fn new_without_key(kind: ErrorKind) -> Self {
+    pub(crate) fn new(kind: ErrorKind) -> Self {
         Self { key: None, kind }
     }
 
     pub(crate) fn malformed(e: impl ToString) -> Self {
-        Self::new_without_key(ErrorKind::new_malformed(e))
+        Self::new(ErrorKind::MalformedValue {
+            message: e.to_string(),
+        })
     }
 
-    pub(crate) fn with_key(mut self, key: impl AsRef<str>) -> Self {
-        self.key = Some(key.as_ref().to_string());
+    pub(crate) fn with_key(mut self, key: impl Into<String>) -> Self {
+        self.key = Some(key.into());
         self
     }
 
@@ -50,14 +45,6 @@ pub enum ErrorKind {
 
     /// Improper UTF-8 bytes were found when proper UTF-8 was expected.
     Utf8EncodingError(Utf8Error),
-}
-
-impl ErrorKind {
-    pub(crate) fn new_malformed(e: impl ToString) -> Self {
-        ErrorKind::MalformedValue {
-            message: e.to_string(),
-        }
-    }
 }
 
 impl std::fmt::Display for Error {
@@ -84,7 +71,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// Execute the provided closure, mapping the key of the returned error (if any) to the provided
 /// key.
-pub(crate) fn try_with_key<G, F: FnOnce() -> Result<G>>(key: impl AsRef<str>, f: F) -> Result<G> {
+pub(crate) fn try_with_key<G, F: FnOnce() -> Result<G>>(key: impl Into<String>, f: F) -> Result<G> {
     f().map_err(|e| e.with_key(key))
 }
 

--- a/src/raw/error.rs
+++ b/src/raw/error.rs
@@ -25,6 +25,10 @@ impl Error {
         Self { key: None, kind }
     }
 
+    pub(crate) fn malformed(e: impl ToString) -> Self {
+        Self::new_without_key(ErrorKind::new_malformed(e))
+    }
+
     pub(crate) fn with_key(mut self, key: impl AsRef<str>) -> Self {
         self.key = Some(key.as_ref().to_string());
         self

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use crate::{
     de::{MIN_BSON_DOCUMENT_SIZE, MIN_CODE_WITH_SCOPE_SIZE},
     oid::ObjectId,
-    raw::{Error, ErrorKind, Result},
+    raw::{Error, Result},
     spec::{BinarySubtype, ElementType},
     Bson,
     DateTime,
@@ -82,11 +82,11 @@ impl<'a> RawIter<'a> {
     fn verify_enough_bytes(&self, start: usize, num_bytes: usize) -> Result<()> {
         let end = checked_add(start, num_bytes)?;
         if self.doc.as_bytes().get(start..end).is_none() {
-            return Err(Error::new_without_key(ErrorKind::new_malformed(format!(
+            return Err(Error::malformed(format!(
                 "length exceeds remaining length of buffer: {} vs {}",
                 num_bytes,
                 self.doc.as_bytes().len() - start
-            ))));
+            )));
         }
         Ok(())
     }
@@ -96,18 +96,16 @@ impl<'a> RawIter<'a> {
         let size = i32_from_slice(&self.doc.as_bytes()[starting_at..])? as usize;
 
         if size < MIN_BSON_DOCUMENT_SIZE as usize {
-            return Err(Error::new_without_key(ErrorKind::new_malformed(format!(
+            return Err(Error::malformed(format!(
                 "document too small: {} bytes",
                 size
-            ))));
+            )));
         }
 
         self.verify_enough_bytes(starting_at, size)?;
 
         if self.doc.as_bytes()[starting_at + size - 1] != 0 {
-            return Err(Error::new_without_key(ErrorKind::new_malformed(
-                "not null terminated",
-            )));
+            return Err(Error::malformed("not null terminated"));
         }
         Ok(size)
     }
@@ -310,7 +308,7 @@ impl<'a> RawElement<'a> {
     }
 
     fn malformed_error(&self, e: impl ToString) -> Error {
-        Error::new_with_key(self.key, ErrorKind::new_malformed(e))
+        Error::malformed(e).with_key(self.key)
     }
 
     pub(crate) fn slice(&self) -> &'a [u8] {
@@ -337,7 +335,7 @@ impl<'a> RawElement<'a> {
         Ok(ObjectId::from_bytes(
             self.doc.as_bytes()[start_at..(start_at + 12)]
                 .try_into()
-                .map_err(|e| Error::new_with_key(self.key, ErrorKind::new_malformed(e)))?,
+                .map_err(|e| Error::malformed(e).with_key(self.key))?,
         ))
     }
 }
@@ -346,9 +344,7 @@ impl<'a> RawIter<'a> {
     fn get_next_length_at(&self, start_at: usize) -> Result<usize> {
         let len = i32_from_slice(&self.doc.as_bytes()[start_at..])?;
         if len < 0 {
-            Err(Error::new_without_key(ErrorKind::new_malformed(
-                "lengths can't be negative",
-            )))
+            Err(Error::malformed("lengths can't be negative"))
         } else {
             Ok(len as usize)
         }
@@ -367,15 +363,11 @@ impl<'a> Iterator for RawIter<'a> {
                 return None;
             } else {
                 self.valid = false;
-                return Some(Err(Error::new_without_key(ErrorKind::new_malformed(
-                    "document not null terminated",
-                ))));
+                return Some(Err(Error::malformed("document not null terminated")));
             }
         } else if self.offset >= self.doc.as_bytes().len() {
             self.valid = false;
-            return Some(Err(Error::new_without_key(ErrorKind::new_malformed(
-                "iteration overflowed document",
-            ))));
+            return Some(Err(Error::malformed("iteration overflowed document")));
         }
 
         let key = match self.doc.read_cstring_at(self.offset + 1) {
@@ -391,13 +383,11 @@ impl<'a> Iterator for RawIter<'a> {
             let element_type = match ElementType::from(self.doc.as_bytes()[self.offset]) {
                 Some(et) => et,
                 None => {
-                    return Err(Error::new_with_key(
-                        key,
-                        ErrorKind::new_malformed(format!(
-                            "invalid tag: {}",
-                            self.doc.as_bytes()[self.offset]
-                        )),
+                    return Err(Error::malformed(format!(
+                        "invalid tag: {}",
+                        self.doc.as_bytes()[self.offset]
                     ))
+                    .with_key(key))
                 }
             };
 

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 
 use crate::{
-    de::{read_bool, MIN_BSON_DOCUMENT_SIZE, MIN_CODE_WITH_SCOPE_SIZE},
+    de::{MIN_BSON_DOCUMENT_SIZE, MIN_CODE_WITH_SCOPE_SIZE},
     oid::ObjectId,
     raw::{Error, ErrorKind, Result},
     spec::{BinarySubtype, ElementType},
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use super::{
+    bool_from_slice,
     checked_add,
     error::try_with_key,
     f64_from_slice,
@@ -186,9 +187,9 @@ impl<'a> RawElement<'a> {
             ElementType::Array => {
                 RawBsonRef::Array(RawArray::from_doc(RawDocument::from_bytes(self.slice())?))
             }
-            ElementType::Boolean => {
-                RawBsonRef::Boolean(read_bool(self.slice()).map_err(|e| self.malformed_error(e))?)
-            }
+            ElementType::Boolean => RawBsonRef::Boolean(
+                bool_from_slice(self.slice()).map_err(|e| self.malformed_error(e))?,
+            ),
             ElementType::DateTime => {
                 RawBsonRef::DateTime(DateTime::from_millis(i64_from_slice(self.slice())?))
             }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -198,6 +198,31 @@ fn i64_from_slice(val: &[u8]) -> Result<i64> {
     Ok(i64::from_le_bytes(arr))
 }
 
+fn u8_from_slice(val: &[u8]) -> Result<u8> {
+    let arr = val
+        .get(0..1)
+        .and_then(|s| s.try_into().ok())
+        .ok_or_else(|| {
+            Error::malformed(format!(
+                "expected 1 byte to read u8, instead got {}",
+                val.len()
+            ))
+        })?;
+    Ok(u8::from_le_bytes(arr))
+}
+
+pub(crate) fn bool_from_slice(val: &[u8]) -> Result<bool> {
+    let val = u8_from_slice(val)?;
+    if val > 1 {
+        return Err(Error::malformed(format!(
+            "boolean must be stored as 0 or 1, got {}",
+            val
+        )));
+    }
+
+    Ok(val != 0)
+}
+
 fn read_len(buf: &[u8]) -> Result<usize> {
     if buf.len() < 4 {
         return Err(Error::new_without_key(ErrorKind::MalformedValue {


### PR DESCRIPTION
RUST-1992

This PR:
* Relocates the remaining raw field parsing from `crate::de` to `crate::raw` to go with the existing other such functions there
* Removes duplicate "read length and contents to buffer" logic from `crate::document` in favor of the function in `crate::de`.
* Cleans up error construction a little bit.