### PR TITLE
RUST-577 Bump dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    # Only bump to the latest version compatible with the dependency's version
+    # in Cargo.toml. This is the equivalent of running `cargo update`.
+    versioning-strategy: lockfile-only
+    # Update all dependencies in a single PR.
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    # Include transitive dependencies.
+    allow:
+      - dependency-type: all


### PR DESCRIPTION
Example PR: https://github.com/isabelatkinson/bson-rust/pull/1
Patch: https://spruce.mongodb.com/version/68375dc997e7750007ff0f95/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC