### PR TITLE
RUST-2028 Fix Decimal128 panic when parsing strings w/o a char boundary at idx 34

### DIFF
--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -333,6 +333,7 @@ pub enum ParseError {
     Overflow,
     Underflow,
     InexactRounding,
+    Unparseable,
 }
 
 impl fmt::Display for ParseError {
@@ -344,6 +345,7 @@ impl fmt::Display for ParseError {
             ParseError::Overflow => write!(f, "overflow"),
             ParseError::Underflow => write!(f, "underflow"),
             ParseError::InexactRounding => write!(f, "inexact rounding"),
+            ParseError::Unparseable => write!(f, "unparseable"),
         }
     }
 }
@@ -473,11 +475,7 @@ fn round_decimal_str(s: &str, precision: usize) -> Result<&str, ParseError> {
     // panic if the index doesn't falls at a codepoint boundary, until then
     // we can check it with s.is_char_boundary(precision)
     if !s.is_char_boundary(precision) {
-        // a non-digit (all single byte utf8) would trigger a ParseIntError::InvalidDigit,
-        // so here we generate a ParseIntError::InvalidDigit kind of error too.
-        return Err(ParseError::InvalidCoefficient(
-            u8::from_str_radix("❤", 10).unwrap_err(),
-        ));
+        return Err(ParseError::Unparseable);
     }
     let (pre, post) = s.split_at(precision);
     // Any nonzero trimmed digits mean it would be an imprecise round.

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -10,9 +10,21 @@ use crate::{
     Binary,
     Bson,
     DateTime,
+    Decimal128,
     Regex,
     Timestamp,
 };
+
+#[test]
+fn test_decimal128_doesnt_panic_on_bad_codepoint_boundary() {
+    use crate::decimal128::ParseError;
+    use std::{num::IntErrorKind::InvalidDigit, str::FromStr};
+    // idx 34 (Coefficient::MAX_DIGITS) on this string isn't a valid codepoint boundary
+    assert!(
+        matches!(Decimal128::from_str("111111111111111111111111111111111❤"),
+        Err(ParseError::InvalidCoefficient(e)) if *e.kind() == InvalidDigit)
+    )
+}
 
 #[test]
 fn string_from_document() {

--- a/src/raw/test/mod.rs
+++ b/src/raw/test/mod.rs
@@ -18,12 +18,12 @@ use crate::{
 #[test]
 fn test_decimal128_doesnt_panic_on_bad_codepoint_boundary() {
     use crate::decimal128::ParseError;
-    use std::{num::IntErrorKind::InvalidDigit, str::FromStr};
+    use std::str::FromStr;
     // idx 34 (Coefficient::MAX_DIGITS) on this string isn't a valid codepoint boundary
-    assert!(
-        matches!(Decimal128::from_str("111111111111111111111111111111111❤"),
-        Err(ParseError::InvalidCoefficient(e)) if *e.kind() == InvalidDigit)
-    )
+    assert!(matches!(
+        Decimal128::from_str("111111111111111111111111111111111❤"),
+        Err(ParseError::Unparseable)
+    ))
 }
 
 #[test]


### PR DESCRIPTION
Fix Decimal128 panic when parsing strings w/o a char boundary at idx 34 (Coefficient::MAX_DIGITS).