### PR TITLE
minor: update rmp-serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,11 +864,10 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "0.15.5"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
- "byteorder",
  "rmp",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ serde_path_to_error = "0.1.16"
 serde_json = { version = "1", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde", "clock", "std"], default-features = false }
 jiff = { version = "0.2", default-features = false, features = ["std"] }
-rmp-serde = "0.15"
+rmp-serde = "1.3"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
We were using a _very_ stale version, which caused issues in the most recent dependabot pr.