### PR TITLE
release v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ahash",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bson"
-version = "3.0.0"
+version = "3.1.0"
 authors = [
     "Y. T. Chung <zonyitoo@gmail.com>",
     "Kevin Yeh <kevinyeah@utexas.edu>",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This crate is available on [crates.io](https://crates.io/crates/bson). To use it
 
 ```toml
 [dependencies]
-bson = "3.0.0"
+bson = "3.1.0"
 ```
 
 Note that if you are using `bson` through the `mongodb` crate, you do not need to specify it in your

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bson = "3.0.0"
+//! bson = "3.1.0"
 //! ```
 //!
 //! Note that if you are using `bson` through the `mongodb` crate, you do not need to specify it in
@@ -434,7 +434,7 @@
 //! is, it will only happen in a minor or major version release.
 
 #![allow(clippy::cognitive_complexity, clippy::derive_partial_eq_without_eq)]
-#![doc(html_root_url = "https://docs.rs/bson/3.0.0")]
+#![doc(html_root_url = "https://docs.rs/bson/3.1.0")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
The [docs build](https://docs.rs/crate/mongodb/latest/builds/2674122/x86_64-unknown-linux-gnu_json.txt) for the driver failed because we're using the impl introduced in https://github.com/mongodb/bson-rust/pull/601 in the Atlas search helpers ~~documentation (but not in code). Fortunately the actual driver release is fine, but I guess this is something that `cargo publish --dry-run` and our rustdoc lint can't catch.~~

Edit - we're actually using the impl when `bson-3` is enabled; I'm not sure why the release build didn't catch this. `cargo update` will pull in the new bson version now that it's out.

My hope is that once this version is published, I can re-run the docs build and it'll pull in the new version without needing an explicit bump of the bson dep in the driver (and therefore another release).

I will also figure out a way to check this before a release to avoid a similar situation in the future 🙂 