### PR TITLE
RUST-2158 update edition & rand crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "Encoding and decoding support for BSON in Rust"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/mongodb/bson-rust"
-edition = "2018"
+edition = "2021"
 keywords = ["bson", "mongodb", "serde", "serialization", "deserialization"]
 categories = ["encoding"]
 
@@ -58,7 +58,7 @@ name = "bson"
 [dependencies]
 ahash = "0.8.0"
 chrono = { version = "0.4.15", features = ["std"], default-features = false, optional = true }
-rand = "0.8"
+rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 indexmap = "2.1.0"

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -2,9 +2,7 @@
 //! For more information, see the documentation for the [`ObjectId`] type.
 
 use std::{
-    error,
-    fmt,
-    result,
+    error, fmt, result,
     str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
 };
@@ -14,7 +12,7 @@ use std::{convert::TryInto, time::SystemTime};
 
 use hex::{self, FromHexError};
 use once_cell::sync::Lazy;
-use rand::{random, thread_rng, Rng};
+use rand::{random, rng, Rng};
 
 const TIMESTAMP_SIZE: usize = 4;
 const PROCESS_ID_SIZE: usize = 5;
@@ -27,7 +25,7 @@ const COUNTER_OFFSET: usize = PROCESS_ID_OFFSET + PROCESS_ID_SIZE;
 const MAX_U24: usize = 0xFF_FFFF;
 
 static OID_COUNTER: Lazy<AtomicUsize> =
-    Lazy::new(|| AtomicUsize::new(thread_rng().gen_range(0..=MAX_U24)));
+    Lazy::new(|| AtomicUsize::new(rng().random_range(0..=MAX_U24)));
 
 /// Errors that can occur during [`ObjectId`] construction and generation.
 #[derive(Clone, Debug)]

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -2,7 +2,9 @@
 //! For more information, see the documentation for the [`ObjectId`] type.
 
 use std::{
-    error, fmt, result,
+    error,
+    fmt,
+    result,
     str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
 };


### PR DESCRIPTION
- update edition
- removed deprecated function [`rand::thread_rng`](https://docs.rs/rand/0.9.0/rand/fn.thread_rng.html)