### PR TITLE
RUST-2058 Fix BSON WASM tests

### DIFF
--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -6,6 +6,10 @@ set -o errexit
 rustup update $RUST_VERSION
 
 if [ ! -z "$TARGET" ]; then
+    if [[ "$TARGET" = "wasm32-wasi" && "$RUST_VERSION" = "nightly" ]]; then
+        # renamed in newer versions of rustc
+        TARGET="wasm32-wasip1"
+    fi
     rustup target add $TARGET --toolchain $RUST_VERSION
     TARGET="--target=$TARGET"
 fi

--- a/.evergreen/run-wasm-tests.sh
+++ b/.evergreen/run-wasm-tests.sh
@@ -4,6 +4,9 @@ set -o errexit
 
 . ~/.cargo/env
 
+rustup update 1.81
+rustup default 1.81
+
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 cd $(dirname $0)/../wasm-test


### PR DESCRIPTION
RUST-2058

There were two unrelated issues here:
* The `wasm32-wasi` target was renamed in newer versions of rustc to `wasm32-wasip1` (to make room for the upcoming `wasm32-wasip2`), so we need conditional logic for that.
* The version of LLVM used in rustc 1.82+ emits webassembly using a reference types specification that's not supported in the node.js runtime ([this bug](https://github.com/rustwasm/wasm-bindgen/issues/4211) has some details).  I've pinned that test to rustc 1.81 for now; hopefully by the time our MSRV catches up to that and we need to unpin it node will have also caught up :)