### PR TITLE
test(fuzz): read -> write bson

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,3 +28,7 @@ path = "fuzz_targets/iterate.rs"
 [[bin]]
 name = "raw_deserialize"
 path = "fuzz_targets/raw_deserialize.rs"
+
+[[bin]]
+name = "raw_deserialize_utf8_lossy"
+path = "fuzz_targets/raw_deserialize_utf8_lossy.rs"

--- a/fuzz/fuzz_targets/iterate.rs
+++ b/fuzz/fuzz_targets/iterate.rs
@@ -1,5 +1,6 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate bson;
 use bson::RawDocument;
 

--- a/fuzz/fuzz_targets/raw_deserialize.rs
+++ b/fuzz/fuzz_targets/raw_deserialize.rs
@@ -1,8 +1,12 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate bson;
 use bson::Document;
 
 fuzz_target!(|buf: &[u8]| {
-    let _ = bson::from_slice::<Document>(buf);
+    if let Ok(doc) = bson::from_slice::<Document>(buf) {
+        let mut vec = Vec::with_capacity(buf.len());
+        let _ = doc.to_writer(&mut vec);
+    }
 });

--- a/fuzz/fuzz_targets/raw_deserialize_utf8_lossy.rs
+++ b/fuzz/fuzz_targets/raw_deserialize_utf8_lossy.rs
@@ -1,13 +1,10 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
+#[macro_use] extern crate libfuzzer_sys;
 extern crate bson;
-
 use bson::Document;
-use std::io::Cursor;
 
 fuzz_target!(|buf: &[u8]| {
-    if let Ok(doc) = Document::from_reader(&mut Cursor::new(&buf[..])) {
+    if let Ok(doc) = bson::from_slice_utf8_lossy::<Document>(buf) {
         let mut vec = Vec::with_capacity(buf.len());
         let _ = doc.to_writer(&mut vec);
     }


### PR DESCRIPTION
Runs `to_writer` in fuzz tests. Makes the fuzzer slower, but covers any write errors. Also adds a fuzz test for `from_slice_utf8_lossy`.

Note: I did not check for equivalence in `from_reader` and `to_writer`, as, even for accounting for length, there is still some loss in data ordering from the reader, as is to be expected.