### PR TITLE
RUST-2401 Increase performance with facet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,3 +103,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mongodb_internal_bench)'] }
+
+[profile.bench]
+debug = true
+strip = false

--- a/src/facet/parse.rs
+++ b/src/facet/parse.rs
@@ -45,6 +45,37 @@ enum Expect {
     Eof,
 }
 
+#[derive(Debug, Copy, Clone)]
+struct Delta {
+    offset: usize,
+    expects: Expect,
+    op: StackOp,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum StackOp {
+    Keep,
+    Push(Expect),
+    Pop,
+}
+
+impl ParseState {
+    fn apply(&mut self, delta: Delta) -> Result<()> {
+        self.offset = delta.offset;
+        self.expects = delta.expects;
+        match delta.op {
+            StackOp::Keep => (),
+            StackOp::Push(exp) => self.outer.push(exp),
+            StackOp::Pop => {
+                if self.outer.pop().is_none() {
+                    return Err(Error::deserialization("mismatched container structure"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 impl<'de> Parser<'de> {
     fn new(bytes: &'de [u8]) -> Self {
         Self {
@@ -58,10 +89,10 @@ impl<'de> Parser<'de> {
         }
     }
 
-    fn peek(&self) -> Result<Option<(ParseEvent<'de>, ParseState)>> {
+    fn peek(&self) -> Result<Option<(ParseEvent<'de>, Delta)>> {
         let mut iter = RawIter::new_unchecked(self.bytes, self.state.offset);
         let event;
-        let next;
+        let delta;
         match self.state.expects {
             Expect::DocStart => {
                 let len = iter.next_document_len(self.state.offset)?;
@@ -69,10 +100,10 @@ impl<'de> Parser<'de> {
                     ParseEventKind::StructStart(ContainerKind::Object),
                     Span::new(self.state.offset, len),
                 );
-                next = ParseState {
+                delta = Delta {
                     offset: self.state.offset + 4, // doc length
                     expects: Expect::ElemKey,
-                    outer: vec![Expect::Eof],
+                    op: StackOp::Push(Expect::Eof),
                 };
             }
             Expect::DocStartRaw => {
@@ -81,10 +112,10 @@ impl<'de> Parser<'de> {
                 // type tag for parsing a `Bson`/`RawBson` value
                 bytes.push(ElementType::EmbeddedDocument as u8);
                 event = ParseEvent::new(scalar_bytes(bytes), Span::new(self.state.offset, len));
-                next = ParseState {
+                delta = Delta {
                     offset: event.span.end(),
                     expects: Expect::Eof,
-                    outer: vec![],
+                    op: StackOp::Keep,
                 };
             }
             Expect::ElemKey => {
@@ -98,11 +129,11 @@ impl<'de> Parser<'de> {
                     )),
                     Span::new(self.state.offset, elt.size()),
                 );
-                next = ParseState {
+                delta = Delta {
                     offset: self.state.offset,
                     expects: Expect::ElemValue { is_array: false },
-                    outer: self.state.outer.clone(),
-                }
+                    op: StackOp::Keep,
+                };
             }
             Expect::ElemValue { is_array } => {
                 let Some(elt) = iter.next().transpose()? else {
@@ -122,25 +153,25 @@ impl<'de> Parser<'de> {
                 event = elt.as_event()?;
                 match &event.kind {
                     ParseEventKind::Scalar(_) => {
-                        next = ParseState {
+                        delta = Delta {
                             offset: event.span.end(),
                             expects: next_expect,
-                            outer: self.state.outer.clone(),
+                            op: StackOp::Keep,
                         };
                     }
                     ParseEventKind::StructStart(_) => {
-                        next = ParseState {
+                        delta = Delta {
                             offset: elt.value_raw().source_offset() + 4,
                             expects: Expect::ElemKey,
-                            outer: vec_and(&self.state.outer, next_expect),
+                            op: StackOp::Push(next_expect),
                         };
                     }
                     ParseEventKind::SequenceStart(_) => {
-                        next = ParseState {
+                        delta = Delta {
                             offset: elt.value_raw().source_offset() + 4,
                             expects: Expect::ElemValue { is_array: true },
-                            outer: vec_and(&self.state.outer, next_expect),
-                        }
+                            op: StackOp::Push(next_expect),
+                        };
                     }
                     ek => {
                         return Err(Error::deserialization(format!(
@@ -161,14 +192,14 @@ impl<'de> Parser<'de> {
                 // type tag for parsing a `Bson`/`RawBson` value
                 bytes.push(elt.element_type() as u8);
                 event = ParseEvent::new(scalar_bytes(bytes), elt.value_raw().span());
-                next = ParseState {
+                delta = Delta {
                     offset: event.span.end(),
                     expects: if is_array {
                         Expect::ElemValue { is_array: true }
                     } else {
                         Expect::ElemKey
                     },
-                    outer: self.state.outer.clone(),
+                    op: StackOp::Keep,
                 };
             }
             Expect::Eof => {
@@ -178,7 +209,7 @@ impl<'de> Parser<'de> {
                 return Ok(None);
             }
         }
-        Ok(Some((event, next)))
+        Ok(Some((event, delta)))
     }
 
     fn parse_err(&self, source: Error) -> ParseError {
@@ -190,22 +221,22 @@ impl<'de> Parser<'de> {
         )
     }
 
-    fn container_end(&self, is_array: bool) -> Result<(ParseEvent<'de>, ParseState)> {
+    fn container_end(&self, is_array: bool) -> Result<(ParseEvent<'de>, Delta)> {
         let ev_kind = if is_array {
             ParseEventKind::SequenceEnd
         } else {
             ParseEventKind::StructEnd
         };
         let event = ParseEvent::new(ev_kind, Span::new(self.state.offset, 1));
-        let Some((expects, outer)) = self.state.outer.split_last() else {
+        let Some(expects) = self.state.outer.last() else {
             return Err(Error::deserialization("mismatched container structure"));
         };
-        let next = ParseState {
+        let delta = Delta {
             offset: self.state.offset + 1, // doc null terminator
             expects: *expects,
-            outer: outer.to_vec(),
+            op: StackOp::Pop,
         };
-        Ok((event, next))
+        Ok((event, delta))
     }
 }
 
@@ -274,10 +305,10 @@ impl<'de> facet_format::FormatParser<'de> for Parser<'de> {
     }
 
     fn next_event(&mut self) -> std::result::Result<Option<ParseEvent<'de>>, ParseError> {
-        let Some((ev, next)) = self.peek().map_err(|e| self.parse_err(e))? else {
+        let Some((ev, delta)) = self.peek().map_err(|e| self.parse_err(e))? else {
             return Ok(None);
         };
-        self.state = next;
+        self.state.apply(delta).map_err(|e| self.parse_err(e))?;
         Ok(Some(ev))
     }
 
@@ -342,10 +373,4 @@ pub fn deserialize_from_slice<T: Facet<'static>>(bytes: &[u8]) -> Result<T> {
     facet_format::FormatDeserializer::new_owned(&mut Parser::new(bytes))
         .deserialize()
         .map_err(Error::deserialization)
-}
-
-fn vec_and<T: Clone>(vs: &[T], v: T) -> Vec<T> {
-    let mut out = vs.to_vec();
-    out.push(v);
-    out
 }

--- a/src/facet/ser.rs
+++ b/src/facet/ser.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{any::TypeId, borrow::Cow};
 
 use facet::Facet;
 use facet_format::{FormatSerializer, ScalarValue, SerializeError};
@@ -55,7 +55,7 @@ struct Serializer {
 impl Serializer {
     fn new() -> Self {
         Self {
-            bytes: vec![],
+            bytes: Vec::with_capacity(1024),
             doc_size_pos: vec![],
             elem_type_pos: None,
             array_ix: vec![],
@@ -177,36 +177,39 @@ impl facet_format::FormatSerializer for Serializer {
 
     fn serialize_opaque_scalar(
         &mut self,
-        _shape: &'static facet::Shape,
+        shape: &'static facet::Shape,
         value: facet_reflect::Peek<'_, '_>,
     ) -> Result<bool> {
+        let id = shape.id.get();
         // Types that can be directly represented as a RawBsonRef
-        let rbr = if let Ok(v) = value.get::<i32>() {
-            Some(RawBsonRef::Int32(*v))
-        } else if let Ok(re) = value.get::<Regex>() {
-            Some(re.into())
-        } else if let Ok(b) = value.get::<Binary>() {
-            Some(b.into())
-        } else if let Ok(ts) = value.get::<Timestamp>() {
-            Some((*ts).into())
-        } else if let Ok(oid) = value.get::<ObjectId>() {
-            Some((*oid).into())
-        } else if let Ok(dt) = value.get::<DateTime>() {
-            Some((*dt).into())
-        } else if let Ok(d) = value.get::<Decimal128>() {
-            Some((*d).into())
-        } else if let Ok(dbp) = value.get::<DbPointer>() {
-            Some(dbp.into())
-        } else if let Ok(rd) = value.get::<RawDocumentBuf>() {
-            Some(RawBsonRef::Document(rd))
-        } else if let Ok(ra) = value.get::<RawArrayBuf>() {
-            Some(RawBsonRef::Array(ra))
-        } else if let Ok(rjscws) = value.get::<RawJavaScriptCodeWithScope>() {
-            Some(RawBsonRef::JavaScriptCodeWithScope(rjscws.into()))
-        } else if let Ok(cs) = value.get::<CString>() {
-            Some(RawBsonRef::String(cs.as_str()))
-        } else if let Ok(rb) = value.get::<crate::RawBson>() {
-            Some(rb.as_raw_bson_ref())
+        let rbr = if id == TypeId::of::<i32>() {
+            Some(RawBsonRef::Int32(*value.get()?))
+        } else if id == TypeId::of::<Regex>() {
+            Some(value.get::<Regex>()?.into())
+        } else if id == TypeId::of::<Binary>() {
+            Some(value.get::<Binary>()?.into())
+        } else if id == TypeId::of::<Timestamp>() {
+            Some((*value.get::<Timestamp>()?).into())
+        } else if id == TypeId::of::<ObjectId>() {
+            Some((*value.get::<ObjectId>()?).into())
+        } else if id == TypeId::of::<DateTime>() {
+            Some((*value.get::<DateTime>()?).into())
+        } else if id == TypeId::of::<Decimal128>() {
+            Some((*value.get::<Decimal128>()?).into())
+        } else if id == TypeId::of::<DbPointer>() {
+            Some(value.get::<DbPointer>()?.into())
+        } else if id == TypeId::of::<RawDocumentBuf>() {
+            Some(RawBsonRef::Document(value.get::<RawDocumentBuf>()?))
+        } else if id == TypeId::of::<RawArrayBuf>() {
+            Some(RawBsonRef::Array(value.get::<RawArrayBuf>()?))
+        } else if id == TypeId::of::<RawJavaScriptCodeWithScope>() {
+            Some(RawBsonRef::JavaScriptCodeWithScope(
+                value.get::<RawJavaScriptCodeWithScope>()?.into(),
+            ))
+        } else if id == TypeId::of::<CString>() {
+            Some(RawBsonRef::String(value.get::<CString>()?.as_str()))
+        } else if id == TypeId::of::<crate::RawBson>() {
+            Some(value.get::<crate::RawBson>()?.as_raw_bson_ref())
         } else {
             None
         };
@@ -216,17 +219,20 @@ impl facet_format::FormatSerializer for Serializer {
         }
 
         // Types that need special handling
-        if let Ok(jscws) = value.get::<JavaScriptCodeWithScope>() {
+        if id == TypeId::of::<JavaScriptCodeWithScope>() {
+            let jscws = value.get::<JavaScriptCodeWithScope>()?;
             self.write_elem_type(ElementType::JavaScriptCodeWithScope)?;
             jscws.append_to(&mut self.bytes)?;
 
             return Ok(true);
-        } else if let Ok(doc) = value.get::<Document>() {
+        } else if id == TypeId::of::<Document>() {
+            let doc = value.get::<Document>()?;
             self.write_elem_type(ElementType::EmbeddedDocument)?;
             doc.append_to(&mut self.bytes)?;
 
             return Ok(true);
-        } else if let Ok(b) = value.get::<Bson>() {
+        } else if id == TypeId::of::<Bson>() {
+            let b = value.get::<Bson>()?;
             self.write_elem_type(b.element_type())?;
             b.append_to(&mut self.bytes)?;
 


### PR DESCRIPTION
RUST-2401

This increases the performance of both the facet parsing and serialization paths via distinct sets of optimizations.  There's still a significant penalty vs serde but this brings the worst case down from 5x to 3x.

For parsing, profiling showed `Parser::peek` to be the hot path; the main cost there was allocating a new `Vec` for the stack of the returned next parse state.  This was an unconditional alloc that was frequently wasted, either if the stack was identical (it would be `clone`d and then the old value dropped) or if the parser was doing lookahead without advancing the state.  To fix that, `peek` now returns a cheap alloc-less `Delta` struct that _describes_ the change to be made to advance the state; that's only applied when necessary and even then if the stack is unchanged (i.e. iterating over fields rather than moving up/down nesting) it saves the clone+drop.

For serialization, `Serializer::serialize_opaque_scalar` was the hot path.  That doesn't have any allocation, but it did have a linear chain of indirect function calls (`value.get::<Type>()`).  This meant that every field walked incurred that chain, increasing by how far down that type happened to be.  To avoid that, the type id is fetched once and directly compared to `TypeId::of::<Type>()`; because that's a `const fn`, those turn into compile-time constants, and then the whole set of comparisons can become an O(1) operation via a jump table or similar.

Side note: the jump table optimization was a _much_ bigger win than the alloc removal, which surprised me quite a bit.

As far as I can tell, this was the low-hanging fruit for optimization.  Getting substantially better performance would probably involve going down the same road some of the other facet format implementations do, e.g. using cranelift to generate machine code for the specific struct shapes.  That would be basically a total rewrite and much more complicated at that, so I'd say we should wait and see what kind of adoption happens before investing that much time.

Benchmarks (lower is better):

## Before
```
test tests::bench::facet_bson_deserialize ... bench:       2,186.13 ns/iter (+/- 51.62)
test tests::bench::facet_deserialize      ... bench:       1,394.19 ns/iter (+/- 29.37)
test tests::bench::facet_bson_serialize   ... bench:       1,073.20 ns/iter (+/- 47.18)
test tests::bench::facet_serialize        ... bench:         833.26 ns/iter (+/- 36.69)
test tests::bench::serde_bson_deserialize ... bench:       1,153.92 ns/iter (+/- 48.89)
test tests::bench::serde_deserialize      ... bench:         356.91 ns/iter (+/- 4.21)
test tests::bench::serde_bson_serialize   ... bench:         358.20 ns/iter (+/- 14.19)
test tests::bench::serde_serialize        ... bench:         187.91 ns/iter (+/- 1.87)
```

### Delta vs serde:
```
facet_bson_deserialize:  1.9x
facet_deserialize:       3.9x
facet_bson_serialize:    3.0x
facet_serialize:         4.5x
```

## After
```
test tests::bench::facet_bson_deserialize ... bench:       1,942.98 ns/iter (+/- 94.60)
test tests::bench::facet_deserialize      ... bench:       1,183.84 ns/iter (+/- 95.58)
test tests::bench::facet_bson_serialize   ... bench:         730.91 ns/iter (+/- 24.30)
test tests::bench::facet_serialize        ... bench:         537.42 ns/iter (+/- 28.59)
```

### Delta vs serde:
```
facet_bson_deserialize:  1.7x
facet_deserialize:       3.3x
facet_bson_serialize:    2.0x
facet_serialize:         2.9x
```

### Delta vs old:
```
facet_bson_deserialize:  0.9x
facet_deserialize:       0.8x
facet_bson_serialize:    0.7x
facet_serialize:         0.6x
```