### PR TITLE
RUST-1992 Factor raw bson encoding out of RawDocumentBuf

### DIFF
--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -223,7 +223,9 @@ impl RawDocumentBuf {
     ///
     /// If the provided key contains an interior null byte, this method will panic.
     pub fn append_ref<'a>(&mut self, key: impl AsRef<str>, value: impl Into<RawBsonRef<'a>>) {
-        raw_writer::RawWriter::new(&mut self.data).append(key.as_ref(), value.into())
+        raw_writer::RawWriter::new(&mut self.data)
+            .append(key.as_ref(), value.into())
+            .unwrap()
     }
 
     /// Convert this [`RawDocumentBuf`] to a [`Document`], returning an error

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -225,7 +225,7 @@ impl RawDocumentBuf {
     pub fn append_ref<'a>(&mut self, key: impl AsRef<str>, value: impl Into<RawBsonRef<'a>>) {
         raw_writer::RawWriter::new(&mut self.data)
             .append(key.as_ref(), value.into())
-            .unwrap()
+            .expect("key should not contain interior null byte")
     }
 
     /// Convert this [`RawDocumentBuf`] to a [`Document`], returning an error

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::{de::MIN_BSON_DOCUMENT_SIZE, spec::BinarySubtype, Document};
+use crate::{de::MIN_BSON_DOCUMENT_SIZE, Document};
 
 use super::{
     bson::RawBson,
@@ -20,6 +20,8 @@ use super::{
     RawIter,
     Result,
 };
+
+mod raw_writer;
 
 /// An owned BSON document (akin to [`std::path::PathBuf`]), backed by a buffer of raw BSON bytes.
 /// This can be created from a `Vec<u8>` or a [`crate::Document`].
@@ -221,103 +223,7 @@ impl RawDocumentBuf {
     ///
     /// If the provided key contains an interior null byte, this method will panic.
     pub fn append_ref<'a>(&mut self, key: impl AsRef<str>, value: impl Into<RawBsonRef<'a>>) {
-        fn append_string(doc: &mut RawDocumentBuf, value: &str) {
-            doc.data
-                .extend(((value.as_bytes().len() + 1) as i32).to_le_bytes());
-            doc.data.extend(value.as_bytes());
-            doc.data.push(0);
-        }
-
-        fn append_cstring(doc: &mut RawDocumentBuf, value: &str) {
-            if value.contains('\0') {
-                panic!("cstr includes interior null byte: {}", value)
-            }
-            doc.data.extend(value.as_bytes());
-            doc.data.push(0);
-        }
-
-        let original_len = self.data.len();
-
-        // write the key for the next value to the end
-        // the element type will replace the previous null byte terminator of the document
-        append_cstring(self, key.as_ref());
-
-        let value = value.into();
-        let element_type = value.element_type();
-
-        match value {
-            RawBsonRef::Int32(i) => {
-                self.data.extend(i.to_le_bytes());
-            }
-            RawBsonRef::String(s) => {
-                append_string(self, s);
-            }
-            RawBsonRef::Document(d) => {
-                self.data.extend(d.as_bytes());
-            }
-            RawBsonRef::Array(a) => {
-                self.data.extend(a.as_bytes());
-            }
-            RawBsonRef::Binary(b) => {
-                let len = b.len();
-                self.data.extend(len.to_le_bytes());
-                self.data.push(b.subtype.into());
-                if let BinarySubtype::BinaryOld = b.subtype {
-                    self.data.extend((len - 4).to_le_bytes())
-                }
-                self.data.extend(b.bytes);
-            }
-            RawBsonRef::Boolean(b) => {
-                self.data.push(b as u8);
-            }
-            RawBsonRef::DateTime(dt) => {
-                self.data.extend(dt.timestamp_millis().to_le_bytes());
-            }
-            RawBsonRef::DbPointer(dbp) => {
-                append_string(self, dbp.namespace);
-                self.data.extend(dbp.id.bytes());
-            }
-            RawBsonRef::Decimal128(d) => {
-                self.data.extend(d.bytes());
-            }
-            RawBsonRef::Double(d) => {
-                self.data.extend(d.to_le_bytes());
-            }
-            RawBsonRef::Int64(i) => {
-                self.data.extend(i.to_le_bytes());
-            }
-            RawBsonRef::RegularExpression(re) => {
-                append_cstring(self, re.pattern);
-                append_cstring(self, re.options);
-            }
-            RawBsonRef::JavaScriptCode(js) => {
-                append_string(self, js);
-            }
-            RawBsonRef::JavaScriptCodeWithScope(code_w_scope) => {
-                let len = code_w_scope.len();
-                self.data.extend(len.to_le_bytes());
-                append_string(self, code_w_scope.code);
-                self.data.extend(code_w_scope.scope.as_bytes());
-            }
-            RawBsonRef::Timestamp(ts) => {
-                self.data.extend(ts.to_le_bytes());
-            }
-            RawBsonRef::ObjectId(oid) => {
-                self.data.extend(oid.bytes());
-            }
-            RawBsonRef::Symbol(s) => {
-                append_string(self, s);
-            }
-            RawBsonRef::Null | RawBsonRef::Undefined | RawBsonRef::MinKey | RawBsonRef::MaxKey => {}
-        }
-
-        // update element type
-        self.data[original_len - 1] = element_type as u8;
-        // append trailing null byte
-        self.data.push(0);
-        // update length
-        let new_len = (self.data.len() as i32).to_le_bytes();
-        self.data[0..4].copy_from_slice(&new_len);
+        raw_writer::RawWriter::new(&mut self.data).append(key.as_ref(), value.into())
     }
 
     /// Convert this [`RawDocumentBuf`] to a [`Document`], returning an error

--- a/src/raw/document_buf/raw_writer.rs
+++ b/src/raw/document_buf/raw_writer.rs
@@ -1,4 +1,8 @@
-use crate::{spec::BinarySubtype, RawBsonRef};
+use crate::{
+    ser::{write_cstring, write_string},
+    spec::BinarySubtype,
+    RawBsonRef,
+};
 
 pub(super) struct RawWriter<'a> {
     data: &'a mut Vec<u8>,
@@ -89,17 +93,10 @@ impl<'a> RawWriter<'a> {
     }
 
     fn append_string(&mut self, value: &str) {
-        self.data
-            .extend(((value.as_bytes().len() + 1) as i32).to_le_bytes());
-        self.data.extend(value.as_bytes());
-        self.data.push(0);
+        write_string(&mut self.data, value)
     }
 
     fn append_cstring(&mut self, value: &str) {
-        if value.contains('\0') {
-            panic!("cstr includes interior null byte: {}", value)
-        }
-        self.data.extend(value.as_bytes());
-        self.data.push(0);
+        write_cstring(&mut self.data, value).unwrap();
     }
 }

--- a/src/raw/document_buf/raw_writer.rs
+++ b/src/raw/document_buf/raw_writer.rs
@@ -1,0 +1,105 @@
+use crate::{spec::BinarySubtype, RawBsonRef};
+
+pub(super) struct RawWriter<'a> {
+    data: &'a mut Vec<u8>,
+}
+
+impl<'a> RawWriter<'a> {
+    pub(super) fn new(data: &'a mut Vec<u8>) -> Self {
+        Self { data }
+    }
+
+    pub(super) fn append<'b>(&mut self, key: &str, value: RawBsonRef<'b>) {
+        let original_len = self.data.len();
+        self.data[original_len - 1] = value.element_type() as u8;
+
+        self.append_cstring(key);
+
+        match value {
+            RawBsonRef::Int32(i) => {
+                self.data.extend(i.to_le_bytes());
+            }
+            RawBsonRef::String(s) => {
+                self.append_string(s);
+            }
+            RawBsonRef::Document(d) => {
+                self.data.extend(d.as_bytes());
+            }
+            RawBsonRef::Array(a) => {
+                self.data.extend(a.as_bytes());
+            }
+            RawBsonRef::Binary(b) => {
+                let len = b.len();
+                self.data.extend(len.to_le_bytes());
+                self.data.push(b.subtype.into());
+                if let BinarySubtype::BinaryOld = b.subtype {
+                    self.data.extend((len - 4).to_le_bytes())
+                }
+                self.data.extend(b.bytes);
+            }
+            RawBsonRef::Boolean(b) => {
+                self.data.push(b as u8);
+            }
+            RawBsonRef::DateTime(dt) => {
+                self.data.extend(dt.timestamp_millis().to_le_bytes());
+            }
+            RawBsonRef::DbPointer(dbp) => {
+                self.append_string(dbp.namespace);
+                self.data.extend(dbp.id.bytes());
+            }
+            RawBsonRef::Decimal128(d) => {
+                self.data.extend(d.bytes());
+            }
+            RawBsonRef::Double(d) => {
+                self.data.extend(d.to_le_bytes());
+            }
+            RawBsonRef::Int64(i) => {
+                self.data.extend(i.to_le_bytes());
+            }
+            RawBsonRef::RegularExpression(re) => {
+                self.append_cstring(re.pattern);
+                self.append_cstring(re.options);
+            }
+            RawBsonRef::JavaScriptCode(js) => {
+                self.append_string(js);
+            }
+            RawBsonRef::JavaScriptCodeWithScope(code_w_scope) => {
+                let len = code_w_scope.len();
+                self.data.extend(len.to_le_bytes());
+                self.append_string(code_w_scope.code);
+                self.data.extend(code_w_scope.scope.as_bytes());
+            }
+            RawBsonRef::Timestamp(ts) => {
+                self.data.extend(ts.to_le_bytes());
+            }
+            RawBsonRef::ObjectId(oid) => {
+                self.data.extend(oid.bytes());
+            }
+            RawBsonRef::Symbol(s) => {
+                self.append_string(s);
+            }
+            RawBsonRef::Null | RawBsonRef::Undefined | RawBsonRef::MinKey | RawBsonRef::MaxKey => {}
+        }
+
+        // append trailing null byte
+        self.data.push(0);
+        // update length
+        let new_len = (self.data.len() as i32).to_le_bytes();
+        self.data[0..4].copy_from_slice(&new_len);
+    }
+
+    fn append_string(&mut self, value: &str) {
+        self.data
+            .extend(((value.as_bytes().len() + 1) as i32).to_le_bytes());
+        self.data.extend(value.as_bytes());
+        self.data.push(0);
+    }
+
+    fn append_cstring(&mut self, value: &str) {
+        if value.contains('\0') {
+            panic!("cstr includes interior null byte: {}", value)
+        }
+        self.data.extend(value.as_bytes());
+        self.data.push(0);
+    }
+}

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -40,19 +40,18 @@ use crate::{
 };
 use ::serde::{ser::Error as SerdeError, Serialize};
 
-fn write_string<W: Write + ?Sized>(writer: &mut W, s: &str) -> Result<()> {
-    writer.write_all(&(s.len() as i32 + 1).to_le_bytes())?;
-    writer.write_all(s.as_bytes())?;
-    writer.write_all(b"\0")?;
-    Ok(())
+pub(crate) fn write_string(buf: &mut Vec<u8>, s: &str) {
+    buf.extend(&(s.len() as i32 + 1).to_le_bytes());
+    buf.extend(s.as_bytes());
+    buf.push(0);
 }
 
-fn write_cstring<W: Write + ?Sized>(writer: &mut W, s: &str) -> Result<()> {
+pub(crate) fn write_cstring(buf: &mut Vec<u8>, s: &str) -> Result<()> {
     if s.contains('\0') {
         return Err(Error::InvalidCString(s.into()));
     }
-    writer.write_all(s.as_bytes())?;
-    writer.write_all(b"\0")?;
+    buf.extend(s.as_bytes());
+    buf.push(0);
     Ok(())
 }
 

--- a/src/ser/raw/mod.rs
+++ b/src/ser/raw/mod.rs
@@ -199,7 +199,8 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     #[inline]
     fn serialize_str(self, v: &str) -> Result<Self::Ok> {
         self.update_element_type(ElementType::String)?;
-        write_string(&mut self.bytes, v)
+        write_string(&mut self.bytes, v);
+        Ok(())
     }
 
     #[inline]

--- a/src/ser/raw/value_serializer.rs
+++ b/src/ser/raw/value_serializer.rs
@@ -265,7 +265,7 @@ impl<'a, 'b> serde::Serializer for &'b mut ValueSerializer<'a> {
                 write_binary(&mut self.root_serializer.bytes, bytes.as_slice(), subtype)?;
             }
             SerializationStep::Symbol | SerializationStep::DbPointerRef => {
-                write_string(&mut self.root_serializer.bytes, v)?;
+                write_string(&mut self.root_serializer.bytes, v);
             }
             SerializationStep::RegExPattern => {
                 write_cstring(&mut self.root_serializer.bytes, v)?;
@@ -278,7 +278,7 @@ impl<'a, 'b> serde::Serializer for &'b mut ValueSerializer<'a> {
                 write_cstring(&mut self.root_serializer.bytes, sorted.as_str())?;
             }
             SerializationStep::Code => {
-                write_string(&mut self.root_serializer.bytes, v)?;
+                write_string(&mut self.root_serializer.bytes, v);
             }
             SerializationStep::CodeWithScopeCode => {
                 self.state = SerializationStep::CodeWithScopeScope {
@@ -313,7 +313,7 @@ impl<'a, 'b> serde::Serializer for &'b mut ValueSerializer<'a> {
                     scope: RawDocument::from_bytes(v).map_err(Error::custom)?,
                 };
                 write_i32(&mut self.root_serializer.bytes, raw.len())?;
-                write_string(&mut self.root_serializer.bytes, code)?;
+                write_string(&mut self.root_serializer.bytes, code);
                 self.root_serializer.bytes.write_all(v)?;
                 self.state = SerializationStep::Done;
                 Ok(())
@@ -590,7 +590,7 @@ impl<'a> CodeWithScopeSerializer<'a> {
     fn start(code: &str, rs: &'a mut Serializer) -> Result<Self> {
         let start = rs.bytes.len();
         write_i32(&mut rs.bytes, 0)?; // placeholder length
-        write_string(&mut rs.bytes, code)?;
+        write_string(&mut rs.bytes, code);
 
         let doc = DocumentSerializer::start(rs)?;
         Ok(Self { start, doc })


### PR DESCRIPTION
RUST-1992

This takes the actual "write to buffer as bytes" code out of `RawDocumentBuf`; my theory is that `RawSerializer` can be reworked to a wrapper around `RawWriter` the way `RawDeserializer` is for `RawElement`.  Even if I'm wrong, I think this is a little cleaner.

I also pruned some string-writing utilities that had proliferated a bit.