### PR TITLE
RUST-1406 Add crate-wide error types, convert value access errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_with",
  "simdutf8",
+ "thiserror",
  "time",
  "uuid",
 ]
@@ -1020,6 +1021,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ uuid = { version = "1.1.2", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "3.1.0", optional = true }
 time = { version = "0.3.9", features = ["formatting", "parsing", "macros"] }
+thiserror = "2"
 bitvec = "1.0.1"
 serde_path_to_error = { version = "0.1.16", optional = true }
 simdutf8 = "0.1.5"

--- a/serde-tests/Cargo.lock
+++ b/serde-tests/Cargo.lock
@@ -87,6 +87,8 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_with",
+ "simdutf8",
+ "thiserror",
  "time 0.3.17",
  "uuid",
 ]
@@ -642,6 +644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +690,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/src/document.rs
+++ b/src/document.rs
@@ -248,328 +248,378 @@ impl Document {
     /// Returns the value for the given key if one is present and is of type
     /// [`ElementType::Double`].
     pub fn get_f64(&self, key: impl AsRef<str>) -> Result<f64> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::Double(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Double,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Double`].
     pub fn get_f64_mut(&mut self, key: impl AsRef<str>) -> Result<&mut f64> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Double(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Double,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a reference to the value for the given key if one is present and is of type
     /// [`ElementType::Decimal128`].
     pub fn get_decimal128(&self, key: impl AsRef<str>) -> Result<&Decimal128> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(Bson::Decimal128(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Decimal128,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Decimal128`].
     pub fn get_decimal128_mut(&mut self, key: impl AsRef<str>) -> Result<&mut Decimal128> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Decimal128(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Decimal128,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a reference to the value for the given key if one is present and is of type
     /// [`ElementType::String`].
     pub fn get_str(&self, key: impl AsRef<str>) -> Result<&str> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(Bson::String(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::String,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::String`].
     pub fn get_str_mut(&mut self, key: impl AsRef<str>) -> Result<&mut str> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::String(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::String,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a reference to the value for the given key if one is present and is of type
     /// [`ElementType::Array`].
     pub fn get_array(&self, key: impl AsRef<str>) -> Result<&Array> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(Bson::Array(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Array,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Array`].
     pub fn get_array_mut(&mut self, key: impl AsRef<str>) -> Result<&mut Array> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Array(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Array,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a reference to the value for the given key if one is present and is of type
     /// [`ElementType::EmbeddedDocument`].
     pub fn get_document(&self, key: impl AsRef<str>) -> Result<&Document> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(Bson::Document(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::EmbeddedDocument,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::EmbeddedDocument`].
     pub fn get_document_mut(&mut self, key: impl AsRef<str>) -> Result<&mut Document> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Document(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::EmbeddedDocument,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a reference to the value for the given key if one is present and is of type
     /// [`ElementType::Boolean`].
     pub fn get_bool(&self, key: impl AsRef<str>) -> Result<bool> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::Boolean(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Boolean,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Boolean`].
     pub fn get_bool_mut(&mut self, key: impl AsRef<str>) -> Result<&mut bool> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Boolean(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Boolean,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns the unit type if the given key corresponds to a [`Bson::Null`] value.
     pub fn get_null(&self, key: impl AsRef<str>) -> Result<()> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::Null) => Ok(()),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Null,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns the value for the given key if one is present and is of type [`ElementType::Int32`].
     pub fn get_i32(&self, key: impl AsRef<str>) -> Result<i32> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::Int32(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Int32,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Int32`].
     pub fn get_i32_mut(&mut self, key: impl AsRef<str>) -> Result<&mut i32> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Int32(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Int32,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns the value for the given key if one is present and is of type [`ElementType::Int64`].
     pub fn get_i64(&self, key: impl AsRef<str>) -> Result<i64> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::Int64(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Int64,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Int64`].
     pub fn get_i64_mut(&mut self, key: impl AsRef<str>) -> Result<&mut i64> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Int64(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Int64,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns the value for the given key if one is present and is of type
     /// [`ElementType::Timestamp`].
     pub fn get_timestamp(&self, key: impl AsRef<str>) -> Result<Timestamp> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::Timestamp(timestamp)) => Ok(timestamp),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Timestamp,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Timestamp`].
     pub fn get_timestamp_mut(&mut self, key: impl AsRef<str>) -> Result<&mut Timestamp> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Timestamp(ref mut timestamp)) => Ok(timestamp),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Timestamp,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a reference to the value for the given key if one is present and is of type
     /// [`ElementType::Binary`] with binary subtype [`BinarySubtype::Generic`].
     pub fn get_binary_generic(&self, key: impl AsRef<str>) -> Result<&Vec<u8>> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::Binary(Binary {
                 subtype: BinarySubtype::Generic,
                 ref bytes,
             })) => Ok(bytes),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Binary,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::Binary`] with binary subtype [`BinarySubtype::Generic`].
     pub fn get_binary_generic_mut(&mut self, key: impl AsRef<str>) -> Result<&mut Vec<u8>> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::Binary(Binary {
                 subtype: BinarySubtype::Generic,
                 ref mut bytes,
             })) => Ok(bytes),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::Binary,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns the value for the given key if one is present and is of type
     /// [`ElementType::ObjectId`].
     pub fn get_object_id(&self, key: impl AsRef<str>) -> Result<ObjectId> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(&Bson::ObjectId(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::ObjectId,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::ObjectId`].
     pub fn get_object_id_mut(&mut self, key: impl AsRef<str>) -> Result<&mut ObjectId> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::ObjectId(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::ObjectId,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a reference to the value for the given key if one is present and is of type
     /// [`ElementType::DateTime`].
     pub fn get_datetime(&self, key: impl AsRef<str>) -> Result<&crate::DateTime> {
+        let key = key.as_ref();
         match self.get(key) {
             Some(Bson::DateTime(v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::DateTime,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 
     /// Returns a mutable reference to the value for the given key if one is present and is of type
     /// [`ElementType::DateTime`].
     pub fn get_datetime_mut(&mut self, key: impl AsRef<str>) -> Result<&mut crate::DateTime> {
+        let key = key.as_ref();
         match self.get_mut(key) {
             Some(&mut Bson::DateTime(ref mut v)) => Ok(v),
             Some(bson) => Err(Error::value_access_unexpected_type(
+                key,
                 bson.element_type(),
                 ElementType::DateTime,
             )),
-            None => Err(Error::value_access_not_present()),
+            None => Err(Error::value_access_not_present(key)),
         }
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -425,11 +425,11 @@ impl Document {
         }
     }
 
-    /// Returns the unit type if the given key corresponds to a [`Bson::Null`] value.
-    pub fn get_null(&self, key: impl AsRef<str>) -> Result<()> {
+    /// Returns [`Bson::Null`] if the given key corresponds to a [`Bson::Null`] value.
+    pub fn get_null(&self, key: impl AsRef<str>) -> Result<Bson> {
         let key = key.as_ref();
         match self.get(key) {
-            Some(&Bson::Null) => Ok(()),
+            Some(&Bson::Null) => Ok(Bson::Null),
             Some(bson) => Err(Error::value_access_unexpected_type(
                 key,
                 bson.element_type(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,83 @@
+use thiserror::Error;
+
+use crate::spec::ElementType;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// An error that can occur in the `bson` crate.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+#[error("Kind: {kind}")]
+pub struct Error {
+    /// The kind of error that occurred.
+    pub kind: ErrorKind,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum ErrorKind {
+    #[error("An error occurred when attempting to access a document value: {kind}")]
+    #[non_exhaustive]
+    ValueAccess { kind: ValueAccessErrorKind },
+}
+
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum ValueAccessErrorKind {
+    /// No value for the specified key was present in the document.
+    #[error("The key was not present in the document")]
+    NotPresent,
+
+    /// The type of the value in the document did not match the requested type.
+    #[error("Expected type {expected:?}, got type {actual:?}")]
+    #[non_exhaustive]
+    UnexpectedType {
+        /// The actual type of the value.
+        actual: ElementType,
+
+        /// The expected type of the value.
+        expected: ElementType,
+    },
+
+    /// An error occurred when attempting to parse the document's BSON bytes.
+    #[error("{message}")]
+    InvalidBson { message: String },
+}
+
+impl Error {
+    pub(crate) fn value_access_not_present() -> Self {
+        Self {
+            kind: ErrorKind::ValueAccess {
+                kind: ValueAccessErrorKind::NotPresent,
+            },
+        }
+    }
+
+    pub(crate) fn value_access_unexpected_type(actual: ElementType, expected: ElementType) -> Self {
+        Self {
+            kind: ErrorKind::ValueAccess {
+                kind: ValueAccessErrorKind::UnexpectedType { actual, expected },
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_value_access_not_present(&self) -> bool {
+        matches!(
+            self.kind,
+            ErrorKind::ValueAccess {
+                kind: ValueAccessErrorKind::NotPresent,
+            }
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_value_access_unexpected_type(&self) -> bool {
+        matches!(
+            self.kind,
+            ErrorKind::ValueAccess {
+                kind: ValueAccessErrorKind::UnexpectedType { .. },
+            }
+        )
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,27 +5,33 @@ use crate::spec::ElementType;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// An error that can occur in the `bson` crate.
-#[non_exhaustive]
 #[derive(Debug, Error)]
 #[error("Kind: {kind}")]
+#[non_exhaustive]
 pub struct Error {
     /// The kind of error that occurred.
     pub kind: ErrorKind,
 }
 
-#[non_exhaustive]
+/// The types of errors that can occur in the `bson` crate.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ErrorKind {
+    /// An error occurred when attempting to access a value in a document.
     #[error("An error occurred when attempting to access a document value for key {key}: {kind}")]
     #[non_exhaustive]
     ValueAccess {
+        /// The key of the value.
         key: String,
+
+        /// The kind of error that occurred.
         kind: ValueAccessErrorKind,
     },
 }
 
-#[non_exhaustive]
+/// The types of errors that can occur when attempting to access a value in a document.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ValueAccessErrorKind {
     /// No value for the specified key was present in the document.
     #[error("The key was not present in the document")]
@@ -44,6 +50,7 @@ pub enum ValueAccessErrorKind {
 
     /// An error occurred when attempting to parse the document's BSON bytes.
     #[error("{message}")]
+    #[non_exhaustive]
     InvalidBson { message: String },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,7 @@ pub mod datetime;
 pub mod de;
 pub mod decimal128;
 pub mod document;
+pub mod error;
 pub mod extjson;
 pub mod oid;
 pub mod raw;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -141,7 +141,7 @@ pub use self::{
     },
     document::RawDocument,
     document_buf::{BindRawBsonRef, RawDocumentBuf},
-    error::{Error, ErrorKind, Result, ValueAccessError, ValueAccessErrorKind, ValueAccessResult},
+    error::{Error, ErrorKind, Result},
     iter::{RawElement, RawIter},
 };
 

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -237,8 +237,8 @@ impl RawDocument {
     /// };
     ///
     /// assert_eq!(doc.get_f64("f64")?, 2.5);
-    /// assert!(matches!(doc.get_f64("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_f64("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_f64("bool").is_err());
+    /// assert!(doc.get_f64("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_f64(&self, key: impl AsRef<str>) -> Result<f64> {
@@ -257,8 +257,8 @@ impl RawDocument {
     /// };
     ///
     /// assert_eq!(doc.get_str("string")?, "hello");
-    /// assert!(matches!(doc.get_str("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_str("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_str("bool").is_err());
+    /// assert!(doc.get_str("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_str(&self, key: impl AsRef<str>) -> Result<&'_ str> {
@@ -278,8 +278,8 @@ impl RawDocument {
     /// };
     ///
     /// assert_eq!(doc.get_document("doc")?.get_str("key")?, "value");
-    /// assert!(matches!(doc.get_document("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_document("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_document("bool").is_err());
+    /// assert!(doc.get_document("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_document(&self, key: impl AsRef<str>) -> Result<&'_ RawDocument> {
@@ -290,7 +290,7 @@ impl RawDocument {
     /// the key corresponds to a value which isn't an array.
     ///
     /// ```
-    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
+    /// use bson::{rawdoc, error::{ErrorKind, ValueAccessErrorKind}};
     ///
     /// let doc = rawdoc! {
     ///     "array": [true, 3],
@@ -303,7 +303,7 @@ impl RawDocument {
     ///
     /// assert!(arr_iter.next().is_none());
     /// assert!(doc.get_array("bool").is_err());
-    /// assert!(matches!(doc.get_array("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_array("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_array(&self, key: impl AsRef<str>) -> Result<&'_ RawArray> {
@@ -327,8 +327,8 @@ impl RawDocument {
     /// };
     ///
     /// assert_eq!(&doc.get_binary("binary")?.bytes, &[1, 2, 3]);
-    /// assert!(matches!(doc.get_binary("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_binary("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_binary("bool").is_err());
+    /// assert!(doc.get_binary("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_binary(&self, key: impl AsRef<str>) -> Result<RawBinaryRef<'_>> {
@@ -348,8 +348,8 @@ impl RawDocument {
     /// };
     ///
     /// let oid = doc.get_object_id("_id")?;
-    /// assert!(matches!(doc.get_object_id("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_object_id("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_object_id("bool").is_err());
+    /// assert!(doc.get_object_id("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_object_id(&self, key: impl AsRef<str>) -> Result<ObjectId> {
@@ -369,8 +369,8 @@ impl RawDocument {
     /// };
     ///
     /// assert!(doc.get_bool("bool")?);
-    /// assert!(matches!(doc.get_bool("_id").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_bool("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_bool("_id").is_err());
+    /// assert!(doc.get_bool("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_bool(&self, key: impl AsRef<str>) -> Result<bool> {
@@ -391,8 +391,8 @@ impl RawDocument {
     /// };
     ///
     /// assert_eq!(doc.get_datetime("created_at")?, dt);
-    /// assert!(matches!(doc.get_datetime("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_datetime("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_datetime("bool").is_err());
+    /// assert!(doc.get_datetime("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_datetime(&self, key: impl AsRef<str>) -> Result<DateTime> {
@@ -415,8 +415,8 @@ impl RawDocument {
     ///
     /// assert_eq!(doc.get_regex("regex")?.pattern, r"end\s*$");
     /// assert_eq!(doc.get_regex("regex")?.options, "i");
-    /// assert!(matches!(doc.get_regex("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_regex("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_regex("bool").is_err());
+    /// assert!(doc.get_regex("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_regex(&self, key: impl AsRef<str>) -> Result<RawRegexRef<'_>> {
@@ -439,8 +439,8 @@ impl RawDocument {
     ///
     /// assert_eq!(timestamp.time, 649876543);
     /// assert_eq!(timestamp.increment, 9);
-    /// assert!(matches!(doc.get_timestamp("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_timestamp("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_timestamp("bool").is_err());
+    /// assert!(doc.get_timestamp("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_timestamp(&self, key: impl AsRef<str>) -> Result<Timestamp> {
@@ -460,8 +460,8 @@ impl RawDocument {
     /// };
     ///
     /// assert_eq!(doc.get_i32("i32")?, 1_000_000);
-    /// assert!(matches!(doc.get_i32("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { ..}));
-    /// assert!(matches!(doc.get_i32("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_i32("bool").is_err());
+    /// assert!(doc.get_i32("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_i32(&self, key: impl AsRef<str>) -> Result<i32> {
@@ -481,8 +481,8 @@ impl RawDocument {
     /// };
     ///
     /// assert_eq!(doc.get_i64("i64")?, 9223372036854775807);
-    /// assert!(matches!(doc.get_i64("bool").unwrap_err().kind, ValueAccessErrorKind::UnexpectedType { .. }));
-    /// assert!(matches!(doc.get_i64("unknown").unwrap_err().kind, ValueAccessErrorKind::NotPresent));
+    /// assert!(doc.get_i64("bool").is_err());
+    /// assert!(doc.get_i64("unknown").is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_i64(&self, key: impl AsRef<str>) -> Result<i64> {

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -228,7 +228,6 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::raw::ValueAccessErrorKind;
     /// use bson::rawdoc;
     ///
     /// let doc = rawdoc! {
@@ -249,7 +248,7 @@ impl RawDocument {
     /// key corresponds to a value which isn't a string.
     ///
     /// ```
-    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
+    /// use bson::rawdoc;
     ///
     /// let doc = rawdoc! {
     ///     "string": "hello",
@@ -270,7 +269,7 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
+    /// use bson::rawdoc;
     ///
     /// let doc = rawdoc! {
     ///     "doc": { "key": "value"},
@@ -290,7 +289,7 @@ impl RawDocument {
     /// the key corresponds to a value which isn't an array.
     ///
     /// ```
-    /// use bson::{rawdoc, error::{ErrorKind, ValueAccessErrorKind}};
+    /// use bson::rawdoc;
     ///
     /// let doc = rawdoc! {
     ///     "array": [true, 3],
@@ -316,7 +315,6 @@ impl RawDocument {
     /// ```
     /// use bson::{
     ///     rawdoc,
-    ///     raw::ValueAccessErrorKind,
     ///     spec::BinarySubtype,
     ///     Binary,
     /// };
@@ -340,7 +338,7 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{rawdoc, oid::ObjectId, raw::ValueAccessErrorKind};
+    /// use bson::{rawdoc, oid::ObjectId};
     ///
     /// let doc = rawdoc! {
     ///     "_id": ObjectId::new(),
@@ -361,7 +359,7 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{rawdoc, oid::ObjectId, raw::ValueAccessErrorKind};
+    /// use bson::{rawdoc, oid::ObjectId};
     ///
     /// let doc = rawdoc! {
     ///     "_id": ObjectId::new(),
@@ -382,7 +380,7 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{rawdoc, raw::ValueAccessErrorKind, DateTime};
+    /// use bson::{rawdoc, DateTime};
     ///
     /// let dt = DateTime::now();
     /// let doc = rawdoc! {
@@ -403,7 +401,7 @@ impl RawDocument {
     /// the key corresponds to a value which isn't a regex.
     ///
     /// ```
-    /// use bson::{rawdoc, Regex, raw::ValueAccessErrorKind};
+    /// use bson::{rawdoc, Regex};
     ///
     /// let doc = rawdoc! {
     ///     "regex": Regex {
@@ -428,7 +426,7 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{rawdoc, Timestamp, raw::ValueAccessErrorKind};
+    /// use bson::{rawdoc, Timestamp};
     ///
     /// let doc = rawdoc! {
     ///     "bool": true,
@@ -452,7 +450,7 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
+    /// use bson::rawdoc;
     ///
     /// let doc = rawdoc! {
     ///     "bool": true,
@@ -473,7 +471,7 @@ impl RawDocument {
     ///
     /// ```
     /// # use bson::raw::Error;
-    /// use bson::{rawdoc, raw::ValueAccessErrorKind};
+    /// use bson::rawdoc;
     ///
     /// let doc = rawdoc! {
     ///     "bool": true,

--- a/src/raw/error.rs
+++ b/src/raw/error.rs
@@ -1,5 +1,3 @@
-use crate::spec::ElementType;
-
 /// An error that occurs when attempting to parse raw BSON bytes.
 #[derive(Debug, PartialEq, Clone)]
 #[non_exhaustive]
@@ -72,65 +70,3 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub(crate) fn try_with_key<G, F: FnOnce() -> Result<G>>(key: impl Into<String>, f: F) -> Result<G> {
     f().map_err(|e| e.with_key(key))
 }
-
-pub type ValueAccessResult<T> = std::result::Result<T, ValueAccessError>;
-
-/// Error to indicate that either a value was empty or it contained an unexpected
-/// type, for use with the direct getters (e.g. [`crate::RawDocument::get_str`]).
-#[derive(Debug, PartialEq, Clone)]
-#[non_exhaustive]
-pub struct ValueAccessError {
-    /// The type of error that was encountered.
-    pub kind: ValueAccessErrorKind,
-
-    /// The key at which the error was encountered.
-    pub(crate) key: String,
-}
-
-impl ValueAccessError {
-    /// The key at which the error was encountered.
-    pub fn key(&self) -> &str {
-        self.key.as_str()
-    }
-}
-
-/// The type of error encountered when using a direct getter (e.g. [`crate::RawDocument::get_str`]).
-#[derive(Debug, PartialEq, Clone)]
-#[non_exhaustive]
-pub enum ValueAccessErrorKind {
-    /// Cannot find the expected field with the specified key
-    NotPresent,
-
-    /// Found a Bson value with the specified key, but not with the expected type
-    #[non_exhaustive]
-    UnexpectedType {
-        /// The type that was expected.
-        expected: ElementType,
-
-        /// The actual type that was encountered.
-        actual: ElementType,
-    },
-
-    /// An error was encountered attempting to decode the document.
-    InvalidBson(super::Error),
-}
-
-impl std::fmt::Display for ValueAccessError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let prefix = format!("error at key: \"{}\": ", self.key);
-
-        match &self.kind {
-            ValueAccessErrorKind::UnexpectedType { actual, expected } => write!(
-                f,
-                "{} unexpected element type: {:?}, expected: {:?}",
-                prefix, actual, expected
-            ),
-            ValueAccessErrorKind::InvalidBson(error) => {
-                write!(f, "{}: {}", prefix, error)
-            }
-            ValueAccessErrorKind::NotPresent => write!(f, "{}value not present", prefix),
-        }
-    }
-}
-
-impl std::error::Error for ValueAccessError {}

--- a/src/raw/test.rs
+++ b/src/raw/test.rs
@@ -5,7 +5,6 @@ use super::*;
 use crate::{
     doc,
     oid::ObjectId,
-    raw::error::ValueAccessErrorKind,
     spec::BinarySubtype,
     Binary,
     Bson,
@@ -183,12 +182,9 @@ fn array() {
         .expect("no key array")
         .as_array()
         .expect("result was not an array");
-    assert_eq!(array.get_str(0), Ok("binary"));
-    assert_eq!(array.get_str(3), Ok("notation"));
-    assert_eq!(
-        array.get_str(4).unwrap_err().kind,
-        ValueAccessErrorKind::NotPresent
-    );
+    assert_eq!(array.get_str(0).unwrap(), "binary");
+    assert_eq!(array.get_str(3).unwrap(), "notation");
+    assert!(array.get_str(4).unwrap_err().is_value_access_not_present());
 }
 
 #[test]

--- a/src/tests/modules/document.rs
+++ b/src/tests/modules/document.rs
@@ -96,7 +96,7 @@ fn test_getters() {
 
     doc.insert("null".to_string(), Bson::Null);
     assert_eq!(Some(&Bson::Null), doc.get("null"));
-    assert!(doc.get_null("null").is_ok());
+    assert_eq!(doc.get_null("null").unwrap(), Bson::Null);
     assert!(doc.get_null("array").is_err());
 
     assert_eq!(Some(&Bson::Int32(1)), doc.get("i32"));

--- a/src/tests/modules/document.rs
+++ b/src/tests/modules/document.rs
@@ -1,6 +1,5 @@
 use crate::{
     doc,
-    document::ValueAccessError,
     oid::ObjectId,
     spec::BinarySubtype,
     tests::LOCK,
@@ -66,42 +65,45 @@ fn test_getters() {
     };
 
     assert_eq!(None, doc.get("nonsense"));
-    assert_eq!(Err(ValueAccessError::NotPresent), doc.get_str("nonsense"));
-    assert_eq!(
-        Err(ValueAccessError::UnexpectedType),
-        doc.get_str("floating_point")
-    );
+    assert!(doc
+        .get_str("nonsense")
+        .unwrap_err()
+        .is_value_access_not_present());
+    assert!(doc
+        .get_str("floating_point")
+        .unwrap_err()
+        .is_value_access_unexpected_type());
 
     assert_eq!(Some(&Bson::Double(10.0)), doc.get("floating_point"));
-    assert_eq!(Ok(10.0), doc.get_f64("floating_point"));
+    assert_eq!(10.0, doc.get_f64("floating_point").unwrap());
 
     assert_eq!(
         Some(&Bson::String("a value".to_string())),
         doc.get("string")
     );
-    assert_eq!(Ok("a value"), doc.get_str("string"));
+    assert_eq!("a value", doc.get_str("string").unwrap());
 
     let array = vec![Bson::Int32(10), Bson::Int32(20), Bson::Int32(30)];
     assert_eq!(Some(&Bson::Array(array.clone())), doc.get("array"));
-    assert_eq!(Ok(&array), doc.get_array("array"));
+    assert_eq!(&array, doc.get_array("array").unwrap());
 
     let embedded = doc! { "key": 1 };
     assert_eq!(Some(&Bson::Document(embedded.clone())), doc.get("doc"));
-    assert_eq!(Ok(&embedded), doc.get_document("doc"));
+    assert_eq!(&embedded, doc.get_document("doc").unwrap());
 
     assert_eq!(Some(&Bson::Boolean(true)), doc.get("bool"));
-    assert_eq!(Ok(true), doc.get_bool("bool"));
+    assert!(doc.get_bool("bool").unwrap());
 
     doc.insert("null".to_string(), Bson::Null);
     assert_eq!(Some(&Bson::Null), doc.get("null"));
-    assert!(doc.is_null("null"));
-    assert!(!doc.is_null("array"));
+    assert!(doc.get_null("null").is_ok());
+    assert!(doc.get_null("array").is_err());
 
     assert_eq!(Some(&Bson::Int32(1)), doc.get("i32"));
-    assert_eq!(Ok(1i32), doc.get_i32("i32"));
+    assert_eq!(1i32, doc.get_i32("i32").unwrap());
 
     assert_eq!(Some(&Bson::Int64(1)), doc.get("i64"));
-    assert_eq!(Ok(1i64), doc.get_i64("i64"));
+    assert_eq!(1i64, doc.get_i64("i64").unwrap());
 
     doc.insert(
         "timestamp".to_string(),
@@ -118,21 +120,21 @@ fn test_getters() {
         doc.get("timestamp")
     );
     assert_eq!(
-        Ok(Timestamp {
+        Timestamp {
             time: 0,
             increment: 100,
-        }),
-        doc.get_timestamp("timestamp")
+        },
+        doc.get_timestamp("timestamp").unwrap()
     );
 
     let dt = crate::DateTime::from_time_0_3(datetime);
     assert_eq!(Some(&Bson::DateTime(dt)), doc.get("datetime"));
-    assert_eq!(Ok(&dt), doc.get_datetime("datetime"));
+    assert_eq!(&dt, doc.get_datetime("datetime").unwrap());
 
     let object_id = ObjectId::new();
     doc.insert("_id".to_string(), Bson::ObjectId(object_id));
     assert_eq!(Some(&Bson::ObjectId(object_id)), doc.get("_id"));
-    assert_eq!(Ok(object_id), doc.get_object_id("_id"));
+    assert_eq!(object_id, doc.get_object_id("_id").unwrap());
 
     assert_eq!(
         Some(&Bson::Binary(Binary {
@@ -141,7 +143,7 @@ fn test_getters() {
         })),
         doc.get("binary")
     );
-    assert_eq!(Ok(&binary), doc.get_binary_generic("binary"));
+    assert_eq!(&binary, doc.get_binary_generic("binary").unwrap());
 }
 
 #[test]
@@ -301,13 +303,7 @@ fn test_display_doc_with_array() {
     let doc_display_expectation = "{ \"hello\": [1, 2, 3] }";
     assert_eq!(doc_display_expectation, format!("{doc}"));
 
-    let doc_display_pretty_expectation = r#"{
-  "hello": [
-    1, 
-    2, 
-    3
-  ]
-}"#;
+    let doc_display_pretty_expectation = "{\n  \"hello\": [\n    1, \n    2, \n    3\n  ]\n}";
     let formatted = format!("{doc:#}");
     assert_eq!(doc_display_pretty_expectation, formatted);
 
@@ -315,15 +311,7 @@ fn test_display_doc_with_array() {
         "a": [1, [1, 2]]
     };
 
-    let expectation = r#"{
-  "a": [
-    1, 
-    [
-      1, 
-      2
-    ]
-  ]
-}"#;
+    let expectation = "{\n  \"a\": [\n    1, \n    [\n      1, \n      2\n    ]\n  ]\n}";
     assert_eq!(expectation, format!("{nested_array_doc:#}"));
 }
 
@@ -338,37 +326,16 @@ fn test_pretty_printing() {
     );
 
     let d = doc! { "hello": "world!", "nested": { "key": "val", "double": { "a": "thing" } } };
-    let expected = r#"{
-  "hello": "world!",
-  "nested": {
-    "key": "val",
-    "double": {
-      "a": "thing"
-    }
-  }
-}"#;
+    #[rustfmt::skip]
+    let expected =  "{\n  \"hello\": \"world!\",\n  \"nested\": {\n    \"key\": \"val\",\n    \"double\": {\n      \"a\": \"thing\"\n    }\n  }\n}";
     let formatted = format!("{d:#}");
-    assert_eq!(
-        expected, formatted,
-        "expected:\n{expected}\ngot:\n{formatted}"
-    );
+    assert_eq!(formatted, expected);
 
     let d =
         doc! { "hello": "world!", "nested": { "key": "val", "double": { "a": [1, 2], "c": "d"} } };
-    let expected = r#"{
-  "hello": "world!",
-  "nested": {
-    "key": "val",
-    "double": {
-      "a": [
-        1, 
-        2
-      ],
-      "c": "d"
-    }
-  }
-}"#;
-    assert_eq!(expected, format!("{d:#}"));
+    #[rustfmt::skip]
+    let expected = "{\n  \"hello\": \"world!\",\n  \"nested\": {\n    \"key\": \"val\",\n    \"double\": {\n      \"a\": [\n        1, \n        2\n      ],\n      \"c\": \"d\"\n    }\n  }\n}";
+    assert_eq!(format!("{d:#}"), expected);
 }
 
 #[test]


### PR DESCRIPTION
RUST-1406

This PR introduces crate-wide `Error` and `Result` types, which are modeled on the equivalent types in the driver, and does the first pass of error conversions for the `Document` and `RawDocument` getter methods. I also did a bit of documentation cleanup for the `Document` methods. I will follow up with more PRs to port over the rest of the error types and finalize the design/documentation of the new types.