### PR TITLE
deps: drop getrandom 0.2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.2",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -120,8 +120,7 @@ dependencies = [
  "bitvec",
  "chrono",
  "criterion",
- "getrandom 0.2.16",
- "getrandom 0.3.2",
+ "getrandom",
  "hex",
  "indexmap 2.11.4",
  "jiff",
@@ -394,19 +393,6 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
@@ -415,7 +401,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -772,7 +758,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom",
 ]
 
 [[package]]
@@ -1082,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1182,7 +1168,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -1212,12 +1198,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_json-1 = ["dep:serde_json"]
 name = "bson"
 
 [dependencies]
-ahash = "0.8.0"
+ahash = "0.8.12"
 chrono = { version = "0.4.15", features = ["std"], default-features = false, optional = true }
 jiff = { version = "0.2", default-features = false, optional = true }
 rand = "0.9"
@@ -65,7 +65,7 @@ serde_json = { version = "1.0", optional = true }
 indexmap = "2.1.0"
 hex = "0.4.2"
 base64 = "0.22.1"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+uuid = { version = "1.13.0", features = ["serde", "v4"] }
 serde_bytes = "0.11.5"
 serde_with = { version = "3.1.0", optional = true }
 time = { version = "0.3.9", features = ["formatting", "parsing", "macros"] }
@@ -77,8 +77,7 @@ simdutf8 = "0.1.5"
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = "0.3"
 uuid = { version = "1.1.2", features = ["serde", "v4", "js"] }
-getrandom = { version = "0.2", features = ["js"] }
-getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]
 assert_matches = "1.2"


### PR DESCRIPTION
This drops the `getrandmom` 0.2 dependency. Updates several dependencies to remove transitive dependencies on `getrandom` 0.2 due to other dependencies.