### PR TITLE
Implement `Ord` for `BinarySubtype`

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -21,7 +21,7 @@
 
 //! Constants derived from the [BSON Specification Version 1.1](http://bsonspec.org/spec.html).
 
-use std::{convert::From, fmt};
+use std::{convert::From, fmt, hash::Hash};
 
 impl fmt::LowerHex for BinarySubtype {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -180,7 +180,7 @@ impl ElementType {
 }
 
 /// The available binary subtypes, plus a user-defined slot.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum BinarySubtype {
@@ -235,6 +235,19 @@ impl From<u8> for BinarySubtype {
             _ if t < BINARY_SUBTYPE_USER_DEFINED => BinarySubtype::Reserved(t),
             _ => BinarySubtype::UserDefined(t),
         }
+    }
+}
+
+// Manual implemntation to ensure that Generic == UserDefined(0x00) == Reserved(0x00)
+impl PartialEq for BinarySubtype {
+    fn eq(&self, other: &BinarySubtype) -> bool {
+        u8::from(*self) == u8::from(*other)
+    }
+}
+
+impl Hash for BinarySubtype {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        u8::from(*self).hash(state);
     }
 }
 


### PR DESCRIPTION
I have the following type in my code that I would like to store in a `BTreeMap`:

```rust
enum BsonType {
    Double,
    String,
    Document,
    Array,
    Binary(BinarySubtype),
    Undefined,
    ObjectId,
    Boolean,
    DateTime,
    Null,
    RegularExpression,
    DbPointer,
    JavaScriptCode,
    Symbol,
    JavaScriptCodeWithScope,
    Int32,
    Timestamp,
    Int64,
    Decimal128,
    MinKey,
    MaxKey,
}
```

So I need to implement `Ord` for it. This is easier to do with this change.