### PR TITLE
RUST-2488 Fix lossy `JavascriptCodeWithScope` decoding

### DIFF
--- a/src/raw/test.rs
+++ b/src/raw/test.rs
@@ -7,8 +7,10 @@ use crate::{
     Bson,
     DateTime,
     Decimal128,
+    Document,
     Regex,
     Timestamp,
+    Utf8Lossy,
     oid::ObjectId,
     spec::BinarySubtype,
 };
@@ -127,6 +129,31 @@ fn rawdoc_to_doc() {
 
     let vec_writer_bytes = doc.to_vec().expect("encode should work");
     assert_eq!(vec_writer_bytes, rawdoc.into_bytes());
+}
+
+#[test]
+fn code_with_scope_invalid_utf8_lossy() {
+    // the code here holds invalid utf-8, so its lossily decoded form is longer than the
+    // bytes actually stored. the scope follows the raw code bytes, so decoding must not
+    // use the replacement-decoded length to find it.
+    let code = unsafe { String::from_utf8_unchecked(vec![0x80, 0xae]) };
+    let rawdoc = rawdoc! {
+        "c": RawJavaScriptCodeWithScope {
+            code,
+            scope: rawdoc! { "ok": true },
+        },
+    };
+
+    let lossy: Utf8Lossy<Document> = (&*rawdoc)
+        .try_into()
+        .expect("lossy conversion should succeed");
+    match lossy.0.get("c").expect("missing key") {
+        Bson::JavaScriptCodeWithScope(jsc) => {
+            assert_eq!(jsc.code, "\u{FFFD}\u{FFFD}");
+            assert!(jsc.scope.get_bool("ok").expect("scope key"));
+        }
+        other => panic!("unexpected value: {:?}", other),
+    }
 }
 
 #[test]

--- a/src/raw/value.rs
+++ b/src/raw/value.rs
@@ -102,11 +102,14 @@ impl<'a> RawValue<'a> {
                 }
 
                 let slice = self.bytes;
-                let code = String::from_utf8_lossy(read_lenencode_bytes(&slice[4..])?).into_owned();
-                let scope_start = 4 + 4 + code.len() + 1;
+                let code_bytes = read_lenencode_bytes(&slice[4..])?;
+                // the scope follows the code's raw bytes; using the lossily decoded
+                // length here would shift the offset whenever the code is not valid utf-8
+                let scope_start = 4 + 4 + code_bytes.len() + 1;
                 if scope_start >= slice.len() {
                     return Err(Error::malformed_bytes("code with scope length overrun"));
                 }
+                let code = String::from_utf8_lossy(code_bytes).into_owned();
                 let scope = RawDocument::from_bytes(&slice[scope_start..])?;
 
                 Utf8LossyBson::JavaScriptCodeWithScope(Utf8LossyJavaScriptCodeWithScope {


### PR DESCRIPTION
When `parse_utf8_lossy` handles a JavaScriptCodeWithScope it works out where the scope document begins from the length of the lossily decoded code string, but that length can be larger than the bytes actually stored whenever the code isn't valid utf-8 (each bad byte decodes to a three-byte replacement character). The offset then overshoots and the conversion either bails out with a misleading "length overrun"/"document too short" error or picks up the wrong scope, which is unfortunate given `Utf8Lossy` is the path meant to tolerate invalid utf-8 in the first place. This computes `scope_start` from the raw code byte length returned by `read_lenencode_bytes` and only decodes the code afterwards. I've added a regression test that round-trips a code-with-scope whose code holds invalid utf-8.