### PR TITLE
RUST-2213 Properly handle NaNs in fuzz testing

### DIFF
--- a/fuzz/fuzz_targets/serialization.rs
+++ b/fuzz/fuzz_targets/serialization.rs
@@ -11,25 +11,37 @@ fn compare_docs(doc1: &Document, doc2: &Document) -> bool {
         return false;
     }
     for (key, value) in doc1 {
-        if !doc2.contains_key(key) {
-            return false;
-        }
         if let Some(val2) = doc2.get(key) {
-            match (value, val2) {
-                (Bson::Double(d1), Bson::Double(d2)) => {
-                    if (!d1.is_nan() || !d2.is_nan()) && d1 != d2 {
-                        return false;
-                    }
-                }
-                (v1, v2) => {
-                    if v1 != v2 {
-                        return false;
-                    }
-                }
+            if !compare_values(value, val2) {
+                return false;
             }
+        } else {
+            return false;
         }
     }
     true
+}
+
+fn compare_values(val1: &Bson, val2: &Bson) -> bool {
+    match (val1, val2) {
+        (Bson::Double(d1), Bson::Double(d2)) => (d1.is_nan() && d2.is_nan()) || d1 == d2,
+        (Bson::Document(doc1), Bson::Document(doc2)) => compare_docs(doc1, doc2),
+        (Bson::Array(arr1), Bson::Array(arr2)) => {
+            if arr1.len() != arr2.len() {
+                return false;
+            }
+            for (subval1, subval2) in std::iter::zip(arr1, arr2) {
+                if !compare_values(subval1, subval2) {
+                    return false;
+                }
+            }
+            true
+        }
+        (Bson::JavaScriptCodeWithScope(jsc1), Bson::JavaScriptCodeWithScope(jsc2)) => {
+            jsc1.code == jsc2.code && compare_docs(&jsc1.scope, &jsc2.scope)
+        }
+        (v1, v2) => v1 == v2,
+    }
 }
 
 fuzz_target!(|input: &[u8]| {


### PR DESCRIPTION
RUST-2213

There was already code to consider `NaN`s equal as values in `Document`s but it wasn't recursing into `Array`s; all of the fuzzer failures we've seen recently have actually been some flavor of `Array([NaN,...])`.  I also added a case for `JavaScriptCodeWithScope` because that could hypothetically have the same failure, although I don't think we've actually seen it.