### PR TITLE
RUST-2169 Clean up and future-proof features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,8 +139,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_path_to_error",
- "serde_with 1.14.0",
- "serde_with 3.12.0",
+ "serde_with",
  "time",
  "uuid",
 ]
@@ -296,36 +295,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -338,19 +313,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -359,7 +323,7 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
+ "darling_core",
  "quote",
  "syn 2.0.101",
 ]
@@ -961,16 +925,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
@@ -983,20 +937,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.12.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1005,7 +947,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -1016,12 +958,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,18 @@ exclude = [
 ]
 
 [features]
-default = []
+default = ["compat-3-0-0"]
+compat-3-0-0 = []
 # if enabled, include API for interfacing with chrono 0.4
-chrono-0_4 = ["chrono"]
+chrono-0_4 = ["dep:chrono"]
 # if enabled, include API for interfacing with uuid 1.x
 uuid-1 = []
 # if enabled, include API for interfacing with time 0.3
 time-0_3 = []
-# If enabled, implement Hash/Eq for Bson and Document
-hashable = []
-# If enabled, the maximum document size will be increased from the MongoDB cap
-# of 16 MB to the BSON spec maximum size of 2^31 - 1
-uncapped_max_size = []
 serde_path_to_error = ["dep:serde_path_to_error"]
 # if enabled, include serde_with interop.
 # should be used in conjunction with chrono-0_4 or uuid-0_8.
-# it's commented out here because Cargo implicitly adds a feature flag for
-# all optional dependencies.
-# serde_with
+serde_with-3 = ["dep:serde_with-3"]
 
 [lib]
 name = "bson"
@@ -67,7 +61,6 @@ base64 = "0.22.1"
 once_cell = "1.5.1"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
-serde_with = { version = "1.3.1", optional = true }
 serde_with-3 = { package = "serde_with", version = "3.1.0", optional = true }
 time = { version = "0.3.9", features = ["formatting", "parsing", "macros", "large-dates"] }
 bitvec = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -50,11 +50,9 @@ Note that if you are using `bson` through the `mongodb` crate, you do not need t
 | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](https://docs.rs/chrono/0.4) crate in the public API.              | n/a                | no      |
 | `uuid-1`     | Enable support for v1.x of the [`uuid`](https://docs.rs/uuid/1.0) crate in the public API.                  | n/a                | no      |
 | `time-0_3`   | Enable support for v0.3 of the [`time`](https://docs.rs/time/0.3) crate in the public API.                  | n/a                | no      |
-| `serde_with` | Enable [`serde_with`](https://docs.rs/serde_with/1.x) 1.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_with-3` | Enable [`serde_with`](https://docs.rs/serde_with/3.x) 3.x integrations for `bson::DateTime` and `bson::Uuid`.| serde_with         | no      |
 | `serde_path_to_error` | Enable support for error paths via integration with [`serde_path_to_error`](https://docs.rs/serde_path_to_err/latest).  This is an unstable feature and any breaking changes to `serde_path_to_error` may affect usage of it via this feature.  | serde_path_to_error  | no |
-| `hashable`   | Implement `core::hash::Hash` and `std::cmp::Eq` on `Bson` and `Document`.                  | n/a                | no      |
-| `uncapped_max_size` | Increase the maximum document size from the MongoDB cap of 16 MB to the BSON spec maximum size of 2^31 - 1 bytes. | n/a | no |
+| `compat-3-0-0` | Required for future compatibility if default features are disabled. | no |
 
 ## Overview of the BSON Format
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -90,7 +90,6 @@ pub enum Bson {
 /// Alias for `Vec<Bson>`.
 pub type Array = Vec<Bson>;
 
-#[cfg(feature = "hashable")]
 impl Hash for Bson {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
@@ -125,7 +124,6 @@ impl Hash for Bson {
     }
 }
 
-#[cfg(feature = "hashable")]
 impl Eq for Bson {}
 
 impl Display for Bson {
@@ -1154,8 +1152,7 @@ impl Display for Regex {
 }
 
 /// Represents a BSON code with scope value.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "hashable", derive(Eq, Hash))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct JavaScriptCodeWithScope {
     /// The JavaScript code.
     pub code: String,

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -16,15 +16,10 @@ use time::format_description::well_known::Rfc3339;
 #[cfg(feature = "chrono-0_4")]
 use chrono::{LocalResult, TimeZone, Utc};
 #[cfg(all(
-    any(feature = "serde_with", feature = "serde_with-3"),
+    feature = "serde_with-3",
     any(feature = "chrono-0_4", feature = "time-0_3")
 ))]
 use serde::{Deserialize, Deserializer, Serialize};
-#[cfg(all(
-    feature = "serde_with",
-    any(feature = "chrono-0_4", feature = "time-0_3")
-))]
-use serde_with::{DeserializeAs, SerializeAs};
 
 /// Struct representing a BSON datetime.
 /// Note: BSON datetimes have millisecond precision.
@@ -479,33 +474,6 @@ impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for crate::DateTime {
     }
 }
 
-#[cfg(all(feature = "chrono-0_4", feature = "serde_with"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "chrono-0_4", feature = "serde_with"))))]
-impl<'de> DeserializeAs<'de, chrono::DateTime<Utc>> for crate::DateTime {
-    fn deserialize_as<D>(deserializer: D) -> std::result::Result<chrono::DateTime<Utc>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let dt = DateTime::deserialize(deserializer)?;
-        Ok(dt.to_chrono())
-    }
-}
-
-#[cfg(all(feature = "chrono-0_4", feature = "serde_with"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "chrono-0_4", feature = "chrono-0_4"))))]
-impl SerializeAs<chrono::DateTime<Utc>> for crate::DateTime {
-    fn serialize_as<S>(
-        source: &chrono::DateTime<Utc>,
-        serializer: S,
-    ) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let dt = DateTime::from_chrono(*source);
-        dt.serialize(serializer)
-    }
-}
-
 #[cfg(all(feature = "chrono-0_4", feature = "serde_with-3"))]
 #[cfg_attr(
     docsrs,
@@ -549,33 +517,6 @@ impl From<crate::DateTime> for time::OffsetDateTime {
 impl From<time::OffsetDateTime> for crate::DateTime {
     fn from(x: time::OffsetDateTime) -> Self {
         Self::from_time_0_3(x)
-    }
-}
-
-#[cfg(all(feature = "time-0_3", feature = "serde_with"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "time-0_3", feature = "serde_with"))))]
-impl<'de> DeserializeAs<'de, time::OffsetDateTime> for crate::DateTime {
-    fn deserialize_as<D>(deserializer: D) -> std::result::Result<time::OffsetDateTime, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let dt = DateTime::deserialize(deserializer)?;
-        Ok(dt.to_time_0_3())
-    }
-}
-
-#[cfg(all(feature = "time-0_3", feature = "serde_with"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "time-0_3", feature = "chrono-0_4"))))]
-impl SerializeAs<time::OffsetDateTime> for crate::DateTime {
-    fn serialize_as<S>(
-        source: &time::OffsetDateTime,
-        serializer: S,
-    ) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let dt = DateTime::from_time_0_3(*source);
-        dt.serialize(serializer)
     }
 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -48,9 +48,6 @@ pub(crate) use self::serde::{convert_unsigned_to_signed_raw, BsonVisitor};
 
 pub(crate) use self::raw::Deserializer as RawDeserializer;
 
-#[cfg(not(feature = "uncapped_max_size"))]
-pub(crate) const MAX_BSON_SIZE: i32 = 16 * 1024 * 1024;
-#[cfg(feature = "uncapped_max_size")]
 pub(crate) const MAX_BSON_SIZE: i32 = i32::MAX;
 pub(crate) const MIN_BSON_DOCUMENT_SIZE: i32 = 4 + 1; // 4 bytes for length, one byte for null terminator
 pub(crate) const MIN_BSON_STRING_SIZE: i32 = 4 + 1; // 4 bytes for length, one byte for null terminator

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,10 +1,9 @@
 //! A BSON document represented as an associative HashMap with insertion ordering.
 
-#[cfg(feature = "hashable")]
-use std::hash::Hash;
 use std::{
     error,
     fmt::{self, Debug, Display, Formatter},
+    hash::Hash,
     io::{Read, Write},
     iter::{Extend, FromIterator, IntoIterator},
     ops::Index,
@@ -58,8 +57,7 @@ impl Display for ValueAccessError {
 impl error::Error for ValueAccessError {}
 
 /// A BSON document represented as an associative HashMap with insertion ordering.
-#[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "hashable", derive(Eq))]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Document {
     inner: IndexMap<String, Bson, RandomState>,
 }
@@ -70,7 +68,6 @@ impl Default for Document {
     }
 }
 
-#[cfg(feature = "hashable")]
 impl Hash for Document {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let mut entries = Vec::from_iter(&self.inner);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,12 +62,11 @@
 //! | Feature      | Description                                                                                          | Default |
 //! |:-------------|:-----------------------------------------------------------------------------------------------------|:--------|
 //! | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](https://docs.rs/chrono/0.4) crate in the public API.       | no      |
-//! | `uuid-0_8`   | Enable support for v0.8 of the [`uuid`](https://docs.rs/uuid/0.8) crate in the public API.           | no      |
 //! | `uuid-1`     | Enable support for v1.x of the [`uuid`](https://docs.rs/uuid/1.x) crate in the public API.           | no      |
 //! | `time-0_3`   | Enable support for v0.3 of the [`time`](https://docs.rs/time/0.3) crate in the public API.           | no      |
-//! | `serde_with` | Enable [`serde_with`](https://docs.rs/serde_with/1.x) 1.x integrations for [`DateTime`] and [`Uuid`]. | no      |
 //! | `serde_with-3` | Enable [`serde_with`](https://docs.rs/serde_with/3.x) 3.x integrations for [`DateTime`] and [`Uuid`]. | no      |
 //! | `serde_path_to_error` | Enable support for error paths via integration with [`serde_path_to_error`](https://docs.rs/serde_path_to_err/latest).  This is an unstable feature and any breaking changes to `serde_path_to_error` may affect usage of it via this feature. | no |
+//! | `compat-3-0-0` | Required for future compatibility if default features are disabled. | no |
 //!
 //! ## BSON values
 //!
@@ -330,3 +329,9 @@ pub mod uuid;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(not(feature = "compat-3-0-0"))]
+compile_error!(
+    "The feature 'compat-3-0-0' must be enabled to ensure forward compatibility with future \
+     versions of this crate."
+);

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -488,7 +488,6 @@ fn debug_print() {
     assert_eq!(format!("{:#?}", doc), pretty_print);
 }
 
-#[cfg(feature = "hashable")]
 #[test]
 fn test_hashable() {
     let mut map = std::collections::HashMap::new();

--- a/src/uuid/mod.rs
+++ b/src/uuid/mod.rs
@@ -453,30 +453,6 @@ macro_rules! trait_impls {
             }
         }
 
-        #[cfg(all($feat, feature = "serde_with"))]
-        #[cfg_attr(docsrs, doc(cfg(all($feat, feature = "serde_with"))))]
-        impl<'de> serde_with::DeserializeAs<'de, $u> for crate::Uuid {
-            fn deserialize_as<D>(deserializer: D) -> std::result::Result<$u, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                let uuid = Uuid::deserialize(deserializer)?;
-                Ok(uuid.into())
-            }
-        }
-
-        #[cfg(all($feat, feature = "serde_with"))]
-        #[cfg_attr(docsrs, doc(cfg(all($feat, feature = "serde_with"))))]
-        impl serde_with::SerializeAs<$u> for crate::Uuid {
-            fn serialize_as<S>(source: &$u, serializer: S) -> std::result::Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
-                let uuid = Uuid::from(*source);
-                uuid.serialize(serializer)
-            }
-        }
-
         #[cfg(all($feat, feature = "serde_with-3"))]
         #[cfg_attr(docsrs, doc(cfg(all($feat, feature = "serde_with-3"))))]
         impl<'de> serde_with_3::DeserializeAs<'de, $u> for crate::Uuid {


### PR DESCRIPTION
RUST-2169

This PR:
* Adds `compat-3-0-0` and associated compile-time error if it's missing.
* Drops support for `serde_with` 1.x in favor of 3.x.
* Makes `hashable` and `uncapped_max_size` baseline since there's no downside.