### PR TITLE
fuzz: remove malformed_length entry

### DIFF
--- a/.evergreen/run-fuzzer.sh
+++ b/.evergreen/run-fuzzer.sh
@@ -35,7 +35,6 @@ run_fuzzer "raw_deserialize"
 run_fuzzer "iterate"
 
 # Run new security-focused targets
-run_fuzzer "malformed_length"
 run_fuzzer "type_markers"
 run_fuzzer "string_handling"
 run_fuzzer "serialization"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -40,10 +40,6 @@ name = "raw_deserialize_utf8_lossy"
 path = "fuzz_targets/raw_deserialize_utf8_lossy.rs"
 
 [[bin]]
-name = "malformed_length"
-path = "fuzz_targets/malformed_length.rs"
-
-[[bin]]
 name = "type_markers"
 path = "fuzz_targets/type_markers.rs"
 


### PR DESCRIPTION
Missing malformed_length target is causing build failure at oss-fuzz