### PR TITLE
minor: replace doc_auto_cfg with doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,7 +435,7 @@
 
 #![allow(clippy::cognitive_complexity, clippy::derive_partial_eq_without_eq)]
 #![doc(html_root_url = "https://docs.rs/bson/3.0.0")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 #[doc(inline)]


### PR DESCRIPTION
same issue as https://github.com/mongodb/mongo-rust-driver/pull/1483