### PR TITLE
minor: const array bson conversion

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -349,6 +349,15 @@ impl<T: Into<Bson>, S> From<HashSet<T, S>> for Bson {
     }
 }
 
+impl<T, const N: usize> From<[T; N]> for Bson
+where
+    T: Into<Bson>,
+{
+    fn from(value: [T; N]) -> Self {
+        Bson::Array(value.into_iter().map(|v| v.into()).collect())
+    }
+}
+
 impl<T> From<&[T]> for Bson
 where
     T: Clone + Into<Bson>,


### PR DESCRIPTION
Where functions have signatures like `fn foo(value: impl Into<Bson>)` this enables the nice `foo([1, 2, 3])` where currently it needs the awkward `foo([1, 2, 3].as_ref())` or similar workaround.

For things accepting arrays, usually you can just use `foo(&[1, 2, 3])` but that doesn't work here because the argument is actually of type `&[i32; 3]`; the compiler will coerce the ref to `&[i32]` only in the context of a concrete type, not when matching against trait impls :(