### PR TITLE
RUST-2019 Respect pretty printing flag for Document and Bson

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -146,7 +146,7 @@ impl Display for Bson {
 
                 fmt.write_str("]")
             }
-            Bson::Document(ref doc) => write!(fmt, "{}", doc),
+            Bson::Document(ref doc) => if fmt.alternate() {write!(fmt, "{doc:#}")} else {write!(fmt, "{}", doc)},
             Bson::Boolean(b) => write!(fmt, "{}", b),
             Bson::Null => write!(fmt, "null"),
             Bson::RegularExpression(ref x) => write!(fmt, "{}", x),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -146,7 +146,13 @@ impl Display for Bson {
 
                 fmt.write_str("]")
             }
-            Bson::Document(ref doc) => if fmt.alternate() {write!(fmt, "{doc:#}")} else {write!(fmt, "{}", doc)},
+            Bson::Document(ref doc) => {
+                if fmt.alternate() {
+                    write!(fmt, "{doc:#}")
+                } else {
+                    write!(fmt, "{}", doc)
+                }
+            }
             Bson::Boolean(b) => write!(fmt, "{}", b),
             Bson::Null => write!(fmt, "null"),
             Bson::RegularExpression(ref x) => write!(fmt, "{}", x),

--- a/src/document.rs
+++ b/src/document.rs
@@ -80,7 +80,10 @@ impl Hash for Document {
 
 impl Display for Document {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        fmt.write_str(if fmt.alternate() { "{\n" } else { "{" })?;
+        fmt.write_str("{")?;
+        if fmt.alternate() && self.inner.len() > 0 {
+            fmt.write_str("\n")?;
+        }
 
         let mut first = true;
         for (k, v) in self {
@@ -94,7 +97,7 @@ impl Display for Document {
             write!(fmt, "\"{}\": {}", k, v)?;
         }
 
-        if fmt.alternate() {
+        if fmt.alternate() && self.inner.len() > 0 {
             write!(fmt, "\n}}")
         } else {
             write!(fmt, "{}}}", if !first { " " } else { "" })

--- a/src/document.rs
+++ b/src/document.rs
@@ -80,7 +80,7 @@ impl Hash for Document {
 
 impl Display for Document {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        fmt.write_str("{")?;
+        fmt.write_str(if fmt.alternate() { "{\n" } else {"{"})?;
 
         let mut first = true;
         for (k, v) in self {
@@ -88,13 +88,20 @@ impl Display for Document {
                 first = false;
                 fmt.write_str(" ")?;
             } else {
-                fmt.write_str(", ")?;
+                fmt.write_str(if fmt.alternate() { ", \n " } else {", "})?;
             }
 
             write!(fmt, "\"{}\": {}", k, v)?;
         }
 
-        write!(fmt, "{}}}", if !first { " " } else { "" })
+        if fmt.alternate() {
+            write!(fmt, "\n}}")
+        }
+        else {
+            write!(fmt, "{}}}", if !first { " " } else { "" })
+
+        }
+
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -80,7 +80,7 @@ impl Hash for Document {
 
 impl Display for Document {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        fmt.write_str(if fmt.alternate() { "{\n" } else {"{"})?;
+        fmt.write_str(if fmt.alternate() { "{\n" } else { "{" })?;
 
         let mut first = true;
         for (k, v) in self {
@@ -88,7 +88,7 @@ impl Display for Document {
                 first = false;
                 fmt.write_str(" ")?;
             } else {
-                fmt.write_str(if fmt.alternate() { ", \n " } else {", "})?;
+                fmt.write_str(if fmt.alternate() { ", \n " } else { ", " })?;
             }
 
             write!(fmt, "\"{}\": {}", k, v)?;
@@ -96,12 +96,9 @@ impl Display for Document {
 
         if fmt.alternate() {
             write!(fmt, "\n}}")
-        }
-        else {
+        } else {
             write!(fmt, "{}}}", if !first { " " } else { "" })
-
         }
-
     }
 }
 


### PR DESCRIPTION
[RUST-2019](https://jira.mongodb.org/browse/RUST-2019)

Didn't add a unit test because `Display` outputs to the console, let me know if this should be tested though
I did test manually with this code
```
let my_hashmap = HashMap::from([
        ("hello", "world!"), ("world", "hello"), ("key", "val")
      ]);
      
    let bson_document = to_bson(&my_hashmap).unwrap();
    println!("{bson_document}");
    println!("{bson_document:#}");

    let hm: HashMap<&str, &str> = HashMap::from([]);
    let md = to_document(&hm).unwrap();
    println!("{md}");
    println!("{md:#}");
```
which outputted
```
{ "hello": "world!", "world": "hello", "key": "val" }
{
 "hello": "world!", 
 "world": "hello", 
 "key": "val"
}
{}
{}
```
did the same test switching to_document instead of to_bson and got the same output.