### PR TITLE
RUST-1375 Update bson crate MSRV policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,7 @@ This crate compiles to the `wasm32-unknown-unknown` target; when doing so, the `
 
 ## Minimum supported Rust version (MSRV)
 
-The MSRV for this crate is currently 1.71.1. This will be rarely be increased, and if it ever is,
-it will only happen in a minor or major version release.
+The MSRV for this crate is currently 1.71.1. Increases to the MSRV will only happen in a minor or major version release, and will be to a Rust version at least six months old.
 
 ## Contributing
 


### PR DESCRIPTION
RUST-1375

Updating to match the change in https://github.com/mongodb/mongo-rust-driver/commit/5b603f25432ccff914dcfd9a85cf9cf83562c1a5.