### PR TITLE
Borrow the buffer instead of owning it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,6 +474,7 @@ pub use self::{
     },
     ser::{
         serialize_to_bson,
+        serialize_to_buffer,
         serialize_to_document,
         serialize_to_raw_document_buf,
         serialize_to_vec,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -89,7 +89,19 @@ pub fn serialize_to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
     T: Serialize,
 {
-    let mut serializer = raw::Serializer::new();
+    let mut bytes = Vec::new();
+    serialize_to_buffer(value, &mut bytes)?;
+    Ok(bytes)
+}
+
+/// Serialize the given `T` as a BSON byte vector into the provided byte buffer.
+/// This allows reusing the same buffer for multiple serializations.
+#[inline]
+pub fn serialize_to_buffer<T>(value: &T, buffer: &mut Vec<u8>) -> Result<()>
+where
+    T: Serialize,
+{
+    let mut serializer = raw::Serializer::new(buffer);
     #[cfg(feature = "serde_path_to_error")]
     {
         serde_path_to_error::serialize(value, &mut serializer).map_err(Error::with_path)?;
@@ -98,7 +110,7 @@ where
     {
         value.serialize(&mut serializer)?;
     }
-    Ok(serializer.into_vec())
+    Ok(())
 }
 
 /// Serialize the given `T` as a [`RawDocumentBuf`].

--- a/src/ser/raw/document_serializer.rs
+++ b/src/ser/raw/document_serializer.rs
@@ -7,19 +7,19 @@ use crate::{
 
 use super::Serializer;
 
-pub(crate) struct DocumentSerializationResult<'a> {
-    pub(crate) root_serializer: &'a mut Serializer,
+pub(crate) struct DocumentSerializationResult<'a, 'b> {
+    pub(crate) root_serializer: &'a mut Serializer<'b>,
 }
 
 /// Serializer used to serialize document or array bodies.
-pub(crate) struct DocumentSerializer<'a> {
-    root_serializer: &'a mut Serializer,
+pub(crate) struct DocumentSerializer<'a, 'b> {
+    root_serializer: &'a mut Serializer<'b>,
     num_keys_serialized: usize,
     start: usize,
 }
 
-impl<'a> DocumentSerializer<'a> {
-    pub(crate) fn start(rs: &'a mut Serializer) -> Self {
+impl<'a, 'b> DocumentSerializer<'a, 'b> {
+    pub(crate) fn start(rs: &'a mut Serializer<'b>) -> Self {
         let start = rs.bytes.len();
         RawBsonRef::Int32(0).append_to(&mut rs.bytes);
         Self {
@@ -30,7 +30,7 @@ impl<'a> DocumentSerializer<'a> {
     }
 
     /// Serialize a document key using the provided closure.
-    fn serialize_doc_key_custom<F: FnOnce(&mut Serializer) -> Result<()>>(
+    fn serialize_doc_key_custom<F: FnOnce(&mut Serializer<'b>) -> Result<()>>(
         &mut self,
         f: F,
     ) -> Result<()> {
@@ -55,7 +55,7 @@ impl<'a> DocumentSerializer<'a> {
         Ok(())
     }
 
-    pub(crate) fn end_doc(self) -> crate::ser::Result<DocumentSerializationResult<'a>> {
+    pub(crate) fn end_doc(self) -> crate::ser::Result<DocumentSerializationResult<'a, 'b>> {
         self.root_serializer.bytes.push(0);
         let length = (self.root_serializer.bytes.len() - self.start) as i32;
         self.root_serializer.replace_i32(self.start, length);
@@ -65,7 +65,7 @@ impl<'a> DocumentSerializer<'a> {
     }
 }
 
-impl serde::ser::SerializeSeq for DocumentSerializer<'_> {
+impl serde::ser::SerializeSeq for DocumentSerializer<'_, '_> {
     type Ok = ();
     type Error = Error;
 
@@ -90,7 +90,7 @@ impl serde::ser::SerializeSeq for DocumentSerializer<'_> {
     }
 }
 
-impl serde::ser::SerializeMap for DocumentSerializer<'_> {
+impl serde::ser::SerializeMap for DocumentSerializer<'_, '_> {
     type Ok = ();
 
     type Error = Error;
@@ -116,7 +116,7 @@ impl serde::ser::SerializeMap for DocumentSerializer<'_> {
     }
 }
 
-impl serde::ser::SerializeStruct for DocumentSerializer<'_> {
+impl serde::ser::SerializeStruct for DocumentSerializer<'_, '_> {
     type Ok = ();
 
     type Error = Error;
@@ -136,7 +136,7 @@ impl serde::ser::SerializeStruct for DocumentSerializer<'_> {
     }
 }
 
-impl serde::ser::SerializeTuple for DocumentSerializer<'_> {
+impl serde::ser::SerializeTuple for DocumentSerializer<'_, '_> {
     type Ok = ();
 
     type Error = Error;
@@ -156,7 +156,7 @@ impl serde::ser::SerializeTuple for DocumentSerializer<'_> {
     }
 }
 
-impl serde::ser::SerializeTupleStruct for DocumentSerializer<'_> {
+impl serde::ser::SerializeTupleStruct for DocumentSerializer<'_, '_> {
     type Ok = ();
 
     type Error = Error;
@@ -178,11 +178,11 @@ impl serde::ser::SerializeTupleStruct for DocumentSerializer<'_> {
 
 /// Serializer used specifically for serializing document keys.
 /// Only keys that serialize to strings will be accepted.
-struct KeySerializer<'a> {
-    root_serializer: &'a mut Serializer,
+struct KeySerializer<'a, 'b> {
+    root_serializer: &'a mut Serializer<'b>,
 }
 
-impl serde::Serializer for KeySerializer<'_> {
+impl serde::Serializer for KeySerializer<'_, '_> {
     type Ok = ();
 
     type Error = Error;


### PR DESCRIPTION
Similar to the idea in #328, `raw::Serializer` now takes a `&mut Vec<u8>`.
Because the `Vec` is borrowed, the same buffer can be reused for many serializations without reallocating.

* added **`serialize_to_buffer`**: serialize `&T` straight into a caller-supplied `Vec<u8>`.
* **`serialize_to_vec`** still exists. It just allocates a `Vec<u8>` and forwards it to `serialize_to_buffer`.

Breaking change: `raw::Serializer::new()` now expects `&mut Vec<u8>`.
