### PR TITLE
add `uncapped_max_size` feature to allow increasing max BSON size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ uuid-1 = []
 time-0_3 = []
 # If enabled, implement Hash/Eq for Bson and Document
 hashable = []
+# If enabled, the maximum document size will be increased from the MongoDB cap
+# of 16 MB to the BSON spec maximum size of 2^31 - 1
+uncapped_max_size = []
 serde_path_to_error = ["dep:serde_path_to_error"]
 # if enabled, include serde_with interop.
 # should be used in conjunction with chrono-0_4 or uuid-0_8.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 | `serde_with-3` | Enable [`serde_with`](https://docs.rs/serde_with/3.x) 3.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_path_to_error` | Enable support for error paths via integration with [`serde_path_to_error`](https://docs.rs/serde_path_to_err/latest).  This is an unstable feature and any breaking changes to `serde_path_to_error` may affect usage of it via this feature.  | serde_path_to_error  | no |
 | `hashable`   | Implement `core::hash::Hash` and `std::cmp::Eq` on `Bson` and `Document`.                  | n/a                | no      |
-| `uncapped_max_size` | Increase the maximum document size will be increased from the MongoDB cap of 16 MB to the BSON spec maximum size of 2^31 - 1 bytes. | n/a | no |
+| `uncapped_max_size` | Increase the maximum document size from the MongoDB cap of 16 MB to the BSON spec maximum size of 2^31 - 1 bytes. | n/a | no |
 
 ## Overview of the BSON Format
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 | `serde_with-3` | Enable [`serde_with`](https://docs.rs/serde_with/3.x) 3.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_path_to_error` | Enable support for error paths via integration with [`serde_path_to_error`](https://docs.rs/serde_path_to_err/latest).  This is an unstable feature and any breaking changes to `serde_path_to_error` may affect usage of it via this feature.  | serde_path_to_error  | no |
 | `hashable`   | Implement `core::hash::Hash` and `std::cmp::Eq` on `Bson` and `Document`.                  | n/a                | no      |
+| `uncapped_max_size` | Increase the maximum document size will be increased from the MongoDB cap of 16 MB to the BSON spec maximum size of 2^31 - 1 bytes. | n/a | no |
 
 ## Overview of the BSON Format
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -47,7 +47,10 @@ pub(crate) use self::serde::{convert_unsigned_to_signed_raw, BsonVisitor};
 
 pub(crate) use self::raw::Deserializer as RawDeserializer;
 
+#[cfg(not(feature = "uncapped_max_size"))]
 pub(crate) const MAX_BSON_SIZE: i32 = 16 * 1024 * 1024;
+#[cfg(feature = "uncapped_max_size")]
+pub(crate) const MAX_BSON_SIZE: i32 = i32::MAX;
 pub(crate) const MIN_BSON_DOCUMENT_SIZE: i32 = 4 + 1; // 4 bytes for length, one byte for null terminator
 pub(crate) const MIN_BSON_STRING_SIZE: i32 = 4 + 1; // 4 bytes for length, one byte for null terminator
 pub(crate) const MIN_CODE_WITH_SCOPE_SIZE: i32 = 4 + MIN_BSON_STRING_SIZE + MIN_BSON_DOCUMENT_SIZE;


### PR DESCRIPTION
For various projects I'm working on, I'm using BSON as an efficient means to transfer potentially quite a bit of data (~200Mb). From what I can read of the BSON standard, it's expected to support document sizes up to 2Gb, but this implementation is currently hard capped to 16Mb to better service MongoDB.

I figured adding an opt-in feature to increase the cap to the maximum would serve to be useful for more people than just me, without affecting the way that it's currently used within MongoDB applications.

I ran all the unit tests and linting tests and didn't encountered any failures with or without the added feature enabled.

Let me know if I'm off-base thinking that this is a useful addition, or if there are any unforseen issues with expanding the max size. I haven't done extensive reading of this library, so I may be missing something else that needs accounted for.

Thanks!