### PR TITLE
RUST-2027 Impl Hash/Eq for BSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ chrono-0_4 = ["chrono"]
 uuid-1 = []
 # if enabled, include API for interfacing with time 0.3
 time-0_3 = []
-# If enabled, implement Hash/Eq
+# If enabled, implement Hash/Eq for Bson and Document
 hashable = []
 serde_path_to_error = ["dep:serde_path_to_error"]
 # if enabled, include serde_with interop.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ chrono-0_4 = ["chrono"]
 uuid-1 = []
 # if enabled, include API for interfacing with time 0.3
 time-0_3 = []
+# If enabled, implement Hash/Eq
+hashable = []
 serde_path_to_error = ["dep:serde_path_to_error"]
 # if enabled, include serde_with interop.
 # should be used in conjunction with chrono-0_4 or uuid-0_8.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 | `serde_with` | Enable [`serde_with`](https://docs.rs/serde_with/1.x) 1.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_with-3` | Enable [`serde_with`](https://docs.rs/serde_with/3.x) 3.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_path_to_error` | Enable support for error paths via integration with [`serde_path_to_error`](https://docs.rs/serde_path_to_err/latest).  This is an unstable feature and any breaking changes to `serde_path_to_error` may affect usage of it via this feature.  | serde_path_to_error  | no |
-| `hashable`   | Implements `core::hash::Hash`/`std::cmp::Eq` on `BSON`.                  | n/a                | no      |
+| `hashable`   | Implement `core::hash::Hash` and `std::cmp::Eq` on `Bson` and `Document`.                  | n/a                | no      |
 
 ## Overview of the BSON Format
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 | `serde_with` | Enable [`serde_with`](https://docs.rs/serde_with/1.x) 1.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_with-3` | Enable [`serde_with`](https://docs.rs/serde_with/3.x) 3.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_path_to_error` | Enable support for error paths via integration with [`serde_path_to_error`](https://docs.rs/serde_path_to_err/latest).  This is an unstable feature and any breaking changes to `serde_path_to_error` may affect usage of it via this feature.  | serde_path_to_error  | no |
+| `hashable`   | Implements `core::hash::Hash`/`std::cmp::Eq` on `BSON`.                  | n/a                | no      |
 
 ## Overview of the BSON Format
 

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 /// Represents a BSON binary value.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Binary {
     /// The subtype of the bytes.
     pub subtype: BinarySubtype,

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -101,7 +101,7 @@ impl Hash for Bson {
                 } else {
                     double.to_bits().hash(state);
                 }
-            },
+            }
             Bson::String(x) => x.hash(state),
             Bson::Array(x) => x.hash(state),
             Bson::Document(x) => x.hash(state),

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -21,7 +21,7 @@ use bitvec::prelude::*;
 /// # }
 /// # example().unwrap()
 /// ```
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Decimal128 {
     /// BSON bytes containing the decimal128. Stored for round tripping.
     pub(crate) bytes: [u8; 16],

--- a/src/document.rs
+++ b/src/document.rs
@@ -6,6 +6,8 @@ use std::{
     io::{Read, Write},
     iter::{Extend, FromIterator, IntoIterator},
 };
+#[cfg(feature = "hashable")]
+use std::hash::Hash;
 
 use ahash::RandomState;
 use indexmap::IndexMap;
@@ -56,6 +58,7 @@ impl error::Error for ValueAccessError {}
 
 /// A BSON document represented as an associative HashMap with insertion ordering.
 #[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "hashable", derive(Eq))]
 pub struct Document {
     inner: IndexMap<String, Bson, RandomState>,
 }
@@ -63,6 +66,15 @@ pub struct Document {
 impl Default for Document {
     fn default() -> Self {
         Document::new()
+    }
+}
+
+#[cfg(feature = "hashable")]
+impl Hash for Document {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let mut entries = Vec::from_iter(&self.inner);
+        entries.sort_unstable_by(|a,b| a.0.cmp(b.0));
+        entries.hash(state);
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,13 +1,13 @@
 //! A BSON document represented as an associative HashMap with insertion ordering.
 
+#[cfg(feature = "hashable")]
+use std::hash::Hash;
 use std::{
     error,
     fmt::{self, Debug, Display, Formatter},
     io::{Read, Write},
     iter::{Extend, FromIterator, IntoIterator},
 };
-#[cfg(feature = "hashable")]
-use std::hash::Hash;
 
 use ahash::RandomState;
 use indexmap::IndexMap;
@@ -73,7 +73,7 @@ impl Default for Document {
 impl Hash for Document {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let mut entries = Vec::from_iter(&self.inner);
-        entries.sort_unstable_by(|a,b| a.0.cmp(b.0));
+        entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
         entries.hash(state);
     }
 }

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -499,6 +499,6 @@ fn test_hashable() {
     assert_eq!(map.remove(&key), Some(1));
     assert_eq!(map.remove(&Bson::Undefined), Some(3));
     assert_eq!(map.remove(&Bson::Null), Some(2));
-    
+
     assert!(map.is_empty());
 }

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -486,3 +486,13 @@ fn debug_print() {
     assert_eq!(format!("{:?}", doc), normal_print);
     assert_eq!(format!("{:#?}", doc), pretty_print);
 }
+
+#[cfg(feature = "hashable")]
+#[test]
+fn test_hashable() {
+    let mut map = std::collections::HashMap::new();
+    map.insert(bson!({"a":1, "b": 2}), 8);
+    let key = bson!({"b": 2, "a":1});
+    assert_eq!(map.remove(&key), Some(8));
+    assert!(map.is_empty());
+}

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -491,8 +491,14 @@ fn debug_print() {
 #[test]
 fn test_hashable() {
     let mut map = std::collections::HashMap::new();
-    map.insert(bson!({"a":1, "b": 2}), 8);
+    map.insert(bson!({"a":1, "b": 2}), 1);
+    map.insert(Bson::Null, 2);
+    map.insert(Bson::Undefined, 3);
+
     let key = bson!({"b": 2, "a":1});
-    assert_eq!(map.remove(&key), Some(8));
+    assert_eq!(map.remove(&key), Some(1));
+    assert_eq!(map.remove(&Bson::Undefined), Some(3));
+    assert_eq!(map.remove(&Bson::Null), Some(2));
+    
     assert!(map.is_empty());
 }


### PR DESCRIPTION
#494
Summery of changes:
* Added feature `hashable` to require the user to choose to opt-in using `Bson` as hash key.
 Although, `serde_json` didn't bother with having this behind the feature flag, so If you like I can remove it.
* `Bson::Double(f64)` - implemented the same solution as [`serde_json`](https://docs.rs/serde_json/1.0.127/src/serde_json/number.rs.html#53-70).
* `Bson::Document(Document)` - implemented the same solution as [`serde_json`](https://docs.rs/serde_json/1.0.127/src/serde_json/map.rs.html#395-397).
* `Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope)` - Able to impl Hash/Eq only if Document is impl Hash/Eq.
* `Bson::{RegularExpression(Regex), Binary(Binary), Decimal128(Decimal128), DbPointer(DbPointer)}` - Added Derive Hash/Eq without feature flag `hashable`, no reason for it not to implement those by default.
* Added unit test to show that using Bson as key works.

I didn't implement it yet, but if the above feature is acceptable,
it might be worth adding another feature like `not(preserve_order)` from `serde_json`,
to change `Bson::Document` to use `BTreeMap` instead of `indexmap` for more efficient hashing (like [`serde_json`](https://docs.rs/serde_json/1.0.127/src/serde_json/map.rs.html#390)).
I don't mind adding this as a separate PR.