### PR TITLE
RUST-1887 Make BindRawBsonRef a little more user-friendly

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -143,7 +143,7 @@ pub use self::{
         RawRegexRef,
     },
     document::RawDocument,
-    document_buf::{BindRawBsonRef, RawDocumentBuf},
+    document_buf::{BindRawBsonRef, BindValue, RawDocumentBuf},
     iter::{RawElement, RawIter},
 };
 

--- a/src/raw/bson_ref.rs
+++ b/src/raw/bson_ref.rs
@@ -489,6 +489,12 @@ impl From<Decimal128> for RawBsonRef<'_> {
     }
 }
 
+impl<'a> From<&'a RawBson> for RawBsonRef<'a> {
+    fn from(value: &'a RawBson) -> Self {
+        value.as_raw_bson_ref()
+    }
+}
+
 /// A BSON binary value referencing raw bytes stored elsewhere.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RawBinaryRef<'a> {


### PR DESCRIPTION
RUST-1887

This uses the technique described in [Alternative Blanket Implementations for a Single Rust Trait](https://www.greyblake.com/blog/alternative-blanket-implementations-for-single-rust-trait/) to remove the requirement for users to implement the unusual `bind` trait method for custom types if they want to use them in `rawdoc!` macros; instead a very small boilerplate impl can now be used.  This does complicate the internal type machinery a bit (introduction of a helper trait and some wrapper types for type-level dispatch) but those don't need to be visible and they're well contained.