### PR TITLE
RUST-1380 Drop support for uuid 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,8 +142,7 @@ dependencies = [
  "serde_with 1.14.0",
  "serde_with 3.12.0",
  "time",
- "uuid 0.8.2",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1138,16 +1137,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.16",
- "serde",
-]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,6 @@ exclude = [
 default = []
 # if enabled, include API for interfacing with chrono 0.4
 chrono-0_4 = ["chrono"]
-# if enabled, include API for interfacing with uuid 0.8
-# This is commented out because Cargo implicitly adds this feature since
-# uuid-0_8 is also an optional dependency.
-# uuid-0_8 = []
 # if enabled, include API for interfacing with uuid 1.x
 uuid-1 = []
 # if enabled, include API for interfacing with time 0.3
@@ -69,7 +65,6 @@ indexmap = "2.1.0"
 hex = "0.4.2"
 base64 = "0.22.1"
 once_cell = "1.5.1"
-uuid-0_8 = { package = "uuid", version = "0.8.1", features = ["serde", "v4"], optional = true }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "1.3.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 | Feature      | Description                                                                                                 | Extra dependencies | Default |
 | :----------- | :---------------------------------------------------------------------------------------------------------- | :----------------- | :------ |
 | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](https://docs.rs/chrono/0.4) crate in the public API.              | n/a                | no      |
-| `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](https://docs.rs/uuid/0.8) crate in the public API.                  | n/a                | no      |
 | `uuid-1`     | Enable support for v1.x of the [`uuid`](https://docs.rs/uuid/1.0) crate in the public API.                  | n/a                | no      |
 | `time-0_3`   | Enable support for v0.3 of the [`time`](https://docs.rs/time/0.3) crate in the public API.                  | n/a                | no      |
 | `serde_with` | Enable [`serde_with`](https://docs.rs/serde_with/1.x) 1.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |

--- a/serde-tests/Cargo.lock
+++ b/serde-tests/Cargo.lock
@@ -88,8 +88,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "time 0.3.17",
- "uuid 0.8.2",
- "uuid 1.2.2",
+ "uuid",
 ]
 
 [[package]]
@@ -574,7 +573,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -723,16 +722,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.8",
- "serde",
-]
 
 [[package]]
 name = "uuid"

--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 default = []
 
 [dependencies]
-bson = { path = "..", features = ["uuid-0_8", "chrono-0_4", "serde_with"] }
+bson = { path = "..", features = ["uuid-1", "chrono-0_4", "serde_with"] }
 serde = { version = "1.0", features = ["derive"] }
 pretty_assertions = "0.6.1"
 hex = "0.4.2"
 serde_with = "1"
 chrono = "0.4"
-uuid = "0.8"
+uuid = "1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -414,14 +414,6 @@ impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for Bson {
     }
 }
 
-#[cfg(feature = "uuid-0_8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
-impl From<uuid_0_8::Uuid> for Bson {
-    fn from(uuid: uuid_0_8::Uuid) -> Self {
-        Bson::Binary(uuid.into())
-    }
-}
-
 #[cfg(feature = "uuid-1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-1")))]
 impl From<uuid::Uuid> for Bson {

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -83,30 +83,6 @@ pub use uuid_1_as_python_legacy_binary::{
     deserialize as deserialize_uuid_1_from_python_legacy_binary,
     serialize as serialize_uuid_1_as_python_legacy_binary,
 };
-#[cfg(feature = "uuid-0_8")]
-#[doc(inline)]
-pub use uuid_as_binary::{
-    deserialize as deserialize_uuid_from_binary,
-    serialize as serialize_uuid_as_binary,
-};
-#[cfg(feature = "uuid-0_8")]
-#[doc(inline)]
-pub use uuid_as_c_sharp_legacy_binary::{
-    deserialize as deserialize_uuid_from_c_sharp_legacy_binary,
-    serialize as serialize_uuid_as_c_sharp_legacy_binary,
-};
-#[cfg(feature = "uuid-0_8")]
-#[doc(inline)]
-pub use uuid_as_java_legacy_binary::{
-    deserialize as deserialize_uuid_from_java_legacy_binary,
-    serialize as serialize_uuid_as_java_legacy_binary,
-};
-#[cfg(feature = "uuid-0_8")]
-#[doc(inline)]
-pub use uuid_as_python_legacy_binary::{
-    deserialize as deserialize_uuid_from_python_legacy_binary,
-    serialize as serialize_uuid_as_python_legacy_binary,
-};
 
 /// Attempts to serialize a u32 as an i32. Errors if an exact conversion is not possible.
 pub fn serialize_u32_as_i32<S: Serializer>(val: &u32, serializer: S) -> Result<S::Ok, S::Error> {
@@ -527,29 +503,6 @@ macro_rules! as_binary_mod {
     };
 }
 
-/// Contains functions to serialize a [`uuid_0_8::Uuid`] as a [`crate::Binary`] and deserialize a
-/// [`uuid_0_8::Uuid`] from a [`crate::Binary`].
-///
-/// ```rust
-/// # #[cfg(feature = "uuid-0_8")]
-/// # {
-/// use serde::{Serialize, Deserialize};
-/// use uuid_0_8::Uuid;
-/// use bson::serde_helpers::uuid_as_binary;
-///
-/// #[derive(Serialize, Deserialize)]
-/// struct Item {
-///     #[serde(with = "uuid_as_binary")]
-///     pub id: Uuid,
-/// }
-/// # }
-/// ```
-#[cfg(feature = "uuid-0_8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
-pub mod uuid_as_binary {
-    as_binary_mod!(cfg(feature = "uuid-0_8"), uuid_0_8::Uuid);
-}
-
 /// Contains functions to serialize a [`uuid::Uuid`] as a [`crate::Binary`] and deserialize a
 /// [`uuid::Uuid`] from a [`crate::Binary`].
 ///
@@ -603,34 +556,6 @@ macro_rules! as_legacy_binary_mod {
     };
 }
 
-/// Contains functions to serialize a [`uuid_0_8::Uuid`] to a [`crate::Binary`] in the legacy
-/// Java driver UUID format and deserialize [`uuid_0_8::Uuid`] from a [`crate::Binary`] in the
-/// legacy Java driver format.
-///
-/// ```rust
-/// #[cfg(feature = "uuid-0_8")]
-/// # {
-/// use serde::{Serialize, Deserialize};
-/// use uuid_0_8::Uuid;
-/// use bson::serde_helpers::uuid_as_java_legacy_binary;
-///
-/// #[derive(Serialize, Deserialize)]
-/// struct Item {
-///     #[serde(with = "uuid_as_java_legacy_binary")]
-///     pub id: Uuid,
-/// }
-/// # }
-/// ```
-#[cfg(feature = "uuid-0_8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
-pub mod uuid_as_java_legacy_binary {
-    as_legacy_binary_mod!(
-        cfg(feature = "uuid-0_8"),
-        uuid_0_8::Uuid,
-        UuidRepresentation::JavaLegacy
-    );
-}
-
 /// Contains functions to serialize a [`uuid::Uuid`] to a [`crate::Binary`] in the legacy
 /// Java driver UUID format and deserialize [`uuid::Uuid`] from a [`crate::Binary`] in the legacy
 /// Java driver format.
@@ -659,34 +584,6 @@ pub mod uuid_1_as_java_legacy_binary {
     );
 }
 
-/// Contains functions to serialize a [`uuid_0_8::Uuid`] to a [`crate::Binary`] in the legacy Python
-/// driver UUID format and deserialize [`uuid_0_8::Uuid`] from a [`crate::Binary`] in the legacy
-/// Python driver format.
-///
-/// ```rust
-/// # #[cfg(feature = "uuid-0_8")]
-/// # {
-/// use serde::{Serialize, Deserialize};
-/// use uuid_0_8::Uuid;
-/// use bson::serde_helpers::uuid_as_python_legacy_binary;
-///
-/// #[derive(Serialize, Deserialize)]
-/// struct Item {
-///     #[serde(with = "uuid_as_python_legacy_binary")]
-///     pub id: Uuid,
-/// }
-/// # }
-/// ```
-#[cfg(feature = "uuid-0_8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
-pub mod uuid_as_python_legacy_binary {
-    as_legacy_binary_mod!(
-        cfg(feature = "uuid-0_8"),
-        uuid_0_8::Uuid,
-        UuidRepresentation::PythonLegacy
-    );
-}
-
 /// Contains functions to serialize a [`uuid::Uuid`] to a [`crate::Binary`] in the legacy Python
 /// driver UUID format and deserialize [`uuid::Uuid`] from a [`crate::Binary`] in the legacy Python
 /// driver format.
@@ -712,34 +609,6 @@ pub mod uuid_1_as_python_legacy_binary {
         cfg(feature = "uuid-1"),
         uuid::Uuid,
         UuidRepresentation::PythonLegacy
-    );
-}
-
-/// Contains functions to serialize a [`uuid_0_8::Uuid`] to a [`crate::Binary`] in the legacy C#
-/// driver UUID format and deserialize [`uuid_0_8::Uuid`] from a [`crate::Binary`] in the legacy C#
-/// driver format.
-///
-/// ```rust
-/// # #[cfg(feature = "uuid-0_8")]
-/// # {
-/// use serde::{Serialize, Deserialize};
-/// use uuid_0_8::Uuid;
-/// use bson::serde_helpers::uuid_as_c_sharp_legacy_binary;
-///
-/// #[derive(Serialize, Deserialize)]
-/// struct Item {
-///     #[serde(with = "uuid_as_c_sharp_legacy_binary")]
-///     pub id: Uuid,
-/// }
-/// # }
-/// ```
-#[cfg(feature = "uuid-0_8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
-pub mod uuid_as_c_sharp_legacy_binary {
-    as_legacy_binary_mod!(
-        cfg(feature = "uuid-0_8"),
-        uuid_0_8::Uuid,
-        UuidRepresentation::CSharpLegacy
     );
 }
 

--- a/src/uuid/mod.rs
+++ b/src/uuid/mod.rs
@@ -71,9 +71,6 @@
 //! # };
 //! ```
 //!
-//! For backwards compatibility, a `uuid-0_8` feature flag can be enabled, which provides the same
-//! API for interoperation with version 0.8 of the `uuid` crate.
-//!
 //! ## The `serde_with-3` feature flag
 //!
 //! The `serde_with-3` feature can be enabled to support more ergonomic serde attributes for
@@ -214,22 +211,6 @@ impl Default for Uuid {
     }
 }
 
-#[cfg(feature = "uuid-0_8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "uuid-0_8")))]
-impl Uuid {
-    /// Create a [`Uuid`] from a [`uuid::Uuid`](https://docs.rs/uuid/0.8/uuid/struct.Uuid.html) from
-    /// the [`uuid`](https://docs.rs/uuid/0.8) crate.
-    pub fn from_uuid_0_8(uuid: uuid_0_8::Uuid) -> Self {
-        Self::from_external_uuid(uuid::Uuid::from_u128(uuid.as_u128()))
-    }
-
-    /// Convert this [`Uuid`] to a [`uuid::Uuid`](https://docs.rs/uuid/0.8/uuid/struct.Uuid.html) from
-    /// the [`uuid`](https://docs.rs/uuid/0.8) crate.
-    pub fn to_uuid_0_8(self) -> uuid_0_8::Uuid {
-        uuid_0_8::Uuid::from_bytes(self.uuid.into_bytes())
-    }
-}
-
 #[cfg(feature = "uuid-1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid-1")))]
 impl Uuid {
@@ -309,20 +290,6 @@ impl From<Uuid> for Binary {
 impl From<Uuid> for Bson {
     fn from(u: Uuid) -> Self {
         Bson::Binary(u.into())
-    }
-}
-
-#[cfg(feature = "uuid-0_8")]
-impl From<uuid_0_8::Uuid> for Uuid {
-    fn from(u: uuid_0_8::Uuid) -> Self {
-        Self::from_uuid_0_8(u)
-    }
-}
-
-#[cfg(feature = "uuid-0_8")]
-impl From<Uuid> for uuid_0_8::Uuid {
-    fn from(s: Uuid) -> Self {
-        s.to_uuid_0_8()
     }
 }
 
@@ -535,7 +502,6 @@ macro_rules! trait_impls {
         }
     };
 }
-trait_impls!(feature = "uuid-0_8", uuid_0_8::Uuid);
 trait_impls!(feature = "uuid-1", uuid::Uuid);
 
 /// Errors that can occur during [`Uuid`] construction and generation.

--- a/src/uuid/test.rs
+++ b/src/uuid/test.rs
@@ -240,22 +240,6 @@ fn test_binary_to_uuid_python_legacy_rep() {
     );
 }
 
-#[cfg(feature = "uuid-0_8")]
-#[test]
-fn interop_0_8() {
-    let uuid = crate::Uuid::new();
-    let uuid_uuid = uuid.to_uuid_0_8();
-    assert_eq!(uuid.to_string(), uuid_uuid.to_string());
-    assert_eq!(&uuid.bytes(), uuid_uuid.as_bytes());
-
-    let back: crate::Uuid = uuid_uuid.into();
-    assert_eq!(back, uuid);
-
-    let d_bson = doc! { "uuid": uuid };
-    let d_uuid = doc! { "uuid": uuid_uuid };
-    assert_eq!(d_bson, d_uuid);
-}
-
 #[cfg(feature = "uuid-1")]
 #[test]
 fn interop_1() {


### PR DESCRIPTION
I left the remaining feature flag name as `uuid-1` in case we need to support `uuid-2` in the future.