### PR TITLE
RUST-2215 Ergonomics for HumanReadable

### DIFF
--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -806,7 +806,7 @@ where
 }
 
 // One could imagine passthrough Borrow impls; however, it turns out that can't be made to work
-// because of the exisitng base library impl of Borrow<T> for T will conflict despite that not
+// because of the existing base library impl of Borrow<T> for T will conflict despite that not
 // actually being possible to construct (https://github.com/rust-lang/rust/issues/50237).  So,
 // sadly, Borrow impls for HumanReadable are deliberately omitted :(
 


### PR DESCRIPTION
RUST-2215

This adds several traits to the `HumanReadable` wrapper type to make it easier to work with:
* The full set of `derive`-able traits in the standard library
* `repr(transparent)` (technically not a trait but close) so it doesn't cost extra memory
* a passthrough `Display`
* `From` for convenient/automatic conversions
* `Deref` and `DerefMut` for method passthroughs
* `AsRef` and `AsMut` for reference conversions (so `&HumanReadable<String>` can be easily converted to `&str` for example)