### PR TITLE
RUST-2174 feat(extjson): parse legacy `{"$date": <ms since epoch>}`

### DIFF
--- a/src/extjson/models.rs
+++ b/src/extjson/models.rs
@@ -256,6 +256,7 @@ pub(crate) struct DateTime {
 pub(crate) enum DateTimeBody {
     Canonical(Int64),
     Relaxed(String),
+    Legacy(i64),
 }
 
 impl DateTimeBody {
@@ -282,6 +283,7 @@ impl DateTime {
                 })?;
                 Ok(datetime)
             }
+            DateTimeBody::Legacy(ms) => Ok(crate::DateTime::from_millis(ms)),
         }
     }
 }

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -666,6 +666,19 @@ fn test_de_uuid_extjson_string() {
 }
 
 #[test]
+fn test_de_date_extjson_number() {
+    let _guard = LOCK.run_concurrently();
+
+    let ext_json_canonical = r#"{ "$date": { "$numberLong": "1136239445000" } }"#;
+    let expected_date_bson: Bson = serde_json::from_str(ext_json_canonical).unwrap();
+
+    let ext_json_legacy_java = r#"{ "$date": 1136239445000 }"#;
+    let actual_date_bson: Bson = serde_json::from_str(ext_json_legacy_java).unwrap();
+
+    assert_eq!(actual_date_bson, expected_date_bson);
+}
+
+#[test]
 fn test_de_oid_string() {
     let _guard = LOCK.run_concurrently();
 


### PR DESCRIPTION
According to the specification, there exists a legacy Extended JSON form of Datetime
https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md#datetime
> Mongoexport 2.4 and the Java driver always transform a Datetime object into an Extended JSON string of the form `{"$date": <ms since epoch>}`. This form has the problem of a potential loss of precision or range on the Datetimes that can be represented.

Specially, this legacy form is called `JsonMode.STRICT` in the Java `JsonWriterSettings`, while the canonical form is `JsonMode.EXTENDED`. The former is still used by the Debezium connector for MongoDB.

This PR adds the ability to parse such legacy format, without conflicting with the standard ones.