### PR TITLE
RUST-2471 Fix Eq implementation for Bson; extend Eq/Hash to raw types

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -44,7 +44,10 @@ use crate::{
 };
 
 /// Possible BSON value types.
-#[derive(Clone, Default, PartialEq)]
+///
+/// Note that `Bson`'s [`PartialEq`] implementation is byte value equality, so `Bson::Double(v)` and
+/// `v` may compare differently.
+#[derive(Clone, Default)]
 #[cfg_attr(
     feature = "facet-unstable",
     repr(C),
@@ -102,34 +105,58 @@ pub type Array = Vec<Bson>;
 
 impl Hash for Bson {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
         match self {
-            Bson::Double(double) => {
-                if *double == 0.0_f64 {
-                    // There are 2 zero representations, +0 and -0, which
-                    // compare equal but have different bits. We use the +0 hash
-                    // for both so that hash(+0) == hash(-0).
-                    0.0_f64.to_bits().hash(state);
-                } else {
-                    double.to_bits().hash(state);
-                }
+            Self::Double(double) => double.to_bits().hash(state),
+            Self::String(x) => x.hash(state),
+            Self::Array(x) => x.hash(state),
+            Self::Document(x) => x.hash(state),
+            Self::Boolean(x) => x.hash(state),
+            Self::RegularExpression(x) => x.hash(state),
+            Self::JavaScriptCode(x) => x.hash(state),
+            Self::JavaScriptCodeWithScope(x) => x.hash(state),
+            Self::Int32(x) => x.hash(state),
+            Self::Int64(x) => x.hash(state),
+            Self::Timestamp(x) => x.hash(state),
+            Self::Binary(x) => x.hash(state),
+            Self::ObjectId(x) => x.hash(state),
+            Self::DateTime(x) => x.hash(state),
+            Self::Symbol(x) => x.hash(state),
+            Self::Decimal128(x) => x.hash(state),
+            Self::DbPointer(x) => x.hash(state),
+            Self::Null | Self::Undefined | Self::MaxKey | Self::MinKey => (),
+        }
+    }
+}
+
+impl PartialEq for Bson {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            Self::Double(s) => matches!(other, Self::Double(o) if s.to_bits() == o.to_bits()),
+            Self::String(s) => matches!(other, Self::String(o) if s == o),
+            Self::Array(s) => matches!(other, Self::Array(o) if s == o),
+            Self::Document(s) => matches!(other, Self::Document(o) if s == o),
+            Self::Boolean(s) => matches!(other, Self::Boolean(o) if s == o),
+            Self::RegularExpression(s) => {
+                matches!(other, Self::RegularExpression(o) if s == o)
             }
-            Bson::String(x) => x.hash(state),
-            Bson::Array(x) => x.hash(state),
-            Bson::Document(x) => x.hash(state),
-            Bson::Boolean(x) => x.hash(state),
-            Bson::RegularExpression(x) => x.hash(state),
-            Bson::JavaScriptCode(x) => x.hash(state),
-            Bson::JavaScriptCodeWithScope(x) => x.hash(state),
-            Bson::Int32(x) => x.hash(state),
-            Bson::Int64(x) => x.hash(state),
-            Bson::Timestamp(x) => x.hash(state),
-            Bson::Binary(x) => x.hash(state),
-            Bson::ObjectId(x) => x.hash(state),
-            Bson::DateTime(x) => x.hash(state),
-            Bson::Symbol(x) => x.hash(state),
-            Bson::Decimal128(x) => x.hash(state),
-            Bson::DbPointer(x) => x.hash(state),
-            Bson::Null | Bson::Undefined | Bson::MaxKey | Bson::MinKey => (),
+            Self::JavaScriptCode(s) => matches!(other, Self::JavaScriptCode(o) if s == o),
+            Self::JavaScriptCodeWithScope(s) => {
+                matches!(other, Self::JavaScriptCodeWithScope(o) if s == o)
+            }
+            Self::Int32(s) => matches!(other, Self::Int32(o) if s == o),
+            Self::Int64(s) => matches!(other, Self::Int64(o) if s == o),
+            Self::Timestamp(s) => matches!(other, Self::Timestamp(o) if s == o),
+            Self::Binary(s) => matches!(other, Self::Binary(o) if s == o),
+            Self::ObjectId(s) => matches!(other, Self::ObjectId(o) if s == o),
+            Self::DateTime(s) => matches!(other, Self::DateTime(o) if s == o),
+            Self::Symbol(s) => matches!(other, Self::Symbol(o) if s == o),
+            Self::Decimal128(s) => matches!(other, Self::Decimal128(o) if s == o),
+            Self::DbPointer(s) => matches!(other, Self::DbPointer(o) if s == o),
+            Self::Null => matches!(other, Self::Null),
+            Self::Undefined => matches!(other, Self::Undefined),
+            Self::MaxKey => matches!(other, Self::MaxKey),
+            Self::MinKey => matches!(other, Self::MinKey),
         }
     }
 }

--- a/src/raw/array.rs
+++ b/src/raw/array.rs
@@ -70,7 +70,7 @@ use crate::{
 /// assert_eq!(rawarray.get_bool(1)?, true);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct RawArray {
     pub(crate) doc: RawDocument,

--- a/src/raw/array_buf.rs
+++ b/src/raw/array_buf.rs
@@ -38,7 +38,7 @@ use super::{RawArrayIter, document_buf::BindRawBsonRef};
 /// any of the type-specific getters, such as [`RawArray::get_object_id`] or [`RawArray::get_str`].
 /// Note that accessing elements is an O(N) operation, as it requires iterating through the document
 /// from the beginning to find the requested key.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "facet-unstable", derive(facet::Facet), facet(opaque = crate::facet::opaque::RawArrayBufAdapter))]
 pub struct RawArrayBuf {
     inner: RawDocumentBuf,
@@ -96,6 +96,14 @@ impl RawArrayBuf {
             value,
         );
         self.len += 1;
+    }
+}
+
+// Hash has to be consistent across owned and borrowed forms; this means that RawArrayBuf has to
+// hash the same as RawArray, so don't include the length field.
+impl std::hash::Hash for RawArrayBuf {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
     }
 }
 

--- a/src/raw/bson.rs
+++ b/src/raw/bson.rs
@@ -25,7 +25,10 @@ use crate::{
 use super::{Error, Result};
 
 /// A BSON value backed by owned raw BSON bytes.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// Note that `RawBson`'s [`PartialEq`] implementation is byte value equality, so
+/// `RawBson::Double(v)` and `v` may compare differently.
+#[derive(Debug, Clone)]
 #[cfg_attr(
     feature = "facet-unstable",
     repr(C),
@@ -329,6 +332,66 @@ impl RawBson {
     }
 }
 
+impl PartialEq for RawBson {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            Self::Double(s) => matches!(other, Self::Double(o) if s.to_bits() == o.to_bits()),
+            Self::String(s) => matches!(other, Self::String(o) if s == o),
+            Self::Array(s) => matches!(other, Self::Array(o) if s == o),
+            Self::Document(s) => matches!(other, Self::Document(o) if s == o),
+            Self::Boolean(s) => matches!(other, Self::Boolean(o) if s == o),
+            Self::RegularExpression(s) => {
+                matches!(other, Self::RegularExpression(o) if s == o)
+            }
+            Self::JavaScriptCode(s) => matches!(other, Self::JavaScriptCode(o) if s == o),
+            Self::JavaScriptCodeWithScope(s) => {
+                matches!(other, Self::JavaScriptCodeWithScope(o) if s == o)
+            }
+            Self::Int32(s) => matches!(other, Self::Int32(o) if s == o),
+            Self::Int64(s) => matches!(other, Self::Int64(o) if s == o),
+            Self::Timestamp(s) => matches!(other, Self::Timestamp(o) if s == o),
+            Self::Binary(s) => matches!(other, Self::Binary(o) if s == o),
+            Self::ObjectId(s) => matches!(other, Self::ObjectId(o) if s == o),
+            Self::DateTime(s) => matches!(other, Self::DateTime(o) if s == o),
+            Self::Symbol(s) => matches!(other, Self::Symbol(o) if s == o),
+            Self::Decimal128(s) => matches!(other, Self::Decimal128(o) if s == o),
+            Self::DbPointer(s) => matches!(other, Self::DbPointer(o) if s == o),
+            Self::Null => matches!(other, Self::Null),
+            Self::Undefined => matches!(other, Self::Undefined),
+            Self::MaxKey => matches!(other, Self::MaxKey),
+            Self::MinKey => matches!(other, Self::MinKey),
+        }
+    }
+}
+
+impl Eq for RawBson {}
+
+impl std::hash::Hash for RawBson {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Double(double) => double.to_bits().hash(state),
+            Self::String(x) => x.hash(state),
+            Self::Array(x) => x.hash(state),
+            Self::Document(x) => x.hash(state),
+            Self::Boolean(x) => x.hash(state),
+            Self::RegularExpression(x) => x.hash(state),
+            Self::JavaScriptCode(x) => x.hash(state),
+            Self::JavaScriptCodeWithScope(x) => x.hash(state),
+            Self::Int32(x) => x.hash(state),
+            Self::Int64(x) => x.hash(state),
+            Self::Timestamp(x) => x.hash(state),
+            Self::Binary(x) => x.hash(state),
+            Self::ObjectId(x) => x.hash(state),
+            Self::DateTime(x) => x.hash(state),
+            Self::Symbol(x) => x.hash(state),
+            Self::Decimal128(x) => x.hash(state),
+            Self::DbPointer(x) => x.hash(state),
+            Self::Null | Self::Undefined | Self::MaxKey | Self::MinKey => (),
+        }
+    }
+}
+
 impl From<i32> for RawBson {
     fn from(i: i32) -> Self {
         RawBson::Int32(i)
@@ -523,7 +586,7 @@ impl TryFrom<Bson> for RawBson {
 }
 
 /// A BSON "code with scope" value backed by owned raw BSON.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "facet-unstable", derive(facet::Facet), facet(opaque = opaque::RawJavaScriptCodeWithScopeAdapter))]
 pub struct RawJavaScriptCodeWithScope {
     /// The code value.

--- a/src/raw/bson_ref.rs
+++ b/src/raw/bson_ref.rs
@@ -29,7 +29,10 @@ use crate::{
 use serde::ser::SerializeStruct as _;
 
 /// A BSON value referencing raw bytes stored elsewhere.
-#[derive(Debug, Clone, Copy, PartialEq)]
+///
+/// Note that `RawBsonRef`'s [`PartialEq`] implementation is byte value equality, so
+/// `RawBsonRef::Double(v)` and `v` may compare differently.
+#[derive(Debug, Clone, Copy)]
 pub enum RawBsonRef<'a> {
     /// 64-bit binary floating point
     Double(f64),
@@ -300,6 +303,66 @@ impl<'a> RawBsonRef<'a> {
     }
 }
 
+impl<'a> PartialEq for RawBsonRef<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            Self::Double(s) => matches!(other, Self::Double(o) if s.to_bits() == o.to_bits()),
+            Self::String(s) => matches!(other, Self::String(o) if s == o),
+            Self::Array(s) => matches!(other, Self::Array(o) if s == o),
+            Self::Document(s) => matches!(other, Self::Document(o) if s == o),
+            Self::Boolean(s) => matches!(other, Self::Boolean(o) if s == o),
+            Self::RegularExpression(s) => {
+                matches!(other, Self::RegularExpression(o) if s == o)
+            }
+            Self::JavaScriptCode(s) => matches!(other, Self::JavaScriptCode(o) if s == o),
+            Self::JavaScriptCodeWithScope(s) => {
+                matches!(other, Self::JavaScriptCodeWithScope(o) if s == o)
+            }
+            Self::Int32(s) => matches!(other, Self::Int32(o) if s == o),
+            Self::Int64(s) => matches!(other, Self::Int64(o) if s == o),
+            Self::Timestamp(s) => matches!(other, Self::Timestamp(o) if s == o),
+            Self::Binary(s) => matches!(other, Self::Binary(o) if s == o),
+            Self::ObjectId(s) => matches!(other, Self::ObjectId(o) if s == o),
+            Self::DateTime(s) => matches!(other, Self::DateTime(o) if s == o),
+            Self::Symbol(s) => matches!(other, Self::Symbol(o) if s == o),
+            Self::Decimal128(s) => matches!(other, Self::Decimal128(o) if s == o),
+            Self::DbPointer(s) => matches!(other, Self::DbPointer(o) if s == o),
+            Self::Null => matches!(other, Self::Null),
+            Self::Undefined => matches!(other, Self::Undefined),
+            Self::MaxKey => matches!(other, Self::MaxKey),
+            Self::MinKey => matches!(other, Self::MinKey),
+        }
+    }
+}
+
+impl<'a> Eq for RawBsonRef<'a> {}
+
+impl<'a> std::hash::Hash for RawBsonRef<'a> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Double(double) => double.to_bits().hash(state),
+            Self::String(x) => x.hash(state),
+            Self::Array(x) => x.hash(state),
+            Self::Document(x) => x.hash(state),
+            Self::Boolean(x) => x.hash(state),
+            Self::RegularExpression(x) => x.hash(state),
+            Self::JavaScriptCode(x) => x.hash(state),
+            Self::JavaScriptCodeWithScope(x) => x.hash(state),
+            Self::Int32(x) => x.hash(state),
+            Self::Int64(x) => x.hash(state),
+            Self::Timestamp(x) => x.hash(state),
+            Self::Binary(x) => x.hash(state),
+            Self::ObjectId(x) => x.hash(state),
+            Self::DateTime(x) => x.hash(state),
+            Self::Symbol(x) => x.hash(state),
+            Self::Decimal128(x) => x.hash(state),
+            Self::DbPointer(x) => x.hash(state),
+            Self::Null | Self::Undefined | Self::MaxKey | Self::MinKey => (),
+        }
+    }
+}
+
 impl<'a> From<RawBsonRef<'a>> for RawBson {
     fn from(value: RawBsonRef<'a>) -> Self {
         match value {
@@ -518,7 +581,7 @@ impl<'a> From<&'a Regex> for RawBsonRef<'a> {
 }
 
 /// A BSON binary value referencing raw bytes stored elsewhere.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RawBinaryRef<'a> {
     /// The subtype of the binary value.
     pub subtype: BinarySubtype,
@@ -651,7 +714,7 @@ impl<'a> From<&'a Binary> for RawBsonRef<'a> {
 }
 
 /// A BSON regex referencing raw bytes stored elsewhere.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RawRegexRef<'a> {
     /// The regex pattern to match.
     pub pattern: &'a CStr,
@@ -739,7 +802,7 @@ impl<'a> From<&'a Regex> for RawRegexRef<'a> {
 }
 
 /// A BSON "code with scope" value referencing raw bytes stored elsewhere.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RawJavaScriptCodeWithScopeRef<'a> {
     /// The JavaScript code.
     pub code: &'a str,
@@ -826,7 +889,7 @@ impl<'a> From<RawJavaScriptCodeWithScopeRef<'a>> for RawBsonRef<'a> {
 }
 
 /// A BSON DB pointer value referencing raw bytes stored elesewhere.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RawDbPointerRef<'a> {
     pub(crate) namespace: &'a str,
     pub(crate) id: ObjectId,

--- a/src/raw/document.rs
+++ b/src/raw/document.rs
@@ -70,7 +70,7 @@ use super::{
 /// assert_eq!(doc.get_str("hi")?, "y'all");
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct RawDocument {
     data: [u8],

--- a/src/raw/document_buf.rs
+++ b/src/raw/document_buf.rs
@@ -50,7 +50,7 @@ use crate::facet::opaque;
 /// assert_eq!(doc.get_str("hi")?, "y'all");
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "facet-unstable", derive(facet::Facet), facet(opaque = opaque::RawDocumentBufAdapter))]
 pub struct RawDocumentBuf {
     data: Vec<u8>,


### PR DESCRIPTION
RUST-2471

This changes the `Bson` impl for `PartialEq` to compare by byte value rather than the derived comparison, which carried the float non-reflexive behavior and made `Eq` a lie.  To keep things consistent, I updated the raw types to use the same comparison; this also meant making the raw types Eq/Hash was straightforward.

Notably, the raw buffer types (`RawDocument[Buf]`, `RawArray[Buf]`) were _already_ just comparing by byte value, so this change makes everything consistent rather than having an undocumented mismatch.

Fixes #683, #684.