### PR TITLE
RUST-1992 Updates to allow the driver to be updated

### DIFF
--- a/src/de/raw.rs
+++ b/src/de/raw.rs
@@ -363,7 +363,7 @@ impl<'de> serde::de::MapAccess<'de> for DocumentAccess<'de> {
         match &self.elem {
             None => Ok(None),
             Some(elem) => seed
-                .deserialize(BorrowedStrDeserializer::new(elem.key()))
+                .deserialize(BorrowedStrDeserializer::new(elem.key().as_str()))
                 .map(Some),
         }
     }
@@ -421,7 +421,8 @@ impl<'de> serde::de::EnumAccess<'de> for DocumentAccess<'de> {
             Some(e) => e,
             None => return Err(Error::end_of_stream()),
         };
-        let de: BorrowedStrDeserializer<'_, Error> = BorrowedStrDeserializer::new(elem.key());
+        let de: BorrowedStrDeserializer<'_, Error> =
+            BorrowedStrDeserializer::new(elem.key().as_str());
         let key = seed.deserialize(de)?;
         Ok((key, self))
     }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -88,6 +88,8 @@
 //! ```rust
 //! use bson::{
 //!    raw::{
+//!        cstr,
+//!        CStr,
 //!        RawBsonRef,
 //!        RawDocumentBuf,
 //!    },
@@ -102,12 +104,12 @@
 //! let doc = RawDocumentBuf::from_document(&original_doc)?;
 //! let mut doc_iter = doc.iter();
 //!
-//! let (key, value): (&str, RawBsonRef) = doc_iter.next().unwrap()?;
-//! assert_eq!(key, "crate");
+//! let (key, value): (&CStr, RawBsonRef) = doc_iter.next().unwrap()?;
+//! assert_eq!(key, cstr!("crate"));
 //! assert_eq!(value.as_str(), Some("bson"));
 //!
-//! let (key, value): (&str, RawBsonRef) = doc_iter.next().unwrap()?;
-//! assert_eq!(key, "year");
+//! let (key, value): (&CStr, RawBsonRef) = doc_iter.next().unwrap()?;
+//! assert_eq!(key, cstr!("year"));
 //! assert_eq!(value.as_str(), Some("2021"));
 //! # Ok::<(), bson::error::Error>(())
 //! ```

--- a/src/raw/cstr.rs
+++ b/src/raw/cstr.rs
@@ -27,7 +27,7 @@ use crate::error::{Error, Result};
 /// // bson::raw::CStr does not:
 /// let invalid: &bson::raw::CStr = cstr!("foo\0bar");  // will not compile
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Eq)]
 #[repr(transparent)]
 pub struct CStr {
     data: [u8],
@@ -82,9 +82,45 @@ impl CStr {
     }
 }
 
-impl PartialEq<&CStr> for &CStr {
-    fn eq(&self, other: &&CStr) -> bool {
+impl PartialEq for CStr {
+    fn eq(&self, other: &CStr) -> bool {
         self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<str> for CStr {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<CString> for CStr {
+    fn eq(&self, other: &CString) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<String> for CStr {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl std::hash::Hash for CStr {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl PartialOrd for CStr {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl Ord for CStr {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
     }
 }
 
@@ -175,7 +211,7 @@ pub use cstr;
 ///
 /// Like `CStr`, this differs from [`std::ffi::CString`] in that it is required to be valid UTF-8,
 /// and does not include the nul terminator in the buffer.
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq)]
 #[repr(transparent)]
 pub struct CString {
     data: String,
@@ -244,6 +280,36 @@ impl std::fmt::Display for CString {
 impl std::borrow::Borrow<CStr> for CString {
     fn borrow(&self) -> &CStr {
         self.as_ref()
+    }
+}
+
+impl PartialEq for CString {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl PartialEq<CStr> for CString {
+    fn eq(&self, other: &CStr) -> bool {
+        self.data.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<String> for CString {
+    fn eq(&self, other: &String) -> bool {
+        &self.data == other
+    }
+}
+
+impl PartialEq<str> for CString {
+    fn eq(&self, other: &str) -> bool {
+        self.data.as_str() == other
+    }
+}
+
+impl std::hash::Hash for CString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.data.hash(state);
     }
 }
 

--- a/src/raw/cstr.rs
+++ b/src/raw/cstr.rs
@@ -76,6 +76,16 @@ impl CStr {
         self.as_str().is_empty()
     }
 
+    /// Returns the lowercase equivalent of this as a new [`CString`].
+    pub fn to_lowercase(&self) -> CString {
+        CString::from_string_unchecked(self.as_str().to_lowercase())
+    }
+
+    /// Returns the uppercase equivalent of this as a new [`CString`].
+    pub fn to_uppercase(&self) -> CString {
+        CString::from_string_unchecked(self.as_str().to_uppercase())
+    }
+
     pub(crate) fn append_to(&self, buf: &mut Vec<u8>) {
         buf.extend(&self.data);
         buf.push(0);
@@ -124,6 +134,12 @@ impl Ord for CStr {
     }
 }
 
+impl std::fmt::Display for CStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
 impl std::borrow::ToOwned for CStr {
     type Owned = CString;
 
@@ -140,6 +156,12 @@ impl AsRef<CStr> for CStr {
 
 impl AsRef<str> for CStr {
     fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'a> Into<&'a str> for &'a CStr {
+    fn into(self) -> &'a str {
         self.as_str()
     }
 }
@@ -265,6 +287,26 @@ impl AsRef<CStr> for CString {
     }
 }
 
+impl Into<String> for CString {
+    fn into(self) -> String {
+        self.into_string()
+    }
+}
+
+impl std::ops::Deref for CString {
+    type Target = CStr;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl std::borrow::Borrow<CStr> for CString {
+    fn borrow(&self) -> &CStr {
+        self.as_ref()
+    }
+}
+
 impl std::fmt::Debug for CString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.data.fmt(f)
@@ -274,12 +316,6 @@ impl std::fmt::Debug for CString {
 impl std::fmt::Display for CString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.data.fmt(f)
-    }
-}
-
-impl std::borrow::Borrow<CStr> for CString {
-    fn borrow(&self) -> &CStr {
-        self.as_ref()
     }
 }
 

--- a/src/raw/cstr.rs
+++ b/src/raw/cstr.rs
@@ -122,15 +122,15 @@ impl std::hash::Hash for CStr {
     }
 }
 
-impl PartialOrd for CStr {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.as_str().partial_cmp(other.as_str())
-    }
-}
-
 impl Ord for CStr {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for CStr {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -160,9 +160,9 @@ impl AsRef<str> for CStr {
     }
 }
 
-impl<'a> Into<&'a str> for &'a CStr {
-    fn into(self) -> &'a str {
-        self.as_str()
+impl<'a> From<&'a CStr> for &'a str {
+    fn from(value: &'a CStr) -> Self {
+        value.as_str()
     }
 }
 
@@ -287,9 +287,9 @@ impl AsRef<CStr> for CString {
     }
 }
 
-impl Into<String> for CString {
-    fn into(self) -> String {
-        self.into_string()
+impl From<CString> for String {
+    fn from(value: CString) -> Self {
+        value.into_string()
     }
 }
 

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -161,7 +161,7 @@ impl RawDocument {
     pub fn get(&self, key: impl AsRef<str>) -> RawResult<Option<RawBsonRef<'_>>> {
         for elem in RawIter::new(self) {
             let elem = elem?;
-            if key.as_ref() == elem.key() {
+            if key.as_ref() == elem.key().as_str() {
                 return Ok(Some(elem.try_into()?));
             }
         }
@@ -524,7 +524,7 @@ impl RawDocument {
         for elem in self.iter_elements() {
             let elem = elem?;
             let value = deep_utf8_lossy(elem.value_utf8_lossy()?)?;
-            out.insert(elem.key(), value);
+            out.insert(elem.key().as_str(), value);
         }
         Ok(out)
     }
@@ -543,7 +543,10 @@ fn deep_utf8_lossy(src: RawBson) -> RawResult<Bson> {
             let mut tmp = doc! {};
             for elem in doc.iter_elements() {
                 let elem = elem?;
-                tmp.insert(elem.key(), deep_utf8_lossy(elem.value_utf8_lossy()?)?);
+                tmp.insert(
+                    elem.key().as_str(),
+                    deep_utf8_lossy(elem.value_utf8_lossy()?)?,
+                );
             }
             Ok(Bson::Document(tmp))
         }
@@ -551,7 +554,10 @@ fn deep_utf8_lossy(src: RawBson) -> RawResult<Bson> {
             let mut tmp = doc! {};
             for elem in scope.iter_elements() {
                 let elem = elem?;
-                tmp.insert(elem.key(), deep_utf8_lossy(elem.value_utf8_lossy()?)?);
+                tmp.insert(
+                    elem.key().as_str(),
+                    deep_utf8_lossy(elem.value_utf8_lossy()?)?,
+                );
             }
             Ok(Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
                 code,
@@ -597,7 +603,7 @@ impl serde::Serialize for &RawDocument {
                     let mut map = serializer.serialize_map(None)?;
                     for kvp in self.0 {
                         let (k, v) = kvp.map_err(serde::ser::Error::custom)?;
-                        map.serialize_entry(k, &v)?;
+                        map.serialize_entry(k.as_str(), &v)?;
                     }
                     map.end()
                 } else {
@@ -643,7 +649,7 @@ impl TryFrom<&RawDocument> for crate::Document {
     fn try_from(rawdoc: &RawDocument) -> RawResult<Document> {
         rawdoc
             .into_iter()
-            .map(|res| res.and_then(|(k, v)| Ok((k.to_owned(), v.try_into()?))))
+            .map(|res| res.and_then(|(k, v)| Ok((k.as_str().to_owned(), v.try_into()?))))
             .collect()
     }
 }
@@ -666,7 +672,7 @@ impl TryFrom<&RawDocumentBuf> for Document {
 
 impl<'a> IntoIterator for &'a RawDocument {
     type IntoIter = Iter<'a>;
-    type Item = RawResult<(&'a str, RawBsonRef<'a>)>;
+    type Item = RawResult<(&'a CStr, RawBsonRef<'a>)>;
 
     fn into_iter(self) -> Iter<'a> {
         self.iter()

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -292,7 +292,7 @@ impl TryFrom<Document> for RawDocumentBuf {
 
 impl<'a> IntoIterator for &'a RawDocumentBuf {
     type IntoIter = Iter<'a>;
-    type Item = Result<(&'a str, RawBsonRef<'a>)>;
+    type Item = Result<(&'a CStr, RawBsonRef<'a>)>;
 
     fn into_iter(self) -> Iter<'a> {
         self.iter()

--- a/src/raw/iter.rs
+++ b/src/raw/iter.rs
@@ -44,13 +44,13 @@ impl<'a> Iter<'a> {
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = Result<(&'a str, RawBsonRef<'a>)>;
+    type Item = Result<(&'a CStr, RawBsonRef<'a>)>;
 
-    fn next(&mut self) -> Option<Result<(&'a str, RawBsonRef<'a>)>> {
+    fn next(&mut self) -> Option<Result<(&'a CStr, RawBsonRef<'a>)>> {
         match self.inner.next() {
             Some(Ok(elem)) => match elem.value() {
                 Err(e) => Some(Err(e)),
-                Ok(value) => Some(Ok((elem.key.as_str(), value))),
+                Ok(value) => Some(Ok((elem.key, value))),
             },
             Some(Err(e)) => Some(Err(e)),
             None => None,
@@ -161,8 +161,8 @@ impl<'a> RawElement<'a> {
         self.size
     }
 
-    pub fn key(&self) -> &'a str {
-        self.key.as_str()
+    pub fn key(&self) -> &'a CStr {
+        self.key
     }
 
     pub fn element_type(&self) -> ElementType {

--- a/src/raw/test.rs
+++ b/src/raw/test.rs
@@ -404,7 +404,7 @@ fn document_iteration() {
     assert_eq!(
         rawdoc
             .into_iter()
-            .collect::<Result<Vec<(&str, _)>>>()
+            .collect::<Result<Vec<(_, _)>>>()
             .expect("collecting iterated doc")
             .len(),
         17


### PR DESCRIPTION
RUST-1992

In the process of updating the driver for the `CStr` changes, I ran across a bunch of things (missing stdlib `impls` mostly) that needed to be fixed in the `bson` crate first.