### PR TITLE
feat: Add integration with `jiff::Timestamp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "getrandom 0.3.2",
  "hex",
  "indexmap 2.10.0",
+ "jiff",
  "js-sys",
  "once_cell",
  "pretty_assertions",
@@ -520,6 +521,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +646,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ default = ["compat-3-0-0"]
 compat-3-0-0 = []
 # if enabled, include API for interfacing with chrono 0.4
 chrono-0_4 = ["dep:chrono"]
+# if enabled, include API for interfacing with jiff 0.2
+jiff-0_2 = ["dep:jiff"]
 # enable the large-dates feature for the time crate
 large_dates = ["time/large-dates"]
 # if enabled, include API for interfacing with uuid 1.x
@@ -56,6 +58,7 @@ name = "bson"
 [dependencies]
 ahash = "0.8.0"
 chrono = { version = "0.4.15", features = ["std"], default-features = false, optional = true }
+jiff = { version = "0.2", default-features = false, optional = true }
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
@@ -87,6 +90,7 @@ serde_bytes = "0.11"
 serde_path_to_error = "0.1.16"
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde", "clock", "std"], default-features = false }
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -408,6 +408,13 @@ impl<T: chrono::TimeZone> From<chrono::DateTime<T>> for Bson {
     }
 }
 
+#[cfg(feature = "jiff-0_2")]
+impl From<jiff::Timestamp> for Bson {
+    fn from(a: jiff::Timestamp) -> Bson {
+        Bson::DateTime(crate::DateTime::from(a))
+    }
+}
+
 #[cfg(feature = "uuid-1")]
 impl From<uuid::Uuid> for Bson {
     fn from(uuid: uuid::Uuid) -> Self {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -260,7 +260,6 @@ impl crate::DateTime {
         }
     }
 
-
     /// Convert this [`DateTime`] to a [`jiff::Timestamp`].
     ///
     /// Note: Not every BSON datetime can be represented as a [`jiff::Timestamp`]. For such dates,
@@ -278,7 +277,7 @@ impl crate::DateTime {
     /// ```
     #[cfg(feature = "jiff-0_2")]
     pub fn to_jiff(self) -> jiff::Timestamp {
-        jiff::Timestamp::from_millisecond(self.0).unwrap_or_else(|_| {
+        jiff::Timestamp::from_millisecond(self.0).unwrap_or({
             if self.0 < 0 {
                 jiff::Timestamp::MIN
             } else {
@@ -521,7 +520,6 @@ impl serde_with::SerializeAs<chrono::DateTime<Utc>> for crate::DateTime {
         dt.serialize(serializer)
     }
 }
-
 
 #[cfg(feature = "jiff-0_2")]
 impl From<crate::DateTime> for jiff::Timestamp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 //! | Feature      | Description                                                                                          | Default |
 //! |:-------------|:-----------------------------------------------------------------------------------------------------|:--------|
 //! | `chrono-0_4` | Enable support for v0.4 of the [`chrono`](https://docs.rs/chrono/0.4) crate in the public API.       | no      |
+//! | `jiff-0_2` | Enable support for v0.2 of the [`jiff`](https://docs.rs/jiff/0.2) crate in the public API.             | no      |
 //! | `uuid-1`     | Enable support for v1.x of the [`uuid`](https://docs.rs/uuid/1.x) crate in the public API.           | no      |
 //! | `time-0_3`   | Enable support for v0.3 of the [`time`](https://docs.rs/time/0.3) crate in the public API.           | no      |
 //! | `serde_with-3` | Enable [`serde_with`](https://docs.rs/serde_with/3.x) 3.x integrations for [`DateTime`] and [`Uuid`]. | no      |

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -81,6 +81,8 @@ pub mod object_id {
 /// - [`datetime::FromI64`] — converts an `i64` to and from a [`crate::DateTime`].
 /// - [`datetime::FromChrono04DateTime`] — converts a [`chrono::DateTime`] to and from a
 ///   [`crate::DateTime`].
+/// - [`datetime::FromJiff02Timestamp`] — converts a [`jiff::Timestamp`] to and from a
+///   [`crate::DateTime`].
 /// - [`datetime::FromTime03OffsetDateTime`] — converts a [`time::OffsetDateTime`] to and from a
 ///   [`crate::DateTime`].
 #[cfg(feature = "serde_with-3")]
@@ -197,6 +199,33 @@ pub mod datetime {
         },
         |bson_date: DateTime| -> Result<chrono::DateTime<Utc>, String> {
             Ok(bson_date.to_chrono())
+        }
+    );
+
+    #[cfg(feature = "jiff-0_2")]
+    serde_conv_doc!(
+        /// Converts a [`jiff::Timestamp`] to and from a [`DateTime`].
+        /// ```rust
+        /// # #[cfg(all(feature = "jiff-0_2", feature = "serde_with-3"))]
+        /// # {
+        /// use bson::serde_helpers::datetime;
+        /// use serde::{Serialize, Deserialize};
+        /// use serde_with::serde_as;
+        /// #[serde_as]
+        /// #[derive(Serialize, Deserialize)]
+        /// struct Event {
+        ///     #[serde_as(as = "datetime::FromJiff02Timestamp")]
+        ///     pub date: jiff::Timestamp,
+        /// }
+        /// # }
+        /// ```
+        pub FromJiff02Timestamp,
+        jiff::Timestamp,
+        |jiff_ts: &jiff::Timestamp| -> Result<DateTime, String> {
+            Ok(DateTime::from_jiff(*jiff_ts))
+        },
+        |bson_date: DateTime| -> Result<jiff::Timestamp, String> {
+            Ok(bson_date.to_jiff())
         }
     );
 

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -407,8 +407,6 @@ fn from_external_datetime() {
     }
     #[cfg(feature = "jiff-0_2")]
     {
-        use chrono::Utc;
-
         let bdt = DateTime::from(jiff::Timestamp::MAX);
         assert_eq!(
             bdt.to_jiff().as_millisecond(),
@@ -425,7 +423,7 @@ fn from_external_datetime() {
         assert_eq!(bdt.to_jiff(), jiff::Timestamp::MAX);
 
         let bdt = DateTime::MIN;
-        assert_eq!(bdt.to_jiff(), jiff::Timestamp::MAX);
+        assert_eq!(bdt.to_jiff(), jiff::Timestamp::MIN);
     }
 }
 

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -309,8 +309,7 @@ fn from_external_datetime() {
     }
     #[cfg(feature = "jiff-0_2")]
     {
-        let no_subsec_millis: jiff::Timestamp =
-            "2014-11-28T12:00:09Z".parse().unwrap();
+        let no_subsec_millis: jiff::Timestamp = "2014-11-28T12:00:09Z".parse().unwrap();
         let dt = DateTime::from(no_subsec_millis);
         assert_millisecond_precision(dt);
         assert_subsec_millis(dt, 0);

--- a/src/tests/modules/bson.rs
+++ b/src/tests/modules/bson.rs
@@ -274,6 +274,15 @@ fn from_external_datetime() {
         let from_chrono = DateTime::from(now);
         assert_millisecond_precision(from_chrono);
     }
+    #[cfg(feature = "jiff-0_2")]
+    {
+        let now = jiff::Timestamp::now();
+        let bson = Bson::from(now);
+        assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
+
+        let from_jiff = DateTime::from(now);
+        assert_millisecond_precision(from_jiff);
+    }
 
     let no_subsec_millis = datetime!(2014-11-28 12:00:09 UTC);
     let dt = DateTime::from_time_0_3(no_subsec_millis);
@@ -289,6 +298,18 @@ fn from_external_datetime() {
     #[cfg(feature = "chrono-0_4")]
     {
         let no_subsec_millis: chrono::DateTime<chrono::Utc> =
+            "2014-11-28T12:00:09Z".parse().unwrap();
+        let dt = DateTime::from(no_subsec_millis);
+        assert_millisecond_precision(dt);
+        assert_subsec_millis(dt, 0);
+
+        let bson = Bson::from(dt);
+        assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
+        assert_subsec_millis(bson.as_datetime().unwrap().to_owned(), 0);
+    }
+    #[cfg(feature = "jiff-0_2")]
+    {
+        let no_subsec_millis: jiff::Timestamp =
             "2014-11-28T12:00:09Z".parse().unwrap();
         let dt = DateTime::from(no_subsec_millis);
         assert_millisecond_precision(dt);
@@ -324,6 +345,17 @@ fn from_external_datetime() {
             assert_subsec_millis(dt, 123);
 
             let bson = Bson::from(chrono_dt);
+            assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
+            assert_subsec_millis(bson.as_datetime().unwrap().to_owned(), 123);
+        }
+        #[cfg(feature = "jiff-0_2")]
+        {
+            let jiff_ts: jiff::Timestamp = s.parse().unwrap();
+            let dt = DateTime::from(jiff_ts);
+            assert_millisecond_precision(dt);
+            assert_subsec_millis(dt, 123);
+
+            let bson = Bson::from(jiff_ts);
             assert_millisecond_precision(bson.as_datetime().unwrap().to_owned());
             assert_subsec_millis(bson.as_datetime().unwrap().to_owned(), 123);
         }
@@ -372,6 +404,28 @@ fn from_external_datetime() {
 
         let bdt = DateTime::MIN;
         assert_eq!(bdt.to_chrono(), chrono::DateTime::<Utc>::MIN_UTC);
+    }
+    #[cfg(feature = "jiff-0_2")]
+    {
+        use chrono::Utc;
+
+        let bdt = DateTime::from(jiff::Timestamp::MAX);
+        assert_eq!(
+            bdt.to_jiff().as_millisecond(),
+            jiff::Timestamp::MAX.as_millisecond()
+        );
+
+        let bdt = DateTime::from(jiff::Timestamp::MIN);
+        assert_eq!(
+            bdt.to_jiff().as_millisecond(),
+            jiff::Timestamp::MIN.as_millisecond()
+        );
+
+        let bdt = DateTime::MAX;
+        assert_eq!(bdt.to_jiff(), jiff::Timestamp::MAX);
+
+        let bdt = DateTime::MIN;
+        assert_eq!(bdt.to_jiff(), jiff::Timestamp::MAX);
     }
 }
 

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -326,6 +326,7 @@ fn test_serialize_utc_date_time() {
     #[allow(unused)]
     let src = time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap();
     #[cfg(feature = "chrono-0_4")]
+    #[allow(unused)]
     let src = chrono::Utc.timestamp_opt(1_286_705_410, 0).unwrap();
     #[cfg(feature = "jiff-0_2")]
     let src = jiff::Timestamp::from_second(1_286_705_410).unwrap();

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -327,6 +327,8 @@ fn test_serialize_utc_date_time() {
     let src = time::OffsetDateTime::from_unix_timestamp(1_286_705_410).unwrap();
     #[cfg(feature = "chrono-0_4")]
     let src = chrono::Utc.timestamp_opt(1_286_705_410, 0).unwrap();
+    #[cfg(feature = "jiff-0_2")]
+    let src = jiff::Timestamp::from_second(1_286_705_410, 0).unwrap();
     let dst = vec![
         18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0,
     ];

--- a/src/tests/modules/serializer_deserializer.rs
+++ b/src/tests/modules/serializer_deserializer.rs
@@ -328,7 +328,7 @@ fn test_serialize_utc_date_time() {
     #[cfg(feature = "chrono-0_4")]
     let src = chrono::Utc.timestamp_opt(1_286_705_410, 0).unwrap();
     #[cfg(feature = "jiff-0_2")]
-    let src = jiff::Timestamp::from_second(1_286_705_410, 0).unwrap();
+    let src = jiff::Timestamp::from_second(1_286_705_410).unwrap();
     let dst = vec![
         18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0,
     ];


### PR DESCRIPTION
### feat: Add interoperability with `jiff::Timestamp`
Hi!
This PR introduces interoperability with the `jiff` ([docs](https://docs.rs/jiff/0.2.15/jiff/)) crate by adding helpers to convert between `jiff::Timestamp` and `bson::DateTime`. This allows users of `jiff`, a modern and standards-focused time library, to seamlessly serialize and deserialize timestamps with BSON, I followed the already present integration with `chrono` to add features and tests.

**Changes included:**

* **Optional Dependency**: Added `jiff` as an optional dependency under the `jiff-0_2` feature flag.
* **Serde Helper**: Created a new `serde_with` helper, `datetime::FromJiff02Timestamp`, to enable ergonomic serialization for structs (e.g., `#[serde_as(as = "datetime::FromJiff02Timestamp")]`).
* **Direct Conversions**: Added `DateTime::from_jiff()` and `DateTime::to_jiff()` for direct, manual conversions between the two types.
* **Tests**: Added tests equivalent to the chrono ones 

Let me know if I missed anything! 